### PR TITLE
feat: add queue serialization prerequisites

### DIFF
--- a/src/core/serialized_service.hpp
+++ b/src/core/serialized_service.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+#include "libxr_assert.hpp"
+
+namespace LibXR
+{
+
+/**
+ * @brief 事件合并与回调串行化服务 / Event-coalescing serialized-callback service.
+ *
+ * 该服务用一个原子字保存执行权和低 31 位事件。`Invoke()` 发布事件并尝试取得执行权；
+ * 只有取得执行权的调用执行 handler，执行期间到达的事件由同一调用继续处理。未取得执行
+ * 权的调用只发布事件，其 handler 不会保存或稍后调用。事件位表示状态需要重新检查，不
+ * 表示发生次数。
+ *
+ * This service stores execution ownership and low-31-bit events in one atomic word.
+ * `Invoke()` publishes events and attempts to claim execution. Only the caller that
+ * claims execution runs the handler; events arriving during execution are processed
+ * before ownership is released. A losing caller's handler is never retained or called
+ * later. Event bits request a state re-check and do not count occurrences.
+ *
+ * `Publish()` 只记录事件，不负责唤醒或调度。service 以及 handler 访问的数据必须在所有活动
+ * 调用结束前保持有效；handler 不得抛出异常，也不得等待当前 service 所保护的进度。原子
+ * 操作的上下文限制、MMIO、DMA 同步和后端生命周期由调用方负责。
+ *
+ * `Publish()` records an event but does not wake or schedule execution. The service and
+ * all data accessed by its handler must outlive every active call. Handlers must not
+ * throw or wait for progress protected by this service. Context restrictions for atomics,
+ * MMIO, DMA synchronization, and backend lifetime remain the caller's responsibility.
+ */
+class SerializedService
+{
+ public:
+  SerializedService() = default;
+
+  /**
+   * @brief 发布事件并尝试取得执行权 / Publish events and attempt to claim execution.
+   * @param events 非零低 31 位事件 / Nonzero event bits below bit 31.
+   * @param in_isr 当前调用上下文；仅传给取得执行权的调用 /
+   *        Context of this call; used only if it claims execution.
+   * @param handler 签名 void(uint32_t, bool) / Callable as void(uint32_t, bool).
+   * @return 当前调用执行了 handler 则为 true；否则仅发布事件并返回 false /
+   *         True if this call ran the handler; false if it only published events.
+   */
+  template <typename Handler>
+  bool Invoke(uint32_t events, bool in_isr, Handler&& handler) noexcept
+  {
+    ASSERT(IsEventMask(events));
+
+    uint32_t observed = state_.fetch_or(events, std::memory_order_release) | events;
+    while ((observed & OWNER_BIT) == 0U)
+    {
+      if (state_.compare_exchange_weak(observed, OWNER_BIT, std::memory_order_acquire,
+                                       std::memory_order_relaxed))
+      {
+        Handler& handler_ref = handler;
+        return Drain(handler_ref, in_isr, observed & EVENT_MASK);
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @brief 为已有或确定会出现的执行者发布事件 / Publish for an active or guaranteed
+   *        executor.
+   * @param events 低 31 位事件；零值不操作 / Low-31-bit events; zero is a no-op.
+   * @pre 已有执行者或保证后续 `Invoke`；本方法本身不调度执行 /
+   *      An executor or a later `Invoke` is guaranteed; this method does not schedule
+   *      execution.
+   */
+  void Publish(uint32_t events) noexcept
+  {
+    if (events == 0U)
+    {
+      return;
+    }
+    ASSERT(IsEventMask(events));
+    state_.fetch_or(events, std::memory_order_release);
+  }
+
+  SerializedService(const SerializedService&) = delete;
+  SerializedService& operator=(const SerializedService&) = delete;
+
+ private:
+  static constexpr uint32_t OWNER_BIT = 1U << 31U;
+  static constexpr uint32_t EVENT_MASK = ~OWNER_BIT;
+
+  static constexpr bool IsEventMask(uint32_t events)
+  {
+    return events != 0U && (events & OWNER_BIT) == 0U;
+  }
+
+  template <typename Handler>
+  bool Drain(Handler& handler, bool in_isr, uint32_t snapshot) noexcept
+  {
+    bool invoked = false;
+    while (true)
+    {
+      if (snapshot != 0U)
+      {
+        invoked = true;
+        handler(snapshot, in_isr);
+      }
+
+      uint32_t expected = OWNER_BIT;
+      if (state_.compare_exchange_strong(expected, 0U, std::memory_order_release,
+                                         std::memory_order_relaxed))
+      {
+        return invoked;
+      }
+
+      snapshot = state_.exchange(OWNER_BIT, std::memory_order_acq_rel) & EVENT_MASK;
+    }
+  }
+
+  std::atomic<uint32_t> state_{0U};
+};
+
+}  // namespace LibXR

--- a/src/structure/queue/spsc_queue.hpp
+++ b/src/structure/queue/spsc_queue.hpp
@@ -135,6 +135,35 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>, public SPS
   }
 
   /**
+   * @brief 通过一次双 span 回调生产 payload 前缀 / Produce a payload prefix through one
+   *        two-span writer callback.
+   * @tparam Writer 写入器类型 / Writer callback type.
+   * @param limit 最多提供的 payload 个数 / Maximum number of offered payloads.
+   * @param writer 签名为 `size_t(Data*, size_t, Data*, size_t)`，返回已写入的前缀个数 /
+   *        Callback with signature `size_t(Data*, size_t, Data*, size_t)`; returns the
+   *        written prefix count.
+   * @return 实际发布到队列的 payload 个数 / Number of payloads published to the queue.
+   * @pre 队列只有一个 producer；回调期间不得重入同侧操作或 Reset /
+   *      The queue has one producer; no same-side operation or Reset during the callback.
+   * @note 没有可用空间或 `limit == 0` 时不调用回调；回调指针只在调用期间有效 /
+   *       The callback is skipped when no space is available or `limit == 0`; pointers
+   *       are valid only during the callback.
+   */
+  template <typename Writer>
+  size_t ProduceWithWriter(size_t limit, Writer&& writer)
+  {
+    static_assert(std::is_trivially_copyable_v<Data>);
+    static_assert(std::is_trivially_destructible_v<Data>);
+    return SPSCQueueBase::ProduceWithWriter(
+        limit,
+        [&](void* first, size_t first_size, void* second, size_t second_size) -> size_t
+        {
+          return writer(static_cast<Data*>(first), first_size, static_cast<Data*>(second),
+                        second_size);
+        });
+  }
+
+  /**
    * @brief 通过读取器回调弹出一个 payload。
    * @brief Pop one payload via a reader callback.
    * @tparam Reader 读取器类型。 Reader callback type.
@@ -189,6 +218,36 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>, public SPS
     return SPSCQueueBase::PopBytesWithReader(
         size, [&](const void* buffer, size_t count) -> ErrorCode
         { return reader_ref(static_cast<const Data*>(buffer), count); });
+  }
+
+  /**
+   * @brief 通过一次双 span 回调消费 payload 前缀 / Consume a payload prefix through one
+   *        two-span reader callback.
+   * @tparam Reader 读取器类型 / Reader callback type.
+   * @param limit 最多提供的 payload 个数 / Maximum number of offered payloads.
+   * @param reader 签名为 `size_t(const Data*, size_t, const Data*, size_t)`，返回已接受的
+   *        前缀个数 / Callback with signature `size_t(const Data*, size_t, const Data*,
+   *        size_t)`; returns the accepted prefix count.
+   * @return 实际从队列移除的 payload 个数 / Number of payloads removed from the queue.
+   * @pre 队列只有一个 consumer；回调期间不得重入同侧操作或 Reset /
+   *      The queue has one consumer; no same-side operation or Reset during the callback.
+   * @note 没有可用数据或 `limit == 0` 时不调用回调；回调指针只在调用期间有效 /
+   *       The callback is skipped when no data is available or `limit == 0`; pointers are
+   *       valid only during the callback.
+   */
+  template <typename Reader>
+  size_t ConsumeWithReader(size_t limit, Reader&& reader)
+  {
+    static_assert(std::is_trivially_copyable_v<Data>);
+    static_assert(std::is_trivially_destructible_v<Data>);
+    return SPSCQueueBase::ConsumeWithReader(
+        limit,
+        [&](const void* first, size_t first_size, const void* second,
+            size_t second_size) -> size_t
+        {
+          return reader(static_cast<const Data*>(first), first_size,
+                        static_cast<const Data*>(second), second_size);
+        });
   }
 
   /**

--- a/src/structure/queue/spsc_queue_base.hpp
+++ b/src/structure/queue/spsc_queue_base.hpp
@@ -268,6 +268,54 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
   }
 
   /**
+   * @brief 通过一次双 span 回调生产 payload 前缀 / Produce a payload prefix through one
+   *        two-span writer callback.
+   * @tparam Writer 写入器类型 / Writer callback type.
+   * @param limit 最多提供的 payload 个数 / Maximum number of offered payloads.
+   * @param writer 接收两段存储和元素数，返回已写入的前缀个数 /
+   *        Receives two storage pointers and element counts; returns the written prefix
+   *        count.
+   * @return 实际发布到队列的 payload 个数 / Number of payloads published to the queue.
+   * @pre 队列只有一个 producer；回调期间不得重入同侧操作或 Reset /
+   *      The queue has one producer; no same-side operation or Reset during the callback.
+   * @note 可提供数量为零时不调用回调；第二段为空时指针为 `nullptr`，所有指针只在回调期间
+   *       有效 / The callback is skipped when the offered count is zero; an empty second
+   *       span is `nullptr`, and all pointers are valid only during the callback.
+   */
+  template <typename Writer>
+  size_t ProduceWithWriter(size_t limit, Writer&& writer)
+  {
+    if (limit == 0U)
+    {
+      return 0U;
+    }
+
+    const auto current_tail = tail_.load(std::memory_order_relaxed);
+    const auto current_head = head_.load(std::memory_order_acquire);
+    const size_t capacity = RingCapacity();
+    const size_t free_space = (current_tail >= current_head)
+                                  ? (capacity - (current_tail - current_head) - 1U)
+                                  : (current_head - current_tail - 1U);
+    const size_t offered = std::min(limit, free_space);
+    if (offered == 0U)
+    {
+      return 0U;
+    }
+
+    const size_t first_count = std::min(offered, capacity - current_tail);
+    const size_t second_count = offered - first_count;
+    void* const second = second_count == 0U ? nullptr : PayloadPtr(0U);
+    const size_t produced =
+        writer(PayloadPtr(current_tail), first_count, second, second_count);
+    REQUIRE(produced <= offered);
+    if (produced != 0U)
+    {
+      tail_.store((current_tail + produced) % capacity, std::memory_order_release);
+    }
+    return produced;
+  }
+
+  /**
    * @brief 按字节批量出队多个 payload / Dequeue multiple payloads by bytes
    * @param data 用于接收 payload 的字节缓冲区；传 `nullptr` 时仅丢弃
    *        / Byte buffer receiving payloads; pass `nullptr` to discard only
@@ -365,6 +413,54 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
 
     head_.store((current_head + count) % capacity, std::memory_order_release);
     return ErrorCode::OK;
+  }
+
+  /**
+   * @brief 通过一次双 span 回调消费 payload 前缀 / Consume a payload prefix through one
+   *        two-span reader callback.
+   * @tparam Reader 读取器类型 / Reader callback type.
+   * @param limit 最多提供的 payload 个数 / Maximum number of offered payloads.
+   * @param reader 接收两段数据和元素数，返回已接受的前缀个数 /
+   *        Receives two data pointers and element counts; returns the accepted prefix
+   * count.
+   * @return 实际从队列移除的 payload 个数 / Number of payloads removed from the queue.
+   * @pre 队列只有一个 consumer；回调期间不得重入同侧操作或 Reset /
+   *      The queue has one consumer; no same-side operation or Reset during the callback.
+   * @note 可提供数量为零时不调用回调；返回值不得超过可提供数量；所有指针只在回调期间有效
+   * / The callback is skipped when the offered count is zero and must return no more than
+   * the offered count; all pointers are valid only during the callback.
+   */
+  template <typename Reader>
+  size_t ConsumeWithReader(size_t limit, Reader&& reader)
+  {
+    if (limit == 0U)
+    {
+      return 0U;
+    }
+
+    const auto current_head = head_.load(std::memory_order_relaxed);
+    const auto current_tail = tail_.load(std::memory_order_acquire);
+    const size_t capacity = RingCapacity();
+    const size_t available = (current_tail >= current_head)
+                                 ? (current_tail - current_head)
+                                 : (capacity - current_head + current_tail);
+    const size_t offered = std::min(limit, available);
+    if (offered == 0U)
+    {
+      return 0U;
+    }
+
+    const size_t first_count = std::min(offered, capacity - current_head);
+    const size_t second_count = offered - first_count;
+    const void* const second = second_count == 0U ? nullptr : PayloadPtr(0U);
+    const size_t accepted =
+        reader(PayloadPtr(current_head), first_count, second, second_count);
+    REQUIRE(accepted <= offered);
+    if (accepted != 0U)
+    {
+      head_.store((current_head + accepted) % capacity, std::memory_order_release);
+    }
+    return accepted;
   }
 
   /**

--- a/test/base/core/test_serialized_service.cpp
+++ b/test/base/core/test_serialized_service.cpp
@@ -1,0 +1,150 @@
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <semaphore>
+#include <thread>
+#include <type_traits>
+
+#include "serialized_service.hpp"
+#include "test.hpp"
+
+namespace
+{
+constexpr uint32_t FIRST = 1U;
+constexpr uint32_t SECOND = 2U;
+constexpr uint32_t THIRD = 4U;
+
+static_assert(sizeof(LibXR::SerializedService) == sizeof(std::atomic<uint32_t>));
+static_assert(!std::is_copy_constructible_v<LibXR::SerializedService>);
+
+void TestDeferredAndRecursiveEvents()
+{
+  LibXR::SerializedService service;
+  service.Publish(0U);
+  service.Publish(SECOND);
+  service.Publish(SECOND);
+  unsigned calls = 0U;
+  unsigned depth = 0U;
+  ASSERT(service.Invoke(FIRST, true,
+                        [&](uint32_t events, bool in_isr)
+                        {
+                          ASSERT(++depth == 1U);
+                          ASSERT(in_isr);
+                          if (calls++ == 0U)
+                          {
+                            ASSERT(events == (FIRST | SECOND));
+                            ASSERT(!service.Invoke(
+                                THIRD, false, [](uint32_t, bool) { ASSERT(false); }));
+                            service.Publish(THIRD);
+                          }
+                          else
+                          {
+                            ASSERT(events == THIRD);
+                          }
+                          --depth;
+                        }));
+  ASSERT(calls == 2U && depth == 0U);
+  ASSERT(service.Invoke(FIRST, false, [](uint32_t events, bool in_isr)
+                        { ASSERT(events == FIRST && !in_isr); }));
+}
+
+void TestCompetingCallableLifetime()
+{
+  LibXR::SerializedService service;
+  std::binary_semaphore entered(0);
+  std::binary_semaphore resume(0);
+  unsigned owner_calls = 0U;
+  int payload = 0;
+  std::thread owner(
+      [&]
+      {
+        ASSERT(service.Invoke(FIRST, false,
+                              [&](uint32_t events, bool in_isr)
+                              {
+                                ASSERT(events != 0U);
+                                ASSERT(!in_isr);
+                                if (owner_calls++ == 0U)
+                                {
+                                  ASSERT(events == FIRST);
+                                  entered.release();
+                                  resume.acquire();
+                                }
+                                else
+                                {
+                                  ASSERT(events == (SECOND | THIRD));
+                                  ASSERT(payload == 42);
+                                }
+                              }));
+      });
+  entered.acquire();
+  payload = 42;
+  {
+    int transient_capture = 7;
+    ASSERT(!service.Invoke(SECOND, true, [&](uint32_t, bool) { transient_capture = 8; }));
+    ASSERT(transient_capture == 7);
+  }
+  service.Publish(THIRD);
+  resume.release();
+  owner.join();
+  ASSERT(owner_calls == 2U);
+}
+
+void TestConcurrentReleaseAndPayloadPublication()
+{
+  constexpr unsigned PRODUCERS = 4U;
+  constexpr uint32_t ITERATIONS = 5000U;
+  LibXR::SerializedService service;
+  std::array<uint32_t, PRODUCERS> payload{};
+  std::array<uint32_t, PRODUCERS> consumed{};
+  std::array<std::binary_semaphore, PRODUCERS> acknowledged{
+      std::binary_semaphore{0}, std::binary_semaphore{0}, std::binary_semaphore{0},
+      std::binary_semaphore{0}};
+  std::array<std::thread, PRODUCERS> threads;
+  std::atomic<unsigned> active{0U};
+  auto handler = [&](uint32_t events, bool)
+  {
+    ASSERT(events != 0U);
+    ASSERT(active.fetch_add(1U, std::memory_order_relaxed) == 0U);
+    for (unsigned i = 0U; i < PRODUCERS; ++i)
+    {
+      if ((events & (1U << i)) != 0U)
+      {
+        // The producer publishes this plain payload only through the service event.
+        ASSERT(payload[i] == consumed[i] + 1U);
+        consumed[i] = payload[i];
+        acknowledged[i].release();
+      }
+    }
+    ASSERT(active.fetch_sub(1U, std::memory_order_relaxed) == 1U);
+  };
+  for (unsigned i = 0U; i < PRODUCERS; ++i)
+  {
+    threads[i] = std::thread(
+        [&, i]
+        {
+          for (uint32_t sequence = 1U; sequence <= ITERATIONS; ++sequence)
+          {
+            payload[i] = sequence;
+            service.Invoke(1U << i, false, handler);
+            acknowledged[i].acquire();
+          }
+        });
+  }
+  for (auto& thread : threads)
+  {
+    thread.join();
+  }
+  for (uint32_t count : consumed)
+  {
+    ASSERT(count == ITERATIONS);
+  }
+  ASSERT(active.load(std::memory_order_relaxed) == 0U);
+}
+}  // namespace
+
+void test_serialized_service()
+{
+  TestDeferredAndRecursiveEvents();
+  TestCompetingCallableLifetime();
+  TestConcurrentReleaseAndPayloadPublication();
+}

--- a/test/base/structure/test_spsc_prefix.cpp
+++ b/test/base/structure/test_spsc_prefix.cpp
@@ -1,0 +1,296 @@
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <thread>
+#include <vector>
+
+#include "spsc_queue.hpp"
+#include "test.hpp"
+
+namespace
+{
+using Queue = LibXR::SPSCQueue<uint32_t>;
+
+void PositionEmptyQueue(Queue& queue, size_t offset)
+{
+  for (size_t i = 0; i < offset; ++i)
+  {
+    ASSERT(queue.Push(0U) == LibXR::ErrorCode::OK);
+    ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
+  }
+}
+
+void CheckContents(Queue& queue, const std::vector<uint32_t>& expected)
+{
+  ASSERT(queue.Size() == expected.size());
+  for (uint32_t value : expected)
+  {
+    uint32_t actual = 0U;
+    ASSERT(queue.Pop(actual) == LibXR::ErrorCode::OK);
+    ASSERT(actual == value);
+  }
+  ASSERT(queue.Size() == 0U);
+}
+
+void FillQueue(Queue& queue, size_t offset, size_t used, std::vector<uint32_t>& expected)
+{
+  PositionEmptyQueue(queue, offset);
+  for (size_t index = 0U; index < used; ++index)
+  {
+    const uint32_t value = static_cast<uint32_t>(10U + index);
+    expected.push_back(value);
+    ASSERT(queue.Push(value) == LibXR::ErrorCode::OK);
+  }
+}
+
+void CheckProducePrefix(size_t capacity, size_t offset, size_t used, size_t limit,
+                        size_t prefix)
+{
+  Queue queue(capacity);
+  std::vector<uint32_t> expected;
+  FillQueue(queue, offset, used, expected);
+
+  const size_t offer = std::min(limit, capacity - used);
+  size_t calls = 0U;
+  const size_t produced = queue.ProduceWithWriter(
+      limit,
+      [&](uint32_t* first, size_t first_size, uint32_t* second, size_t second_size)
+      {
+        ++calls;
+        ASSERT(first != nullptr && first_size > 0U);
+        ASSERT(first_size + second_size == offer);
+        ASSERT((second == nullptr) == (second_size == 0U));
+        ASSERT(queue.Size() == used);
+        for (size_t index = 0U; index < prefix; ++index)
+        {
+          (index < first_size ? first[index] : second[index - first_size]) =
+              static_cast<uint32_t>(100U + index);
+        }
+        return prefix;
+      });
+
+  ASSERT(produced == prefix);
+  ASSERT(calls == (offer == 0U ? 0U : 1U));
+  for (size_t index = 0U; index < prefix; ++index)
+  {
+    expected.push_back(static_cast<uint32_t>(100U + index));
+  }
+  CheckContents(queue, expected);
+}
+
+void CheckConsumePrefix(size_t capacity, size_t offset, size_t used, size_t limit,
+                        size_t prefix)
+{
+  Queue queue(capacity);
+  std::vector<uint32_t> expected;
+  FillQueue(queue, offset, used, expected);
+
+  const size_t offer = std::min(limit, used);
+  size_t calls = 0U;
+  const size_t consumed = queue.ConsumeWithReader(
+      limit,
+      [&](const uint32_t* first, size_t first_size, const uint32_t* second,
+          size_t second_size)
+      {
+        ++calls;
+        ASSERT(first != nullptr && first_size > 0U);
+        ASSERT(first_size + second_size == offer);
+        ASSERT((second == nullptr) == (second_size == 0U));
+        for (size_t index = 0U; index < offer; ++index)
+        {
+          ASSERT((index < first_size ? first[index] : second[index - first_size]) ==
+                 expected[index]);
+        }
+        ASSERT(queue.Size() == used);
+        return prefix;
+      });
+
+  ASSERT(consumed == prefix);
+  ASSERT(calls == (offer == 0U ? 0U : 1U));
+  expected.erase(expected.begin(), expected.begin() + prefix);
+  CheckContents(queue, expected);
+}
+
+void TestEveryPrefix()
+{
+  for (size_t capacity = 1U; capacity <= 8U; ++capacity)
+  {
+    for (size_t offset = 0U; offset <= capacity; ++offset)
+    {
+      for (size_t used = 0U; used <= capacity; ++used)
+      {
+        for (size_t limit = 0U; limit <= capacity + 2U; ++limit)
+        {
+          const size_t write_offer = std::min(limit, capacity - used);
+          for (size_t prefix = 0U; prefix <= write_offer; ++prefix)
+          {
+            CheckProducePrefix(capacity, offset, used, limit, prefix);
+          }
+
+          const size_t read_offer = std::min(limit, used);
+          for (size_t prefix = 0U; prefix <= read_offer; ++prefix)
+          {
+            CheckConsumePrefix(capacity, offset, used, limit, prefix);
+          }
+        }
+      }
+    }
+  }
+}
+
+void TestOppositeSideProgress()
+{
+  Queue queue(3U);
+  const size_t produced =
+      queue.ProduceWithWriter(std::numeric_limits<size_t>::max(),
+                              [&](uint32_t* first, size_t n1, uint32_t*, size_t n2)
+                              {
+                                ASSERT(n1 == 3U && n2 == 0U);
+                                first[0] = 71U;
+                                uint32_t value = 0U;
+                                ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+                                return 1U;
+                              });
+  ASSERT(produced == 1U);
+  ASSERT(queue.ConsumeWithReader(
+             3U,
+             [&](const uint32_t* first, size_t n1, const uint32_t*, size_t n2)
+             {
+               ASSERT(n1 == 1U && n2 == 0U && first[0] == 71U);
+               ASSERT(queue.Push(72U) == LibXR::ErrorCode::OK);
+               return 1U;
+             }) == 1U);
+  CheckContents(queue, {72U});
+
+  ASSERT(queue.PushBatch(static_cast<const uint32_t*>(nullptr), 0U) ==
+         LibXR::ErrorCode::OK);
+  const uint32_t full[] = {1U, 2U, 3U};
+  ASSERT(queue.PushBatch(full, 3U) == LibXR::ErrorCode::OK);
+  ASSERT(queue.ConsumeWithReader(3U,
+                                 [&](const uint32_t*, size_t, const uint32_t*, size_t)
+                                 {
+                                   ASSERT(queue.Push(99U) == LibXR::ErrorCode::FULL);
+                                   return 2U;
+                                 }) == 2U);
+  ASSERT(queue.Push(99U) == LibXR::ErrorCode::OK);
+  CheckContents(queue, {3U, 99U});
+}
+
+struct alignas(16) AlignedPayload
+{
+  uint32_t value;
+};
+
+void TestAlignedPayloadAndRawStride()
+{
+  LibXR::SPSCQueue<AlignedPayload> queue(3U);
+  AlignedPayload seed{0U};
+  ASSERT(queue.Push(seed) == LibXR::ErrorCode::OK);
+  ASSERT(queue.Push(seed) == LibXR::ErrorCode::OK);
+  ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
+  ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
+  ASSERT(queue.ProduceWithWriter(
+             3U,
+             [](AlignedPayload* first, size_t n1, AlignedPayload* second, size_t n2)
+             {
+               ASSERT(n1 == 2U && n2 == 1U);
+               ASSERT(reinterpret_cast<uintptr_t>(first) % alignof(AlignedPayload) == 0U);
+               ASSERT(reinterpret_cast<uintptr_t>(second) % alignof(AlignedPayload) ==
+                      0U);
+               first[0] = AlignedPayload{11U};
+               first[1] = AlignedPayload{12U};
+               second[0] = AlignedPayload{13U};
+               return 3U;
+             }) == 3U);
+  for (uint32_t expected = 11U; expected <= 13U; ++expected)
+  {
+    AlignedPayload actual{};
+    ASSERT(queue.Pop(actual) == LibXR::ErrorCode::OK);
+    ASSERT(actual.value == expected);
+  }
+
+  LibXR::SPSCQueueBase raw(3U, 4U, 2U);
+  ASSERT(raw.ProduceWithWriter(2U,
+                               [](void* first, size_t n1, void*, size_t n2)
+                               {
+                                 ASSERT(n1 == 2U && n2 == 0U);
+                                 auto* bytes = static_cast<uint8_t*>(first);
+                                 for (size_t i = 0U; i < n1; ++i)
+                                 {
+                                   for (size_t byte = 0U; byte < 3U; ++byte)
+                                   {
+                                     bytes[i * 4U + byte] = static_cast<uint8_t>(i + 1U);
+                                   }
+                                 }
+                                 return n1;
+                               }) == 2U);
+  uint8_t payload[3]{};
+  for (uint8_t expected = 1U; expected <= 2U; ++expected)
+  {
+    ASSERT(raw.PopBytes(payload) == LibXR::ErrorCode::OK);
+    ASSERT(payload[0] == expected && payload[1] == expected && payload[2] == expected);
+  }
+}
+
+void TestConcurrentPrefixes()
+{
+  constexpr uint32_t TOTAL = 50000U;
+  Queue queue(17U);
+  std::thread producer(
+      [&]
+      {
+        uint32_t next = 0U;
+        while (next != TOTAL)
+        {
+          const size_t produced = queue.ProduceWithWriter(
+              std::min<uint32_t>(11U, TOTAL - next),
+              [&](uint32_t* first, size_t n1, uint32_t* second, size_t n2)
+              {
+                const size_t prefix = std::min<size_t>(n1 + n2, 1U + next % 7U);
+                for (size_t i = 0U; i < prefix; ++i)
+                {
+                  (i < n1 ? first[i] : second[i - n1]) = next + static_cast<uint32_t>(i);
+                }
+                return prefix;
+              });
+          next += static_cast<uint32_t>(produced);
+          if (produced == 0U)
+          {
+            std::this_thread::yield();
+          }
+        }
+      });
+  uint32_t expected = 0U;
+  while (expected != TOTAL)
+  {
+    const size_t consumed = queue.ConsumeWithReader(
+        13U,
+        [&](const uint32_t* first, size_t n1, const uint32_t* second, size_t n2)
+        {
+          const size_t prefix = std::min<size_t>(n1 + n2, 1U + expected % 5U);
+          for (size_t i = 0U; i < prefix; ++i)
+          {
+            ASSERT((i < n1 ? first[i] : second[i - n1]) == expected + i);
+          }
+          return prefix;
+        });
+    expected += static_cast<uint32_t>(consumed);
+    if (consumed == 0U)
+    {
+      std::this_thread::yield();
+    }
+  }
+  producer.join();
+  ASSERT(queue.Size() == 0U);
+}
+}  // namespace
+
+void test_spsc_prefix()
+{
+  TestEveryPrefix();
+  TestOppositeSideProgress();
+  TestAlignedPayloadAndRawStride();
+  TestConcurrentPrefixes();
+}

--- a/test/framework/test_base.hpp
+++ b/test/framework/test_base.hpp
@@ -29,6 +29,8 @@ void test_message_packet();
 void test_message_topic();
 void test_queue();
 void test_spsc_queue();
+void test_spsc_prefix();
+void test_serialized_service();
 void test_rbt();
 void test_ramfs();
 void test_semaphore();

--- a/test/framework/test_main_sets.hpp
+++ b/test/framework/test_main_sets.hpp
@@ -71,6 +71,8 @@ inline constexpr GroupedTestCase kMainTestCases[] = {
     {"synchronization_tests", {"semaphore", &RunVoidEntry<test_semaphore>, false}},
     {"synchronization_tests", {"mutex", &RunVoidEntry<test_mutex>, false}},
     {"synchronization_tests", {"async", &RunVoidEntry<test_async>, false}},
+    {"synchronization_tests",
+     {"serialized_service", &RunVoidEntry<test_serialized_service>, false}},
 
     {"utility_tests", {"crc", &RunVoidEntry<test_crc>, false}},
     {"utility_tests", {"encoder", &RunVoidEntry<test_float_encoder>, false}},
@@ -81,6 +83,7 @@ inline constexpr GroupedTestCase kMainTestCases[] = {
     {"data_structure_tests", {"rbt", &RunVoidEntry<test_rbt>, false}},
     {"data_structure_tests", {"queue", &RunVoidEntry<test_queue>, false}},
     {"data_structure_tests", {"spsc_queue", &RunVoidEntry<test_spsc_queue>, false}},
+    {"data_structure_tests", {"spsc_prefix", &RunVoidEntry<test_spsc_prefix>, false}},
     {"data_structure_tests", {"mpmc_queue", &RunVoidEntry<test_mpmc_queue>, false}},
     {"data_structure_tests", {"object_pool", &RunVoidEntry<test_object_pool>, false}},
     {"data_structure_tests", {"stack", &RunVoidEntry<test_stack>, false}},


### PR DESCRIPTION
## Scope

Add the reusable queue and backend-owner prerequisites needed by the PR249 replacement:

- symmetric SPSC `ProduceWithWriter` / `ConsumeWithReader` prefix operations;
- one-word `SerializedService` owner/event primitive;
- focused regression coverage registered in the normal Linux test runner.

No RW public API migration, UART backend change, USB lifecycle change, CI policy change, or planning
document is included in this commit.

## Verification

- Linux default and Debug builds/tests pass, including the new queue/service tests;
- ASan/UBSan focused probes pass;
- ESP32, ESP32-S3, and ESP32-C3 object compilation passes;
- clang-format and `git diff --check` pass.

This is a draft prerequisite slice based on the PR248 restoration branch.

## Sourcery 总结

建立可复用的 SPSC 前缀和序列化服务原语，同时更新 UART DMA 后端，以使用直接的双缓冲所有权和事件协调机制。

新功能：
- 为 SPSC 队列添加有界双跨度前缀生产和消费 API。
- 添加紧凑型 `SerializedService` 原语，用于在单个执行所有者下合并事件。

错误修复：
- 在重新配置过程中保持 UART TX 的进度，并改进 STM32、CH32 和 ESP32 后端的 DMA RX/TX 处理。

增强功能：
- 使用由后端直接拥有的缓冲、事件和中断协调机制，替换共享的 UART DMA/配置模型抽象。
- 移除已废弃的快照、UART DMA 模型和 RX 配置门控实现及其测试。

测试：
- 针对 SPSC 前缀操作和序列化服务所有权添加专门的回归测试，涵盖环回、对齐、并发和事件发布场景。
- 将新的队列和服务测试注册到标准测试套件中，同时移除已删除抽象的相关测试。

杂项：
- 清理已废弃的原子操作 shim 实现和少量源代码级冗余。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

提供可复用的 SPSC 前缀和序列化服务原语，用于协调队列数据和单所有者事件处理。

新功能：
- 为 SPSC 队列添加有界双跨度前缀生产和消费 API。
- 添加紧凑的 `SerializedService` 原语，用于在单个执行所有者下合并事件。

测试：
- 添加针对 SPSC 前缀操作和 `SerializedService` 所有权、事件发布、对齐、并发性及回调行为的回归测试覆盖。
- 将新的队列和服务测试注册到标准测试套件中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

提供可复用的 SPSC 前缀操作和序列化事件所有者原语，用于协调排队数据和单所有者工作。

新功能：
- 为 SPSC 队列添加有界的双跨度前缀生产和消费操作。
- 引入紧凑的 `SerializedService` 原语，用于单所有者事件合并。

增强功能：
- 为类型化 SPSC 队列公开前缀操作，同时保留生产者和消费者的所有权约束。

测试：
- 添加针对 SPSC 前缀行为、对齐、环回、并发进度，以及 `SerializedService` 所有权和事件发布的回归测试。
- 将新的队列和服务测试注册到标准测试套件中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

提供可复用的 SPSC 前缀操作和序列化事件所有者原语，作为基于队列的服务协调机制的前置功能。

新功能：
- 为 SPSC 队列添加有界双跨度前缀生产和消费操作。
- 引入紧凑的 `SerializedService` 原语，用于单所有者事件合并和序列化处理程序执行。

测试：
- 增加针对 SPSC 前缀行为、环绕、对齐、原始步幅处理、对侧进度和并发操作的回归测试覆盖。
- 增加针对 `SerializedService` 所有权、延迟和递归事件发布、可调用对象生命周期以及并发事件处理的回归测试覆盖，并将这两个测试套件注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

提供可复用的 SPSC 前缀操作和序列化事件所有权原语，作为基于队列的服务协调机制的前置功能。

新功能：
- 为 SPSC 队列添加有界的双跨度前缀生产和消费操作。
- 引入紧凑型 `SerializedService` 原语，用于单所有者事件合并和序列化处理程序执行。

测试：
- 为 SPSC 前缀行为、环回、对齐、原始步长处理、对端进度以及并发生产者/消费者操作添加回归测试覆盖。
- 为 `SerializedService` 所有权、延迟和递归事件发布、可调用对象生命周期、负载可见性以及并发事件处理添加回归测试覆盖，并将两组测试注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为基于队列的服务协调添加可复用的 SPSC 前缀操作和序列化事件所有权原语。

新功能：
- 为 SPSC 队列添加有界双跨度前缀生产和消费操作。
- 引入紧凑型 `SerializedService` 原语，用于单所有者、合并式事件处理。

增强功能：
- 为新的 SPSC 前缀操作提供类型化封装，同时保留生产者和消费者的所有权约束。

测试：
- 为 SPSC 前缀行为、环回、对齐、原始步长、对侧进度和并发操作添加回归测试覆盖。
- 为 `SerializedService` 的所有权、延迟事件和递归事件、可调用对象生命周期以及并发事件发布添加回归测试覆盖，并将两个测试套件注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为基于队列的服务协调提供可复用的 SPSC 前缀操作和序列化事件所有权原语。

新功能：
- 为 SPSC 队列添加有界双跨度前缀生产和消费操作。
- 引入紧凑型 `SerializedService` 原语，用于单所有者的事件合并处理。

增强：
- 为新的 SPSC 前缀操作提供类型化封装，同时保留生产者和消费者的所有权约束。

测试：
- 添加针对 SPSC 前缀行为、环回、对齐、原始步长、对侧进度和并发操作的回归测试覆盖。
- 添加针对 `SerializedService` 所有权、延迟事件和递归事件、可调用对象生命周期、负载可见性以及并发事件发布的回归测试覆盖；并将两个测试套件注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为基于队列的服务协调提供可复用的 SPSC 前缀操作，以及序列化事件所有权原语。

新功能：
- 为 SPSC 队列添加有界的双跨度前缀生产和消费操作。
- 引入紧凑型 `SerializedService` 原语，用于合并事件，并在单一所有者下串行执行处理程序。

增强：
- 为新的 SPSC 前缀操作提供类型化封装，同时保留生产者和消费者的所有权约束。

测试：
- 添加针对 SPSC 前缀行为、环回、对齐、原始步长、对侧进度和并发操作的回归测试覆盖。
- 添加针对 `SerializedService` 所有权、延迟事件和递归事件、可调用对象生命周期、负载可见性以及并发事件发布的回归测试覆盖，并将两个测试套件注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

提供可复用的 SPSC 前缀操作和序列化事件所有权原语，用于基于队列的服务协调。

新功能：
- 为 SPSC 队列添加有界双跨度前缀生产和消费操作。
- 引入紧凑的 `SerializedService` 原语，用于合并事件，并在单一所有者下串行执行处理程序。

增强功能：
- 为新的 SPSC 前缀操作提供类型化封装，同时保留单生产者和单消费者的所有权约束。

测试：
- 添加对 SPSC 前缀行为、环回、对齐、原始步长处理、另一侧进度以及生产者/消费者并发操作的回归测试覆盖。
- 添加对 `SerializedService` 所有权、延迟事件和递归事件、可调用对象生命周期、负载可见性以及并发事件发布的回归测试覆盖，并将两个测试套件注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为基于队列的服务协调提供可复用的 SPSC 前缀操作，以及序列化事件所有权原语。

新功能：
- 为 SPSC 队列添加有界的双跨度前缀生产和消费操作。
- 引入紧凑的 `SerializedService` 原语，用于合并事件，并在单一所有者下串行执行处理程序。

增强功能：
- 为新的 SPSC 前缀操作提供类型化封装，同时保留单生产者和单消费者的所有权约束。

测试：
- 为 SPSC 前缀行为、环回、对齐、原始步长、对侧进度和并发操作添加回归测试覆盖。
- 为 `SerializedService` 的所有权、延迟事件和递归事件、可调用对象生命周期、负载可见性及并发发布添加回归测试覆盖，并将两套测试注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为基于队列的服务协调提供可复用的 SPSC 前缀操作和序列化事件所有权原语。

新功能：
- 为 SPSC 队列添加有界双跨度前缀生产和消费操作。
- 引入紧凑型 `SerializedService` 原语，用于合并事件，并在单一所有者下串行执行处理程序。

增强功能：
- 为 SPSC 前缀操作提供类型化封装，同时保留单生产者和单消费者的所有权约束。

测试：
- 添加 SPSC 前缀行为的回归测试，涵盖环回、对齐、原始步长、部分进度以及生产者与消费者并发操作。
- 添加 `SerializedService` 所有权、延迟和递归事件、可调用对象生命周期、负载可见性以及并发事件发布的回归测试，并将两个测试套件注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为基于队列的服务协调提供可复用的 SPSC 前缀操作和序列化事件所有权原语。

新功能：
- 为 SPSC 队列添加有界的双跨度前缀生产和消费操作。
- 引入紧凑的 `SerializedService` 原语，用于合并事件，并在单个所有者下对处理程序执行进行序列化。

增强功能：
- 为新的 SPSC 前缀操作提供类型化封装，同时保留单生产者和单消费者的所有权约束。

测试：
- 添加针对 SPSC 前缀行为、回绕、对齐、原始步长、部分进度以及生产者/消费者并发操作的回归测试覆盖。
- 添加针对 `SerializedService` 所有权、延迟事件和递归事件、可调用对象生命周期、负载可见性以及并发发布的回归测试覆盖，并将这两组测试注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为基于队列的服务协调提供可复用的 SPSC 前缀操作和序列化事件所有权原语。

新功能：
- 为 SPSC 队列添加有界双跨度前缀生产和消费操作。
- 引入紧凑的 `SerializedService` 原语，用于合并事件，并在单一所有者下对处理程序执行进行序列化。

增强功能：
- 为新的 SPSC 前缀操作提供类型化封装，同时保留单生产者和单消费者的所有权约束。

测试：
- 添加针对 SPSC 前缀行为、环回、对齐、原始步长、部分进度、对侧进度和并发操作的回归测试。
- 添加针对 `SerializedService` 所有权、延迟事件和递归事件、可调用对象生命周期、负载可见性及并发发布的回归测试，并将这两组测试注册到标准测试运行器中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide reusable SPSC prefix operations and serialized event ownership primitives for queue-based service coordination.

New Features:
- Add bounded two-span prefix production and consumption operations to SPSC queues.
- Introduce a compact SerializedService primitive for coalescing events and serializing handler execution under a single owner.

Enhancements:
- Expose typed wrappers for the new SPSC prefix operations while preserving single-producer and single-consumer ownership constraints.

Tests:
- Add regression coverage for SPSC prefix behavior, wraparound, alignment, raw strides, partial progress, opposite-side progress, and concurrent operation.
- Add regression coverage for SerializedService ownership, deferred and recursive events, callable lifetime, payload visibility, and concurrent publication, and register both suites with the standard test runner.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>