### PR TITLE
test: correct terminal history navigation oracle

### DIFF
--- a/test/base/middleware/terminal/test_input_history.cpp
+++ b/test/base/middleware/terminal/test_input_history.cpp
@@ -60,6 +60,7 @@ void TestInputCrLfAndHistory()
   ASSERT(two_count == 2);
 
   fixture.SendRaw(KEY_UP, sizeof(KEY_UP) - 1);
+  fixture.SendRaw(KEY_UP, sizeof(KEY_UP) - 1);
   auto older_history = fixture.SendRaw(KEY_UP, sizeof(KEY_UP) - 1);
   ASSERT(older_history.find("one") != std::string::npos);
   auto move_forward_history = fixture.SendRaw(KEY_DOWN, sizeof(KEY_DOWN) - 1);


### PR DESCRIPTION
Correct the terminal history test to account for a command recalled and executed being appended to history again. This adds one Up navigation and changes no production code.

## Sourcery 总结

修正终端历史记录导航测试，以反映召回并执行命令后的历史记录行为。

错误修复：
- 修正终端历史记录导航测试，以考虑已执行的召回命令会追加到历史记录中。

测试：
- 根据修正后的历史记录序列，使用额外的一次向上导航更新终端历史记录测试预期结果。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修正执行已调用命令后重复条目的终端历史记录导航测试预期。

错误修复：
- 修正终端输入历史记录导航测试，以考虑已调用并执行的命令会再次追加到历史记录中。

测试：
- 更新终端历史记录测试预期，增加一次向上导航。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

纠正调用并执行命令后终端历史记录导航的预期行为。

错误修复：
- 修正终端输入历史记录导航测试，以考虑已执行的调用命令会再次添加到历史记录中。

测试：
- 更新终端历史记录测试，以根据修正后的历史记录顺序执行额外一次向上导航。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修正终端历史记录导航测试中对重复条目的预期，该问题发生在执行已调出的命令之后。

错误修复：
- 修正终端输入历史记录导航测试，以考虑已执行的调出命令会再次追加到历史记录中。

测试：
- 更新终端历史记录测试的预期，以包含根据修正后的历史记录序列所需的额外向上导航操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct terminal history navigation test expectations for repeated entries after executing a recalled command.

Bug Fixes:
- Correct the terminal input history navigation test to account for executed recalled commands being appended to history again.

Tests:
- Update the terminal history test expectations to include the additional upward navigation required by the corrected history sequence.

</details>

</details>

</details>

</details>