### PR TITLE
fix: retry exact completion handoffs

### DIFF
--- a/src/core/rw/operation.hpp
+++ b/src/core/rw/operation.hpp
@@ -286,9 +286,12 @@ class AsyncBlockWait
       return ErrorCode::TIMEOUT;
     }
 
-    auto finish_wait_ans = sem_->Wait(UINT32_MAX);
-    UNUSED(finish_wait_ans);
-    ASSERT(finish_wait_ans == ErrorCode::OK);
+    ErrorCode finish_wait_ans;
+    do
+    {
+      finish_wait_ans = sem_->Wait(UINT32_MAX);
+    } while (finish_wait_ans == ErrorCode::TIMEOUT);
+    REQUIRE(finish_wait_ans == ErrorCode::OK);
     state_.store(State::IDLE, std::memory_order_release);
     return result_;
   }

--- a/src/core/rw/read_port.cpp
+++ b/src/core/rw/read_port.cpp
@@ -174,9 +174,12 @@ ErrorCode ReadPort::operator()(RawData data, ReadOperation& op, bool in_isr)
 
       // Timeout lost after completion had already claimed the waiter.
       // 超时发生得太晚，完成侧已经 claim 了当前 waiter。
-      auto finish_wait_ans = op.data.sem_info.sem->Wait(UINT32_MAX);
-      UNUSED(finish_wait_ans);
-      ASSERT(finish_wait_ans == ErrorCode::OK);
+      ErrorCode finish_wait_ans;
+      do
+      {
+        finish_wait_ans = op.data.sem_info.sem->Wait(UINT32_MAX);
+      } while (finish_wait_ans == ErrorCode::TIMEOUT);
+      REQUIRE(finish_wait_ans == ErrorCode::OK);
       busy_.store(BusyState::IDLE, std::memory_order_release);
       return block_result_;
     }

--- a/src/core/rw/write_port.cpp
+++ b/src/core/rw/write_port.cpp
@@ -195,9 +195,12 @@ ErrorCode WritePort::CommitWrite(ConstRawData data, WriteOperation& op, bool met
 
       if (state == BusyState::BLOCK_CLAIMED)
       {
-        auto finish_wait_ans = op.data.sem_info.sem->Wait(UINT32_MAX);
-        UNUSED(finish_wait_ans);
-        ASSERT(finish_wait_ans == ErrorCode::OK);
+        ErrorCode finish_wait_ans;
+        do
+        {
+          finish_wait_ans = op.data.sem_info.sem->Wait(UINT32_MAX);
+        } while (finish_wait_ans == ErrorCode::TIMEOUT);
+        REQUIRE(finish_wait_ans == ErrorCode::OK);
         busy_.store(BusyState::IDLE, std::memory_order_release);
         return block_result_;
       }
@@ -274,9 +277,12 @@ ErrorCode WritePort::CommitWrite(ConstRawData data, WriteOperation& op, bool met
 
     // Timeout lost after completion had already claimed the waiter.
     // 超时发生得太晚，完成侧已经 claim 了当前 waiter。
-    auto finish_wait_ans = op.data.sem_info.sem->Wait(UINT32_MAX);
-    UNUSED(finish_wait_ans);
-    ASSERT(finish_wait_ans == ErrorCode::OK);
+    ErrorCode finish_wait_ans;
+    do
+    {
+      finish_wait_ans = op.data.sem_info.sem->Wait(UINT32_MAX);
+    } while (finish_wait_ans == ErrorCode::TIMEOUT);
+    REQUIRE(finish_wait_ans == ErrorCode::OK);
     busy_.store(BusyState::IDLE, std::memory_order_release);
 
     return block_result_;

--- a/src/middleware/message/subscriber/sync.hpp
+++ b/src/middleware/message/subscriber/sync.hpp
@@ -186,9 +186,12 @@ class Topic::SyncSubscriber
 
     ASSERT(data.wait_state.load(std::memory_order_acquire) == SyncBlock::WAIT_CLAIMED);
 
-    auto finish_wait_ans = data.sem.Wait(UINT32_MAX);
-    UNUSED(finish_wait_ans);
-    ASSERT(finish_wait_ans == ErrorCode::OK);
+    ErrorCode finish_wait_ans;
+    do
+    {
+      finish_wait_ans = data.sem.Wait(UINT32_MAX);
+    } while (finish_wait_ans == ErrorCode::TIMEOUT);
+    REQUIRE(finish_wait_ans == ErrorCode::OK);
     data.wait_state.store(SyncBlock::WAIT_IDLE, std::memory_order_release);
     return ErrorCode::OK;
   }


### PR DESCRIPTION
## Scope

Harden exact completion handoffs for the existing RW and synchronous-subscriber paths.

- Retry only transient `TIMEOUT` results while consuming a completion token already claimed by the state machine.
- Accept `OK`; treat any other result as an internal contract violation.
- Cover `AsyncBlockWait`, ReadPort and WritePort BLOCK handoffs, and synchronous topic subscriber completion.

This PR is based on `dev@1dd52aa` and contains no RW frontend migration, UART backend, USB, or master changes.

## Verification

- Dependency Quality, License Compliance, and Security Analysis: passed.
- Linux Debug build: passed.
- Full Linux test runner: passed with `All tests completed.`
- clang-format and `git diff --check`: passed.

The PR adds no test target, build option, linker hook, or CMake wiring.

## Sourcery 摘要

通过拒绝意外的完成结果，确保精确完成交接在发生暂时性超时后仍能可靠完成。

Bug 修复：
- 在完成所有权被获取后，通过重试暂时性超时结果，增强 RW 阻塞操作和同步主题订阅者中的精确完成交接。

增强功能：
- 强制成功消费完成令牌，并将意外的信号量结果标记为内部契约违规。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make exact completion handoffs reliably finish after transient timeouts while rejecting unexpected completion results.

Bug Fixes:
- Harden exact completion handoffs across RW blocking operations and synchronous topic subscribers by retrying transient timeout results after completion ownership has been claimed.

Enhancements:
- Enforce successful completion-token consumption and flag unexpected semaphore results as internal contract violations.

</details>