### PR TITLE
feat: migrate Linux UART to serialized I/O

### DIFF
--- a/driver/linux/linux_uart.hpp
+++ b/driver/linux/linux_uart.hpp
@@ -6,15 +6,21 @@
 #include <fcntl.h>
 #include <libudev.h>
 #include <linux/serial.h>
+#include <poll.h>
+#include <sys/eventfd.h>
 #include <sys/ioctl.h>
-#include <sys/select.h>
+#include <sys/uio.h>
 #include <termios.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
+#include <atomic>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <string>
 #include <system_error>
 #include <vector>
 
@@ -25,19 +31,72 @@
 
 namespace LibXR
 {
+class LinuxUART;
+
+namespace Detail
+{
 /**
- * @brief Linux UART 串口驱动实现 / Linux UART driver implementation
+ * @brief 通知串口线程恢复接收的读端口 / Read port that wakes UART reception.
+ */
+class LinuxUARTReadPort : public ReadPort
+{
+ public:
+  /// 构造接收端口并关联串口 / Construct the RX port associated with its UART.
+  LinuxUARTReadPort(size_t size, LinuxUART& owner) : ReadPort(size), owner_(owner) {}
+
+  /// 释放空间后唤醒串口线程 / Wake the UART thread after space is freed.
+  void OnReadQueueSpaceAvailable(bool) override;
+
+ private:
+  LinuxUART& owner_;  ///< 所属串口 / Associated UART.
+};
+}  // namespace Detail
+
+/**
+ * @brief 使用单个 I/O 线程的 Linux 串口 / Linux UART with one I/O thread.
  *
- * 支持按设备路径或 USB VID/PID(/control interface name[/serial]) 自动发现并创建 UART
- * 通道。
- * Supports UART creation by device path or USB VID/PID(/control interface
- * name[/serial]) auto discovery.
+ * 支持设备路径和 USB VID/PID、控制接口名称、序列号匹配。线程统一负责打开、关闭、
+ * 接收、发送、配置和重连，读写端口的通知只唤醒该线程。
+ * Supports device paths or USB VID/PID, control-interface name, and serial matching.
+ * One thread handles open, close, RX, TX, configuration, and reconnect. Port callbacks
+ * only wake that thread.
+ *
+ * @note 写完成表示数据已被 Linux 接收。短写保留剩余部分；部分发送后断线会以 FAILED
+ *       结束该请求，尚未发送的后续请求保留到重连。接收队列满时暂停读取设备。
+ *       Writes complete on kernel acceptance. Short writes retain the suffix; a
+ *       disconnect after partial transmission fails that request and retains later
+ *       requests for reconnect. Full RX queues pause device reads.
+ * @pre 读写操作遵守端口约定。对象用于长期运行，线程结束前须保持对象和端口有效。
+ *      Follow the port contracts. Keep this startup-lifetime object and its ports
+ *      valid for the lifetime of the I/O thread.
  */
 class LinuxUART : public UART
 {
+  friend class Detail::LinuxUARTReadPort;
+
+  /// 单个待应用配置的发布状态 / Publication state of the pending configuration.
+  enum class ConfigState : uint8_t
+  {
+    EMPTY,      ///< 可接受配置 / Available for a configuration.
+    RESERVED,   ///< 调用者正在写入 / Caller writing the configuration.
+    PUBLISHED,  ///< 等待线程应用 / Awaiting application by the I/O thread.
+  };
+
  public:
   /**
-   * @brief 通过设备路径构造 UART / Construct UART by device path
+   * @brief 通过设备路径构造串口 / Construct a UART by device path.
+   * @param dev_path 设备路径 / Device path.
+   * @param baudrate 初始波特率，必须大于零 / Positive initial baud rate.
+   * @param parity 奇偶校验方式 / Parity mode.
+   * @param data_bits 数据位数，范围 5 至 8 / Data bits, from 5 to 8.
+   * @param stop_bits 停止位数，1 或 2 / Stop bits, 1 or 2.
+   * @param tx_queue_size 请求队列容量，必须大于零 / Positive TX request capacity.
+   * @param buffer_size 每个方向的字节队列容量，必须大于零 / Positive per-direction
+   * capacity.
+   * @param thread_stack_size I/O 线程栈大小，单位为字节 / I/O thread stack size in bytes.
+   * @note 路径不存在时等待；路径存在后等待线程首次尝试打开设备，失败由线程继续重连。
+   *       Waits for the path, then for the thread's first open attempt. Failure is
+   *       recovered by the thread's reconnect loop.
    */
   LinuxUART(const char* dev_path, unsigned int baudrate = 115200,
             Parity parity = Parity::NO_PARITY, uint8_t data_bits = 8,
@@ -45,12 +104,13 @@ class LinuxUART : public UART
             size_t thread_stack_size = 65536)
       : UART(&_read_port, &_write_port),
         rx_buff_(new uint8_t[buffer_size]),
-        tx_buff_(new uint8_t[buffer_size]),
         buff_size_(buffer_size),
-        _read_port(buffer_size),
+        config_{baudrate, parity, data_bits, stop_bits},
+        _read_port(buffer_size, *this),
         _write_port(tx_queue_size, buffer_size)
   {
     ASSERT(buff_size_ > 0);
+    REQUIRE(tx_queue_size > 0);
 
     while (!std::filesystem::exists(dev_path))
     {
@@ -60,39 +120,21 @@ class LinuxUART : public UART
 
     device_path_ = GetByPathForTTY(dev_path);
 
-    fd_ = open(device_path_.c_str(), O_RDWR | O_NOCTTY);
-    if (fd_ < 0)
-    {
-      XR_LOG_ERROR("Cannot open UART device: %s", device_path_.c_str());
-      ASSERT(false);
-    }
-    else
-    {
-      XR_LOG_PASS("Open UART device: %s", device_path_.c_str());
-    }
-
-    config_ = {};
-    config_.baudrate = baudrate;
-    config_.parity = parity;
-    config_.data_bits = data_bits;
-    config_.stop_bits = stop_bits;
-
-    SetConfig(config_);
-
-    _read_port = ReadFun;
-    _write_port = WriteFun;
-
-    rx_thread_.Create<LinuxUART*>(
-        this, [](LinuxUART* self) { self->RxLoop(); }, "rx_uart", thread_stack_size,
-        Thread::Priority::REALTIME);
-
-    tx_thread_.Create<LinuxUART*>(
-        this, [](LinuxUART* self) { self->TxLoop(); }, "tx_uart", thread_stack_size,
-        Thread::Priority::REALTIME);
+    StartIoOwner(thread_stack_size);
   }
 
   /**
-   * @brief 通过 USB VID/PID 构造 UART / Construct UART by USB VID/PID
+   * @brief 通过 USB VID/PID 构造串口 / Construct a UART by USB VID/PID.
+   * @param vid USB 厂商 ID 字符串 / USB vendor ID string.
+   * @param pid USB 产品 ID 字符串 / USB product ID string.
+   * @param baudrate 初始波特率，必须大于零 / Positive initial baud rate.
+   * @param parity 奇偶校验方式 / Parity mode.
+   * @param data_bits 数据位数，范围 5 至 8 / Data bits, from 5 to 8.
+   * @param stop_bits 停止位数，1 或 2 / Stop bits, 1 or 2.
+   * @param tx_queue_size 请求队列容量，必须大于零 / Positive TX request capacity.
+   * @param buffer_size 每个方向的字节队列容量，必须大于零 / Positive per-direction
+   * capacity.
+   * @param thread_stack_size I/O 线程栈大小，单位为字节 / I/O thread stack size in bytes.
    */
   LinuxUART(const std::string& vid, const std::string& pid,
             unsigned int baudrate = 115200, Parity parity = Parity::NO_PARITY,
@@ -104,14 +146,19 @@ class LinuxUART : public UART
   }
 
   /**
-   * @brief 通过 USB VID/PID/control interface name 构造 UART
-   *        Construct UART by USB VID/PID/control interface name
-   *
-   * @note CDC ACM 有 control/data 两个 interface；这里匹配 Linux ttyACM 父级
-   *       usb_interface 的 control interface 名称，不匹配 data interface 名称。
-   *       CDC ACM has control/data interfaces; this selector matches the Linux
-   *       ttyACM parent usb_interface control interface name, not the data
-   *       interface name.
+   * @brief 按 USB 控制接口名称构造串口 / Construct a UART by USB control interface.
+   * @param vid USB 厂商 ID 字符串 / USB vendor ID string.
+   * @param pid USB 产品 ID 字符串 / USB product ID string.
+   * @param control_interface_name 控制接口名称，空值不限制 / Control interface, empty for
+   * any.
+   * @param baudrate 初始波特率，必须大于零 / Positive initial baud rate.
+   * @param parity 奇偶校验方式 / Parity mode.
+   * @param data_bits 数据位数，范围 5 至 8 / Data bits, from 5 to 8.
+   * @param stop_bits 停止位数，1 或 2 / Stop bits, 1 or 2.
+   * @param tx_queue_size 请求队列容量，必须大于零 / Positive TX request capacity.
+   * @param buffer_size 每个方向的字节队列容量，必须大于零 / Positive per-direction
+   * capacity.
+   * @param thread_stack_size I/O 线程栈大小，单位为字节 / I/O thread stack size in bytes.
    */
   LinuxUART(const std::string& vid, const std::string& pid,
             const std::string& control_interface_name, unsigned int baudrate = 115200,
@@ -124,14 +171,23 @@ class LinuxUART : public UART
   }
 
   /**
-   * @brief 通过 USB VID/PID/control interface name/serial 构造 UART
-   *        Construct UART by USB VID/PID/control interface name/serial
-   *
-   * @note CDC ACM 有 control/data 两个 interface；这里匹配 Linux ttyACM 父级
-   *       usb_interface 的 control interface 名称，不匹配 data interface 名称。
-   *       CDC ACM has control/data interfaces; this selector matches the Linux
-   *       ttyACM parent usb_interface control interface name, not the data
-   *       interface name.
+   * @brief 按 USB 接口和序列号构造串口 / Construct a UART by USB interface and serial.
+   * @param vid USB 厂商 ID 字符串 / USB vendor ID string.
+   * @param pid USB 产品 ID 字符串 / USB product ID string.
+   * @param control_interface_name 控制接口名称，空值不限制 / Control interface, empty for
+   * any.
+   * @param serial 设备序列号，空值不限制 / Device serial number, empty for any.
+   * @param baudrate 初始波特率，必须大于零 / Positive initial baud rate.
+   * @param parity 奇偶校验方式 / Parity mode.
+   * @param data_bits 数据位数，范围 5 至 8 / Data bits, from 5 to 8.
+   * @param stop_bits 停止位数，1 或 2 / Stop bits, 1 or 2.
+   * @param tx_queue_size 请求队列容量，必须大于零 / Positive TX request capacity.
+   * @param buffer_size 每个方向的字节队列容量，必须大于零 / Positive per-direction
+   * capacity.
+   * @param thread_stack_size I/O 线程栈大小，单位为字节 / I/O thread stack size in bytes.
+   * @note 等待匹配设备出现；多个匹配时按路径排序选择首项。CDC ACM 匹配控制接口名称。
+   *       Waits for a match; selects the first sorted path on ambiguity. CDC ACM
+   *       matching uses the control-interface name.
    */
   LinuxUART(const std::string& vid, const std::string& pid,
             const std::string& control_interface_name, const std::string& serial,
@@ -140,11 +196,13 @@ class LinuxUART : public UART
             size_t buffer_size = 512, size_t thread_stack_size = 65536)
       : UART(&_read_port, &_write_port),
         rx_buff_(new uint8_t[buffer_size]),
-        tx_buff_(new uint8_t[buffer_size]),
         buff_size_(buffer_size),
-        _read_port(buffer_size),
+        config_{baudrate, parity, data_bits, stop_bits},
+        _read_port(buffer_size, *this),
         _write_port(tx_queue_size, buffer_size)
   {
+    REQUIRE(tx_queue_size > 0);
+    REQUIRE(buff_size_ > 0);
     while (!FindUSBTTYByVidPid(vid, pid, control_interface_name, serial, device_path_))
     {
       XR_LOG_WARN(
@@ -166,37 +224,15 @@ class LinuxUART : public UART
 
     device_path_ = GetByPathForTTY(device_path_);
 
-    fd_ = open(device_path_.c_str(), O_RDWR | O_NOCTTY);
-    if (fd_ < 0)
-    {
-      XR_LOG_ERROR("Cannot open UART device: %s", device_path_.c_str());
-      ASSERT(false);
-    }
-    else
-    {
-      XR_LOG_PASS("Open UART device: %s", device_path_.c_str());
-    }
-
-    config_ = {};
-    config_.baudrate = baudrate;
-    config_.parity = parity;
-    config_.data_bits = data_bits;
-    config_.stop_bits = stop_bits;
-
-    SetConfig(config_);
-
-    _read_port = ReadFun;
-    _write_port = WriteFun;
-
-    rx_thread_.Create<LinuxUART*>(
-        this, [](LinuxUART* self) { self->RxLoop(); }, "rx_uart", thread_stack_size,
-        Thread::Priority::REALTIME);
-
-    tx_thread_.Create<LinuxUART*>(
-        this, [](LinuxUART* self) { self->TxLoop(); }, "tx_uart", thread_stack_size,
-        Thread::Priority::REALTIME);
+    StartIoOwner(thread_stack_size);
   }
 
+  /**
+   * @brief 查找设备的稳定路径 / Find a stable path for a TTY.
+   * @param tty_name 原始设备路径 / Original device path.
+   * @return 匹配的 by-path 链接，未找到时返回原路径 / Matching by-path link, or original
+   * path.
+   */
   std::string GetByPathForTTY(const std::string& tty_name)
   {
     const std::string BASE = "/dev/serial/by-path";
@@ -215,18 +251,26 @@ class LinuxUART : public UART
       }
       if (full == tty_name)
       {
-        return entry.path().string();  // 返回符号链接路径
+        return entry.path().string();  // 返回稳定链接 / Return the stable link.
       }
     }
-    return tty_name;  // 未命中 by-path 时保留原始 tty 路径
+    return tty_name;  // 保留原路径 / Keep the original path.
   }
 
+  /**
+   * @brief 查找匹配的 USB 串口设备 / Find a matching USB TTY device.
+   * @return 找到匹配路径时返回 true / True when a matching path is found.
+   */
   static bool FindUSBTTYByVidPid(const std::string& target_vid,
                                  const std::string& target_pid, std::string& tty_path)
   {
     return FindUSBTTYByVidPid(target_vid, target_pid, "", "", tty_path);
   }
 
+  /**
+   * @brief 查找匹配的 USB 串口设备 / Find a matching USB TTY device.
+   * @return 找到匹配路径时返回 true / True when a matching path is found.
+   */
   static bool FindUSBTTYByVidPid(const std::string& target_vid,
                                  const std::string& target_pid,
                                  const std::string& target_control_interface_name,
@@ -236,6 +280,10 @@ class LinuxUART : public UART
                               tty_path);
   }
 
+  /**
+   * @brief 查找匹配的 USB 串口设备 / Find a matching USB TTY device.
+   * @return 找到匹配路径时返回 true / True when a matching path is found.
+   */
   static bool FindUSBTTYByVidPid(const std::string& target_vid,
                                  const std::string& target_pid,
                                  const std::string& target_control_interface_name,
@@ -278,8 +326,8 @@ class LinuxUART : public UART
         const char* control_interface_name = nullptr;
         if (usb_interface)
         {
-          // For Linux cdc_acm tty nodes this parent is the CDC control interface
-          // (for example if00 / if02), not the CDC data interface.
+          // Linux cdc_acm 的 tty 父节点对应 CDC 控制接口。
+          // The parent of a Linux cdc_acm TTY is the CDC control interface.
           control_interface_name =
               udev_device_get_sysattr_value(usb_interface, "interface");
         }
@@ -327,41 +375,97 @@ class LinuxUART : public UART
     return true;
   }
 
+  /**
+   * @brief 尝试启用设备低延迟选项 / Try to enable the device low-latency option.
+   * @param fd 已打开的设备描述符 / Open device descriptor.
+   * @note 仅在线程处理配置时调用，不支持该选项的设备直接跳过。
+   *       Called during owner-side configuration; skips unsupported devices.
+   */
   void SetLowLatency(int fd)
   {
-    struct serial_struct serinfo;
-    ioctl(fd, TIOCGSERIAL, &serinfo);
+    struct serial_struct serinfo{};
+    if (ioctl(fd, TIOCGSERIAL, &serinfo) != 0)
+    {
+      return;
+    }
     serinfo.flags |= ASYNC_LOW_LATENCY;
     ioctl(fd, TIOCSSERIAL, &serinfo);
   }
 
+  /**
+   * @brief 提交串口配置请求 / Submit a UART configuration request.
+   * @param config 目标配置 / Requested configuration.
+   * @return 接纳返回 OK，已有待处理配置返回 BUSY，参数无效返回 ARG_ERR。
+   *         OK on admission, BUSY for an occupied slot, ARG_ERR for invalid parameters.
+   * @note OK 不表示已经生效。线程等待当前部分写入结束及内核输出队列排空后应用。
+   *       断线时保留请求，重连时使用新配置；应用失败继续保留请求。
+   *       OK does not mean applied. The thread finishes the partial front and drains
+   *       kernel output before applying. Pending configuration survives disconnect or
+   *       application failure and is used on reopen.
+   */
   ErrorCode SetConfig(UART::Configuration config) override
   {
-    if (&config != &config_)
+    if (ValidateConfig(config) != ErrorCode::OK)
     {
-      config_ = config;
+      return ErrorCode::ARG_ERR;
     }
 
+    uint8_t expected = static_cast<uint8_t>(ConfigState::EMPTY);
+    if (!config_state_.compare_exchange_strong(
+            expected, static_cast<uint8_t>(ConfigState::RESERVED),
+            std::memory_order_acq_rel, std::memory_order_acquire))
+    {
+      return ErrorCode::BUSY;
+    }
+
+    requested_config_ = config;
+    config_state_.store(static_cast<uint8_t>(ConfigState::PUBLISHED),
+                        std::memory_order_release);
+    NotifyIoOwner();
+    return ErrorCode::OK;
+  }
+
+ private:
+  /// 检查支持的配置范围 / Validate the supported configuration range.
+  static ErrorCode ValidateConfig(const UART::Configuration& config)
+  {
+    if (config.baudrate == 0U || (config.stop_bits != 1U && config.stop_bits != 2U) ||
+        config.data_bits < 5U || config.data_bits > 8U)
+    {
+      return ErrorCode::ARG_ERR;
+    }
+
+    switch (config.parity)
+    {
+      case UART::Parity::NO_PARITY:
+      case UART::Parity::EVEN:
+      case UART::Parity::ODD:
+        return ErrorCode::OK;
+      default:
+        return ErrorCode::ARG_ERR;
+    }
+  }
+
+  /// 在线程中设置参数，仅打开设备时清空内核缓冲 / Apply settings; flush only on open.
+  ErrorCode ApplyConfig(int fd, const UART::Configuration& config, bool flush)
+  {
     struct termios2 tio{};
-    if (ioctl(fd_, TCGETS2, &tio) != 0)
+    if (ioctl(fd, TCGETS2, &tio) != 0)
     {
       return ErrorCode::INIT_ERR;
     }
 
-    // 设置自定义波特率
     tio.c_cflag &= ~CBAUD;
     tio.c_cflag |= BOTHER;
     tio.c_ispeed = config.baudrate;
     tio.c_ospeed = config.baudrate;
 
-    // 输入模式：关闭软件流控、特殊字符处理
     tio.c_iflag &= ~(IXON | IXOFF | IXANY | ISTRIP | IGNCR | INLCR | ICRNL
 #ifdef IUCLC
                      | IUCLC
 #endif
     );
 
-    // 输出模式：关闭所有加工
     tio.c_oflag &= ~(OPOST
 #ifdef ONLCR
                      | ONLCR
@@ -377,10 +481,8 @@ class LinuxUART : public UART
 #endif
     );
 
-    // 本地模式：禁用行缓冲、回显、信号中断
     tio.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);
 
-    // 控制模式：设置数据位、校验、停止位、流控
     tio.c_cflag &= ~CSIZE;
     switch (config.data_bits)
     {
@@ -400,152 +502,503 @@ class LinuxUART : public UART
         return ErrorCode::ARG_ERR;
     }
 
-    // 停止位
     tio.c_cflag &= ~CSTOPB;
-    if (config.stop_bits == 2)
+    if (config.stop_bits == 2U)
     {
       tio.c_cflag |= CSTOPB;
     }
 
-    // 奇偶校验
+    tio.c_cflag &= ~(PARENB | PARODD);
     switch (config.parity)
     {
       case UART::Parity::NO_PARITY:
-        tio.c_cflag &= ~PARENB;
         break;
       case UART::Parity::EVEN:
         tio.c_cflag |= PARENB;
-        tio.c_cflag &= ~PARODD;
         break;
       case UART::Parity::ODD:
-        tio.c_cflag |= PARENB;
-        tio.c_cflag |= PARODD;
+        tio.c_cflag |= PARENB | PARODD;
         break;
     }
 
-    // 禁用硬件流控
     tio.c_cflag &= ~CRTSCTS;
-
-    // 启用本地模式、读功能
     tio.c_cflag |= (CLOCAL | CREAD);
-
-    // 控制字符配置：阻塞直到读到 1 字节
-    // for (int i = 0; i < NCCS; ++i) tio.c_cc[i] = 0;
     tio.c_cc[VTIME] = 0;
     tio.c_cc[VMIN] = 1;
 
-    if (ioctl(fd_, TCSETS2, &tio) != 0)
+    if (ioctl(fd, TCSETS2, &tio) != 0)
     {
       return ErrorCode::INIT_ERR;
     }
 
-    SetLowLatency(fd_);
-
-    tcflush(fd_, TCIOFLUSH);
-
+    SetLowLatency(fd);
+    if (flush && tcflush(fd, TCIOFLUSH) != 0)
+    {
+      return ErrorCode::INIT_ERR;
+    }
     return ErrorCode::OK;
   }
 
-  static ErrorCode ReadFun(ReadPort&, bool) { return ErrorCode::PENDING; }
-
-  static ErrorCode WriteFun(WritePort& port, bool)
+  /// 唤醒串口线程处理已提交写入 / Wake the I/O thread for submitted writes.
+  static void WriteFun(WritePort& port, bool)
   {
     auto* uart = LibXR::ContainerOf(&port, &LinuxUART::_write_port);
-    uart->write_sem_.Post();
-    return ErrorCode::PENDING;
+    uart->NotifyIoOwner();
   }
 
- private:
-  void RxLoop()
-  {
-    while (true)
-    {
-      if (!connected_)
-      {
-        close(fd_);
-        fd_ = open(device_path_.c_str(), O_RDWR | O_NOCTTY);
+  static constexpr int RECONNECT_DELAY_MS = 1000;
+  static constexpr int CONFIG_DRAIN_POLL_MS = 10;
 
-        if (fd_ < 0)
-        {
-          XR_LOG_WARN("Cannot open UART device: %s", device_path_.c_str());
-          Thread::Sleep(1000);
-        }
-        else
-        {
-          SetConfig(config_);
-          XR_LOG_PASS("Reopen UART device: %s", device_path_.c_str());
-          connected_ = true;
-        }
-      }
-      auto n = read(fd_, rx_buff_, buff_size_);
-      if (n > 0)
+  /// 创建唤醒描述符并等线程完成首次打开尝试 / Start the thread and await its first open
+  /// attempt.
+  void StartIoOwner(size_t thread_stack_size)
+  {
+    REQUIRE(ValidateConfig(config_) == ErrorCode::OK);
+
+    wake_fd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    REQUIRE(wake_fd_ >= 0);
+
+    _write_port = WriteFun;
+    io_thread_.Create<LinuxUART*>(
+        this, [](LinuxUART* self) { self->IoLoop(); }, "io_uart", thread_stack_size,
+        Thread::Priority::REALTIME);
+
+    ErrorCode wait_result = ErrorCode::TIMEOUT;
+    do
+    {
+      wait_result = startup_sem_.Wait();
+    } while (wait_result == ErrorCode::TIMEOUT);
+    REQUIRE(wait_result == ErrorCode::OK);
+  }
+
+  /// 发布唤醒通知，已有未处理通知时允许合并 / Signal progress, coalescing pending wakes.
+  void NotifyIoOwner()
+  {
+    REQUIRE(wake_fd_ >= 0);
+    const uint64_t value = 1U;
+    for (;;)
+    {
+      const ssize_t written = write(wake_fd_, &value, sizeof(value));
+      if (written == static_cast<ssize_t>(sizeof(value)))
       {
-        read_port_->queue_data_->PushBatch(rx_buff_, n);
-        read_port_->ProcessPendingReads(false);
+        return;
+      }
+      if (written < 0 && errno == EINTR)
+      {
+        continue;
+      }
+      if (written < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+      {
+        return;
+      }
+      REQUIRE(false);
+    }
+  }
+
+  /// 取走当前唤醒通知，随后重新检查工作状态 / Drain wakes before rechecking work.
+  void DrainWakeFd()
+  {
+    uint64_t value = 0U;
+    for (;;)
+    {
+      const ssize_t bytes = read(wake_fd_, &value, sizeof(value));
+      if (bytes == static_cast<ssize_t>(sizeof(value)))
+      {
+        continue;
+      }
+      if (bytes < 0 && errno == EINTR)
+      {
+        continue;
+      }
+      if (bytes < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+      {
+        return;
+      }
+      REQUIRE(false);
+    }
+  }
+
+  /// 非阻塞打开并配置设备，失败交给重连处理 / Open nonblocking; retry failures on
+  /// reconnect.
+  int OpenDevice(const Configuration& config, bool reconnect, ErrorCode& result)
+  {
+    const int fd = open(device_path_.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
+    if (fd < 0)
+    {
+      result = ErrorCode::INIT_ERR;
+      XR_LOG_WARN("Cannot open UART device: %s", device_path_.c_str());
+      return -1;
+    }
+
+    result = ApplyConfig(fd, config, true);
+    if (result != ErrorCode::OK)
+    {
+      XR_LOG_WARN("Cannot configure UART device: %s", device_path_.c_str());
+      (void)close(fd);
+      return -1;
+    }
+
+    XR_LOG_PASS("%s UART device: %s", reconnect ? "Reopen" : "Open",
+                device_path_.c_str());
+    return fd;
+  }
+
+  /// 关闭设备，按当前请求是否可继续发送决定失败通知 / Close and optionally fail the
+  /// front.
+  void Disconnect(int& fd, bool fail_front)
+  {
+    if (fd >= 0)
+    {
+      (void)close(fd);
+      fd = -1;
+    }
+
+    if (fail_front)
+    {
+      auto queue = _write_port.GetWriteQueue(false);
+      if (!queue.Empty())
+      {
+        queue.FailFront(ErrorCode::FAILED);
+      }
+      tx_front_unreplayable_ = false;
+    }
+  }
+
+  /// 按顺序发送最多两段数据，返回内核接收长度 / Write up to two spans and return accepted
+  /// bytes.
+  size_t WriteSpans(int fd, const uint8_t* first, size_t first_size,
+                    const uint8_t* second, size_t second_size, bool& fatal_error)
+  {
+    std::array<iovec, 2> spans{};
+    spans[0] = iovec{const_cast<uint8_t*>(first), first_size};
+    spans[1] = iovec{const_cast<uint8_t*>(second), second_size};
+    const int span_count = second_size == 0U ? 1 : 2;
+
+    for (;;)
+    {
+      const ssize_t written = writev(fd, spans.data(), span_count);
+      if (written > 0)
+      {
+        const size_t accepted = static_cast<size_t>(written);
+        REQUIRE(accepted <= first_size + second_size);
+        return accepted;
+      }
+      if (written == 0)
+      {
+        return 0U;
+      }
+      if (errno == EINTR)
+      {
+        continue;
+      }
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+      {
+        return 0U;
+      }
+
+      fatal_error = true;
+      return 0U;
+    }
+  }
+
+  /// 只检查已发布请求，不把 Stream 未提交数据计入 / Check released requests only.
+  bool HasPendingTx()
+  {
+    auto queue = _write_port.GetWriteQueue(false);
+    return !queue.Empty();
+  }
+
+  /// 推进当前队头，保留短写和暂时无法发送的数据 / Progress the front; retain short-write
+  /// suffixes.
+  bool PumpTx(int& fd)
+  {
+    bool fatal_error = false;
+    size_t offered = 0U;
+    size_t accepted = 0U;
+    {
+      auto queue = _write_port.GetWriteQueue(false);
+      offered = queue.AvailableSize();
+      if (offered != 0U)
+      {
+        accepted = queue.PopWithWriter(
+            offered,
+            [this, fd, &fatal_error](const uint8_t* first, size_t first_size,
+                                     const uint8_t* second, size_t second_size) -> size_t
+            {
+              return WriteSpans(fd, first, first_size, second, second_size, fatal_error);
+            });
+      }
+    }
+
+    if (offered == 0U)
+    {
+      return false;
+    }
+
+    if (fatal_error)
+    {
+      XR_LOG_WARN("Cannot write UART device: %s", device_path_.c_str());
+      Disconnect(fd, true);
+      return false;
+    }
+
+    if (accepted == 0U)
+    {
+      // 暂时无法发送时，保留此前部分发送的记录。
+      // Preserve prior partial progress while waiting for writability.
+      return true;
+    }
+    tx_front_unreplayable_ = accepted < offered;
+    return accepted < offered || HasPendingTx();
+  }
+
+  /// 按接收队列空闲空间读取并发布数据 / Read within RX free space and publish bytes.
+  bool DrainRx(int& fd, bool terminal = false)
+  {
+    size_t budget = terminal ? static_cast<size_t>(-1) : buff_size_;
+    while (budget > 0U)
+    {
+      const size_t empty_size = _read_port.EmptySize();
+      if (empty_size == 0U)
+      {
+        return true;
+      }
+
+      const size_t read_size = std::min(budget, empty_size);
+      auto queue = _read_port.GetReadQueue(false);
+      const ssize_t bytes = read(fd, rx_buff_, read_size);
+      if (bytes > 0)
+      {
+        REQUIRE(queue.PushBatch(rx_buff_, static_cast<size_t>(bytes)) == ErrorCode::OK);
+        queue.Publish();
+        budget -= static_cast<size_t>(bytes);
+        continue;
+      }
+
+      queue.Publish();
+      if (bytes < 0 && errno == EINTR)
+      {
+        continue;
+      }
+      if (bytes < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+      {
+        return true;
+      }
+      if (bytes == 0)
+      {
+        XR_LOG_WARN("UART device closed: %s", device_path_.c_str());
       }
       else
       {
         XR_LOG_WARN("Cannot read UART device: %s", device_path_.c_str());
-        connected_ = false;
       }
+      Disconnect(fd, tx_front_unreplayable_);
+      return false;
+    }
+    return true;
+  }
+
+  /// 检查调用者是否已完整发布配置 / Check for a fully published configuration.
+  bool ConfigRequested() const
+  {
+    return config_state_.load(std::memory_order_acquire) ==
+           static_cast<uint8_t>(ConfigState::PUBLISHED);
+  }
+
+  /// 等当前部分写入和内核输出完成后应用配置 / Apply configuration at the TX drain
+  /// boundary.
+  void ServiceConfig(int& fd, Configuration& current_config)
+  {
+    if (!ConfigRequested() || tx_front_unreplayable_)
+    {
+      return;
+    }
+
+    int queued_bytes = 0;
+    if (ioctl(fd, TIOCOUTQ, &queued_bytes) != 0)
+    {
+      XR_LOG_WARN("Cannot inspect UART output queue: %s", device_path_.c_str());
+      Disconnect(fd, false);
+      return;
+    }
+    if (queued_bytes > 0)
+    {
+      return;
+    }
+
+    const Configuration requested = requested_config_;
+    const ErrorCode result = ApplyConfig(fd, requested, false);
+    if (result != ErrorCode::OK)
+    {
+      XR_LOG_WARN("Cannot apply UART configuration: %s", device_path_.c_str());
+      Disconnect(fd, false);
+      return;
+    }
+
+    current_config = requested;
+    config_state_.store(static_cast<uint8_t>(ConfigState::EMPTY),
+                        std::memory_order_release);
+  }
+
+  /// 等待重连时限或新的工作通知 / Wait for the reconnect interval or new work.
+  void WaitForReconnectWake()
+  {
+    pollfd wake_poll{};
+    wake_poll.fd = wake_fd_;
+    wake_poll.events = POLLIN;
+
+    int result = 0;
+    do
+    {
+      result = poll(&wake_poll, 1U, RECONNECT_DELAY_MS);
+    } while (result < 0 && errno == EINTR);
+
+    REQUIRE(result >= 0);
+    if (result > 0)
+    {
+      DrainWakeFd();
     }
   }
 
-  void TxLoop()
+  /// 串行处理设备访问、配置及重连 / Serialize device I/O, configuration, and reconnect.
+  void IoLoop()
   {
-    WriteInfoBlock info;
+    Configuration current_config = config_;
+    ErrorCode open_result = ErrorCode::INIT_ERR;
+    int fd = OpenDevice(current_config, false, open_result);
+
+    startup_sem_.Post();
+
     while (true)
     {
-      if (!connected_)
+      if (fd < 0)
       {
-        Thread::Sleep(1);
-        continue;
-      }
-
-      if (write_sem_.Wait() != ErrorCode::OK)
-      {
-        continue;
-      }
-
-      if (write_port_->queue_info_->Pop(info) == ErrorCode::OK)
-      {
-        if (write_port_->queue_data_->PopBatch(tx_buff_, info.data.size_) ==
-            ErrorCode::OK)
+        const bool config_pending = ConfigRequested();
+        const Configuration target_config =
+            config_pending ? requested_config_ : current_config;
+        fd = OpenDevice(target_config, true, open_result);
+        if (fd >= 0)
         {
-          auto written = write(fd_, tx_buff_, info.data.size_);
-          if (written < 0)
+          current_config = target_config;
+          if (config_pending)
           {
-            XR_LOG_WARN("Cannot write UART device: %s", device_path_.c_str());
-            connected_ = false;
+            config_state_.store(static_cast<uint8_t>(ConfigState::EMPTY),
+                                std::memory_order_release);
           }
-          write_port_->Finish(false,
-                              (written == static_cast<int>(info.data.size_))
-                                  ? ErrorCode::OK
-                                  : ErrorCode::FAILED,
-                              info);
+          continue;
         }
-        else
-        {
-          info.op.UpdateStatus(false, ErrorCode::FAILED);
-        }
+
+        WaitForReconnectWake();
+        continue;
+      }
+
+      ServiceConfig(fd, current_config);
+      if (fd < 0)
+      {
+        continue;
+      }
+
+      const bool tx_waiting =
+          (!ConfigRequested() || tx_front_unreplayable_) && PumpTx(fd);
+      if (fd < 0)
+      {
+        continue;
+      }
+      ServiceConfig(fd, current_config);
+      if (fd < 0)
+      {
+        continue;
+      }
+
+      std::array<pollfd, 2> poll_fds{};
+      poll_fds[0].fd = fd;
+      if (_read_port.EmptySize() != 0U)
+      {
+        poll_fds[0].events |= POLLIN;
+      }
+      if (tx_waiting)
+      {
+        poll_fds[0].events |= POLLOUT;
+      }
+      // 无收发需求时只等唤醒，避免满接收队列遇到 HUP 后空转。
+      // With no I/O demand, wait only for wakes; a full RX queue must not spin on HUP.
+      if (poll_fds[0].events == 0)
+      {
+        poll_fds[0].fd = -1;
+      }
+
+      poll_fds[1].fd = wake_fd_;
+      poll_fds[1].events = POLLIN;
+      const int timeout = ConfigRequested() && !tx_waiting ? CONFIG_DRAIN_POLL_MS : -1;
+
+      int poll_result = 0;
+      do
+      {
+        poll_result = poll(poll_fds.data(), poll_fds.size(), timeout);
+      } while (poll_result < 0 && errno == EINTR);
+
+      if (poll_result < 0)
+      {
+        XR_LOG_WARN("Cannot poll UART device: %s", device_path_.c_str());
+        Disconnect(fd, tx_front_unreplayable_);
+        continue;
+      }
+      if (poll_result == 0)
+      {
+        continue;
+      }
+
+      if ((poll_fds[1].revents & POLLIN) != 0)
+      {
+        DrainWakeFd();
+      }
+
+      const bool hung_up = (poll_fds[0].revents & POLLHUP) != 0;
+      if (((poll_fds[0].revents & POLLIN) != 0 || hung_up) && !DrainRx(fd, hung_up))
+      {
+        continue;
+      }
+      if (fd < 0)
+      {
+        continue;
+      }
+      if ((poll_fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) != 0)
+      {
+        XR_LOG_WARN("UART device disconnected: %s", device_path_.c_str());
+        Disconnect(fd, tx_front_unreplayable_);
+        continue;
       }
     }
   }
 
-  int fd_ = -1;
-  bool connected_ = true;
-  Configuration config_;
+  /// 设备稳定路径 / Stable device path.
   std::string device_path_;
-  Thread rx_thread_;
-  Thread tx_thread_;
+  /// 唯一设备访问线程 / Sole device I/O thread.
+  Thread io_thread_;
+  /// 接收临时缓冲 / RX staging buffer.
   uint8_t* rx_buff_ = nullptr;
-  uint8_t* tx_buff_ = nullptr;
+  /// 接收缓冲容量 / RX buffer capacity.
   size_t buff_size_ = 0;
-  Semaphore write_sem_;
-  Mutex read_mutex_;
+  /// 构造时的初始配置 / Initial construction configuration.
+  Configuration config_{};
+  /// 发布后由线程读取的配置 / Configuration published to the I/O thread.
+  Configuration requested_config_{};
+  /// 共用的 eventfd 唤醒描述符 / Shared eventfd wake descriptor.
+  int wake_fd_ = -1;
+  /// 首次打开尝试结束通知 / Initial open-attempt completion.
+  Semaphore startup_sem_;
+  /// 配置槽的发布状态 / Configuration slot publication state.
+  std::atomic<uint8_t> config_state_{static_cast<uint8_t>(ConfigState::EMPTY)};
+  /// 当前队头已有外部发送进展，仅 I/O 线程访问 / Owner-only partial TX progress.
+  bool tx_front_unreplayable_ = false;
 
-  ReadPort _read_port;    // NOLINT
-  WritePort _write_port;  // NOLINT
+  Detail::LinuxUARTReadPort _read_port;  // NOLINT
+  WritePort _write_port;                 // NOLINT
 };
+
+inline void Detail::LinuxUARTReadPort::OnReadQueueSpaceAvailable(bool)
+{
+  owner_.NotifyIoOwner();
+}
 
 }  // namespace LibXR

--- a/test/framework/test_main_sets.hpp
+++ b/test/framework/test_main_sets.hpp
@@ -20,6 +20,14 @@ void test_linux_stdio_print();
 void test_linux_database_raw();
 void test_linux_database_sequential();
 void test_linux_shm_topic();
+void test_linux_uart_rx_backpressure();
+void test_linux_uart_tx_backpressure();
+void test_linux_uart_block_timeout();
+void test_linux_uart_callback_write();
+void test_linux_uart_stream_config();
+void test_linux_uart_reconnect();
+void test_linux_uart_partial_disconnect();
+void test_linux_uart_initial_open_recovery();
 
 inline int RunLinuxStdioAndDatabaseSet()
 {
@@ -59,6 +67,24 @@ struct GroupedTestCase
 };
 
 inline constexpr GroupedTestCase kMainTestCases[] = {
+    {"linux_uart_tests",
+     {"uart_rx_space", &RunVoidEntry<test_linux_uart_rx_backpressure>, true}},
+    {"linux_uart_tests",
+     {"uart_tx_partial", &RunVoidEntry<test_linux_uart_tx_backpressure>, true}},
+    {"linux_uart_tests",
+     {"uart_block_timeout", &RunVoidEntry<test_linux_uart_block_timeout>, true}},
+    {"linux_uart_tests",
+     {"uart_callback_write", &RunVoidEntry<test_linux_uart_callback_write>, true}},
+    {"linux_uart_tests",
+     {"uart_stream_config", &RunVoidEntry<test_linux_uart_stream_config>, true}},
+    {"linux_uart_tests",
+     {"uart_reconnect", &RunVoidEntry<test_linux_uart_reconnect>, true}},
+    {"linux_uart_tests",
+     {"uart_partial_disconnect", &RunVoidEntry<test_linux_uart_partial_disconnect>,
+      true}},
+    {"linux_uart_tests",
+     {"uart_initial_recovery", &RunVoidEntry<test_linux_uart_initial_open_recovery>,
+      true}},
     {"core_tests", {"assert", &RunVoidEntry<test_assert>, false}},
     {"core_tests", {"def", &RunVoidEntry<test_def>, false}},
     {"core_tests", {"callback", &RunVoidEntry<test_cb>, false}},

--- a/test/runtime/driver/test_linux_uart.cpp
+++ b/test/runtime/driver/test_linux_uart.cpp
@@ -1,0 +1,426 @@
+/**
+ * @file
+ * @brief Linux UART 伪终端回归测试 / Linux UART pseudo-terminal regression tests.
+ */
+#include <poll.h>
+#include <unistd.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "linux_uart.hpp"
+#include "test.hpp"
+
+namespace
+{
+using namespace LibXR;
+using Clock = std::chrono::steady_clock;
+using PollingStatus = WriteOperation::OperationPollingStatus;
+constexpr auto WAIT_LIMIT = std::chrono::seconds(5);
+
+template <typename Predicate>
+void WaitUntil(Predicate predicate)
+{
+  const auto deadline = Clock::now() + WAIT_LIMIT;
+  while (!predicate())
+  {
+    ASSERT(Clock::now() < deadline);
+    Thread::Sleep(1);
+  }
+}
+
+struct Pty
+{
+  Pty()
+  {
+    master = posix_openpt(O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
+    ASSERT(master >= 0);
+    ASSERT(grantpt(master) == 0);
+    ASSERT(unlockpt(master) == 0);
+    char* name = ptsname(master);
+    ASSERT(name != nullptr);
+    path = name;
+    observer = open(path.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
+    ASSERT(observer >= 0);
+  }
+
+  uint32_t Baudrate() const
+  {
+    termios2 config{};
+    ASSERT(ioctl(observer, TCGETS2, &config) == 0);
+    return config.c_ospeed;
+  }
+
+  void Send(const std::vector<uint8_t>& data)
+  {
+    size_t offset = 0;
+    const auto deadline = Clock::now() + WAIT_LIMIT;
+    while (offset < data.size())
+    {
+      const ssize_t count = write(master, data.data() + offset, data.size() - offset);
+      if (count > 0)
+      {
+        offset += static_cast<size_t>(count);
+        continue;
+      }
+      ASSERT(count < 0 && (errno == EINTR || errno == EAGAIN));
+      ASSERT(Clock::now() < deadline);
+      Thread::Sleep(1);
+    }
+  }
+
+  std::vector<uint8_t> Receive(size_t size)
+  {
+    std::vector<uint8_t> data(size);
+    size_t offset = 0;
+    const auto deadline = Clock::now() + WAIT_LIMIT;
+    while (offset < size)
+    {
+      const ssize_t count = read(master, data.data() + offset, size - offset);
+      if (count > 0)
+      {
+        offset += static_cast<size_t>(count);
+        continue;
+      }
+      ASSERT(count < 0 && (errno == EINTR || errno == EAGAIN));
+      ASSERT(Clock::now() < deadline);
+      Thread::Sleep(1);
+    }
+    return data;
+  }
+
+  void ExpectNoOutput()
+  {
+    pollfd item{master, POLLIN, 0};
+    ASSERT(poll(&item, 1, 20) == 0);
+  }
+
+  int master = -1;
+  int observer = -1;
+  std::string path;
+};
+
+// 通知对象和驱动同寿命，等待与检查使用相同的 acquire 读取。
+// Completion targets live with the driver; waits and checks use acquire loads.
+struct Completion
+{
+  bool Is(PollingStatus expected) const
+  {
+    return status.load(std::memory_order_acquire) == expected;
+  }
+
+  void Wait(PollingStatus expected = PollingStatus::DONE)
+  {
+    WaitUntil([&] { return Is(expected); });
+  }
+
+  std::atomic<PollingStatus> status{PollingStatus::READY};
+  WriteOperation op{status};
+};
+
+// 临时路径可在两台伪终端之间切换，退出测试时移除链接和目录。
+// Switch a temporary path between PTYs; remove the link and directory on scope exit.
+struct DevicePath
+{
+  explicit DevicePath(const Pty* initial = nullptr)
+  {
+    ASSERT(mkdtemp(directory) != nullptr);
+    path = std::string(directory) + "/uart";
+    if (initial != nullptr)
+    {
+      Connect(*initial);
+    }
+    else
+    {
+      // 普通文件可打开，但无法配置为串口，用于验证首次打开恢复。
+      // A regular file opens but rejects TTY configuration, exercising initial recovery.
+      const int fd = open(path.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0600);
+      ASSERT(fd >= 0);
+      ASSERT(close(fd) == 0);
+    }
+  }
+
+  ~DevicePath()
+  {
+    Remove();
+    ASSERT(rmdir(directory) == 0);
+  }
+
+  void Remove() { ASSERT(unlink(path.c_str()) == 0); }
+  void Connect(const Pty& pty) { ASSERT(symlink(pty.path.c_str(), path.c_str()) == 0); }
+
+  void Disconnect(const Pty& pty)
+  {
+    Remove();
+    ASSERT(close(pty.observer) == 0);
+    ASSERT(close(pty.master) == 0);
+  }
+
+  char directory[sizeof("/tmp/libxr-uart-test-XXXXXX")] = "/tmp/libxr-uart-test-XXXXXX";
+  std::string path;
+};
+
+std::vector<uint8_t> Pattern(size_t size)
+{
+  std::vector<uint8_t> result(size);
+  for (size_t i = 0; i < size; ++i)
+  {
+    result[i] = static_cast<uint8_t>(i * 17U + i / 251U);
+  }
+  return result;
+}
+
+// 每项由现有 runner 在独立子进程运行；驱动与通知对象保持到进程退出。
+// The runner isolates each case; driver and notification objects live until process exit.
+struct Fixture
+{
+  explicit Fixture(size_t capacity = 64)
+  {
+    uart = new LinuxUART(pty.path.c_str(), 115200, UART::Parity::NO_PARITY, 8, 1, 8,
+                         capacity);
+    ASSERT(pty.Baudrate() == 115200);
+  }
+
+  Pty pty;
+  LinuxUART* uart = nullptr;
+  Completion completion;
+};
+}  // namespace
+
+/**
+ * @brief 验证接收队列满后释放空间可继续接收 / Verify RX resumes after space is freed.
+ */
+void test_linux_uart_rx_backpressure()
+{
+  auto* fixture = new Fixture;
+  const auto expected = Pattern(192);
+  fixture->pty.Send(expected);
+  WaitUntil([&] { return fixture->uart->read_port_->Size() == 64; });
+
+  std::vector<uint8_t> received;
+  for (size_t i = 0; i < 3; ++i)
+  {
+    std::array<uint8_t, 64> chunk{};
+    Semaphore sem;
+    ReadOperation op(sem, 1000);
+    ASSERT(fixture->uart->Read(RawData{chunk.data(), chunk.size()}, op) == ErrorCode::OK);
+    received.insert(received.end(), chunk.begin(), chunk.end());
+  }
+  ASSERT(received == expected);
+  ASSERT(fixture->uart->read_port_->Size() == 0);
+}
+
+/**
+ * @brief 验证短写后的后续发送与请求顺序 / Verify short-write continuation and FIFO order.
+ */
+void test_linux_uart_tx_backpressure()
+{
+  constexpr size_t PAYLOAD_SIZE = 256 * 1024;
+  auto* fixture = new Fixture(PAYLOAD_SIZE + 64);
+  auto expected = Pattern(PAYLOAD_SIZE);
+  ASSERT(fixture->uart->Write(ConstRawData{expected.data(), expected.size()},
+                              fixture->completion.op) == ErrorCode::OK);
+  WaitUntil(
+      [&]
+      {
+        const auto remaining = fixture->uart->write_port_->Size();
+        return remaining > 0 && remaining < PAYLOAD_SIZE;
+      });
+  ASSERT(fixture->completion.Is(PollingStatus::RUNNING));
+  const UART::Configuration config{57600, UART::Parity::NO_PARITY, 8, 1};
+  ASSERT(fixture->uart->SetConfig(config) == ErrorCode::OK);
+  ASSERT(fixture->pty.Baudrate() == 115200);
+
+  const std::vector<uint8_t> suffix{0, 0xFF, '\r', '\n', 0x11, 0x13};
+  auto* suffix_completion = new Completion;
+  ASSERT(fixture->uart->Write(ConstRawData{suffix.data(), suffix.size()},
+                              suffix_completion->op) == ErrorCode::OK);
+  expected.insert(expected.end(), suffix.begin(), suffix.end());
+  ASSERT(fixture->pty.Receive(expected.size()) == expected);
+  suffix_completion->Wait();
+  ASSERT(fixture->completion.Is(PollingStatus::DONE));
+  WaitUntil([&] { return fixture->pty.Baudrate() == config.baudrate; });
+}
+
+/**
+ * @brief 验证阻塞写超时保留数据且不再释放旧信号量
+ *        / Verify BLOCK timeout preserves data without a late semaphore post.
+ */
+void test_linux_uart_block_timeout()
+{
+  auto* fixture = new Fixture(256 * 1024);
+  const auto expected = Pattern(256 * 1024);
+  auto* sem = new Semaphore;
+  WriteOperation op(*sem, 30);
+  ASSERT(fixture->uart->Write(ConstRawData{expected.data(), expected.size()}, op) ==
+         ErrorCode::TIMEOUT);
+  ASSERT(fixture->uart->write_port_->Size() > 0);
+  ASSERT(fixture->pty.Receive(expected.size()) == expected);
+  WaitUntil([&] { return fixture->uart->write_port_->Size() == 0; });
+  ASSERT(sem->Value() == 0);
+}
+
+/**
+ * @brief 验证完成回调提交的写请求仍会推进 / Verify callback-generated writes progress.
+ */
+void test_linux_uart_callback_write()
+{
+  struct Context
+  {
+    Fixture fixture;
+    std::atomic<int> calls{0};
+    ErrorCode submit_result = ErrorCode::FAILED;
+    std::array<uint8_t, 3> second{4, 5, 6};
+  };
+  auto* ctx = new Context;
+  auto* callback = new WriteOperation::Callback(WriteOperation::Callback::Create(
+      [](bool in_isr, Context* self, ErrorCode result)
+      {
+        ASSERT(!in_isr && result == ErrorCode::OK);
+        self->submit_result = self->fixture.uart->Write(
+            ConstRawData{self->second.data(), self->second.size()},
+            self->fixture.completion.op);
+        self->calls.fetch_add(1, std::memory_order_release);
+      },
+      ctx));
+  WriteOperation op(*callback);
+  const std::array<uint8_t, 3> first{1, 2, 3};
+  ASSERT(ctx->fixture.uart->Write(ConstRawData{first.data(), first.size()}, op) ==
+         ErrorCode::OK);
+  ASSERT(ctx->fixture.pty.Receive(6) == std::vector<uint8_t>({1, 2, 3, 4, 5, 6}));
+  ctx->fixture.completion.Wait();
+  ASSERT(ctx->calls.load(std::memory_order_acquire) == 1);
+  ASSERT(ctx->submit_result == ErrorCode::OK);
+}
+
+/**
+ * @brief 验证未提交的 Stream 不阻挡配置且不会提前发送
+ *        / Verify an uncommitted Stream neither blocks configuration nor transmits.
+ */
+void test_linux_uart_stream_config()
+{
+  auto* fixture = new Fixture;
+  auto* stream =
+      new WritePort::Stream(fixture->uart->write_port_, fixture->completion.op);
+  const auto expected = Pattern(32);
+  ASSERT(stream->Write(ConstRawData{expected.data(), expected.size()}) == ErrorCode::OK);
+  fixture->pty.ExpectNoOutput();
+  UART::Configuration config{57600, UART::Parity::NO_PARITY, 8, 1};
+  ASSERT(fixture->uart->SetConfig(config) == ErrorCode::OK);
+  WaitUntil([&] { return fixture->pty.Baudrate() == config.baudrate; });
+  fixture->pty.ExpectNoOutput();
+  ASSERT(stream->Commit() == ErrorCode::OK);
+  ASSERT(fixture->pty.Receive(expected.size()) == expected);
+  fixture->completion.Wait();
+  config.baudrate = 0;
+  ASSERT(fixture->uart->SetConfig(config) == ErrorCode::ARG_ERR);
+}
+
+/**
+ * @brief 验证重连保留读写请求和待应用配置 / Verify requests and configuration survive
+ * reconnect.
+ */
+void test_linux_uart_reconnect()
+{
+  auto* old_pty = new Pty;
+  auto* next_pty = new Pty;
+  DevicePath device(old_pty);
+  auto* uart = new LinuxUART(device.path.c_str());
+  ASSERT(old_pty->Baudrate() == 115200);
+  device.Disconnect(*old_pty);
+
+  // 先确认旧 fd 已关闭，再提交尚未尝试发送的新请求。
+  // Observe old fd closure before admitting a request that has never been sent.
+  WaitUntil(
+      [&]
+      {
+        for (const auto& entry : std::filesystem::directory_iterator("/proc/self/fd"))
+        {
+          std::error_code ec;
+          const auto target = std::filesystem::read_symlink(entry.path(), ec).string();
+          if (!ec && (target == old_pty->path || target == old_pty->path + " (deleted)"))
+          {
+            return false;
+          }
+        }
+        return true;
+      });
+  auto* completion = new Completion;
+  const auto expected = Pattern(48);
+  ASSERT(uart->Write(ConstRawData{expected.data(), expected.size()}, completion->op) ==
+         ErrorCode::OK);
+  const UART::Configuration config{38400, UART::Parity::NO_PARITY, 8, 1};
+  ASSERT(uart->SetConfig(config) == ErrorCode::OK);
+  ASSERT(uart->SetConfig(config) == ErrorCode::BUSY);
+  auto* received = new std::array<uint8_t, 48>;
+  auto* read_completion = new Completion;
+  ASSERT(uart->Read(RawData{received->data(), received->size()}, read_completion->op) ==
+         ErrorCode::OK);
+
+  device.Connect(*next_pty);
+  ASSERT(next_pty->Receive(expected.size()) == expected);
+  ASSERT(next_pty->Baudrate() == config.baudrate);
+  next_pty->Send(expected);
+  read_completion->Wait();
+  ASSERT(std::memcmp(received->data(), expected.data(), expected.size()) == 0);
+  ASSERT(completion->Is(PollingStatus::DONE));
+}
+
+/**
+ * @brief 验证部分发送后断线只失败当前请求 / Verify disconnect fails only a partial front.
+ */
+void test_linux_uart_partial_disconnect()
+{
+  auto* old_pty = new Pty;
+  auto* next_pty = new Pty;
+  DevicePath device(old_pty);
+  constexpr size_t PAYLOAD_SIZE = 256 * 1024;
+  auto* uart = new LinuxUART(device.path.c_str(), 115200, UART::Parity::NO_PARITY, 8, 1,
+                             8, PAYLOAD_SIZE + 64);
+  const auto first = Pattern(PAYLOAD_SIZE);
+  auto* first_completion = new Completion;
+  ASSERT(uart->Write(ConstRawData{first.data(), first.size()}, first_completion->op) ==
+         ErrorCode::OK);
+  WaitUntil(
+      [&]
+      {
+        const auto remaining = uart->write_port_->Size();
+        return remaining > 0 && remaining < PAYLOAD_SIZE;
+      });
+  const auto second = Pattern(32);
+  auto* second_completion = new Completion;
+  ASSERT(uart->Write(ConstRawData{second.data(), second.size()}, second_completion->op) ==
+         ErrorCode::OK);
+
+  device.Disconnect(*old_pty);
+  first_completion->Wait(PollingStatus::ERROR);
+  ASSERT(second_completion->Is(PollingStatus::RUNNING));
+  device.Connect(*next_pty);
+  ASSERT(next_pty->Receive(second.size()) == second);
+  second_completion->Wait();
+  next_pty->ExpectNoOutput();
+}
+
+/**
+ * @brief 验证首次打开失败后仍可恢复 / Verify recovery from an initial open failure.
+ */
+void test_linux_uart_initial_open_recovery()
+{
+  auto* pty = new Pty;
+  DevicePath device;
+  auto* uart = new LinuxUART(device.path.c_str());
+  auto* completion = new Completion;
+  const auto expected = Pattern(32);
+  ASSERT(uart->Write(ConstRawData{expected.data(), expected.size()}, completion->op) ==
+         ErrorCode::OK);
+  device.Remove();
+  device.Connect(*pty);
+  ASSERT(pty->Receive(expected.size()) == expected);
+  completion->Wait();
+}


### PR DESCRIPTION
Linux UART still uses the removed RW metadata interfaces and shares its descriptor between RX, TX, and configuration calls. This change migrates it to the frontend now on `dev`, with one nonblocking I/O thread handling device access, configuration, and reconnect.

- Consume only released WriteQueue requests; preserve short-write and temporary-error suffixes. Fail an unreplayable front once on disconnect and retain later requests.
- Bound RX reads by free queue space and resume through the shared eventfd when readers release space.
- Admit one pending configuration, then apply it after the active partial write and kernel output drain. An uncommitted Stream does not block configuration or cause writable polling without a released request.
- Recover from initial open/configuration failure. Skip unsupported low-latency tuning without reading uninitialized ioctl output.

The PR contains **three files in one commit**: the Linux UART header, eight PTY regression cases, and registration in the existing test runner. It retains the current `UART::SetConfig(Configuration)` signature. `SetConfig` returns OK for admission, not immediate application. No common RW, MCU, USB, CMake, or CI changes are included.

Validation on Ubuntu24, GNU 13.3.0, Debug:

- Eight PTY cases pass: RX backpressure, TX partial/FIFO plus configuration drain, BLOCK timeout, callback-generated write, uncommitted Stream/configuration, reconnect with retained requests/configuration, partial-front disconnect, and initial-open recovery.
- The full Linux test runner passes on clean `dev` and the final candidate.
- A task-local syscall probe verifies zero/EINTR/EAGAIN retry behavior. Restoring only the old zero-return failure classification makes that probe fail as expected.
- clang-format 21.1.8 and `git diff --check` pass. The three tested file hashes match the submitted files.

One exploratory full run failed the existing shared-memory broadcast benchmark; the clean control and subsequent full candidate runs passed without benchmark changes. PTYs do not validate physical framing, baud timing, USB discovery, or bridge/wire drain.

Draft pending manual source review; merge target is `dev`.

## Sourcery 摘要

将 Linux UART 操作迁移为串行化的非阻塞 I/O，并支持稳健的背压、延迟配置和重新连接处理。

新功能：
- 将 Linux UART 设备访问迁移到单个非阻塞 I/O 线程，由该线程协调读取、写入、配置和重新连接。
- 支持延迟 UART 配置：在待发送数据处理完毕且内核输出排空后进行验证和应用。
- 在初始打开/配置失败及设备断开后恢复 UART 操作，同时保留可重放的请求。

错误修复：
- 通过将读取量限制为可用空间，并在消费者释放容量时唤醒接收操作，避免 RX 队列溢出。
- 在临时错误和重新连接期间保留短写入的剩余部分及后续排队请求，仅对无法重放的部分请求报告失败。
- 当设备不支持低延迟调优时，避免使用未初始化的 ioctl 数据应用该调优。

增强功能：
- 确保只有已释放的写入请求会驱动传输和可写轮询，从而避免未提交的流阻塞配置或产生输出。

测试：
- 添加八个 Linux PTY 回归测试用例，覆盖 RX 背压、TX 部分写入和配置排空、超时行为、回调写入、未提交流、重新连接、部分断开以及初始打开恢复。
- 将 Linux UART 回归测试套件注册到现有测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将 Linux UART 驱动迁移到经过序列化的非阻塞 I/O 模型，并提供可靠的配置、背压、写入保留和重连行为。

错误修复：
- 将 Linux UART 设备访问迁移到可恢复的单线程 I/O 模型，以一致地处理 RX、TX、配置和重连。
- 在短写入和重连期间保留排队的写入，仅在部分断开连接后对无法重放的请求执行失败处理。
- 根据可用队列容量限制 UART 接收，并在消费者释放空间后恢复读取。
- 支持在活动传输和内核输出排空后延迟应用配置，包括从初始打开或配置失败中恢复。
- 安全地跳过不受支持的低延迟串行调优，避免使用未初始化的 ioctl 数据。

增强功能：
- 添加基于 eventfd 的协调机制，用于已释放写入、配置请求和 RX 背压通知。
- 添加八个 PTY 回归测试用例，涵盖背压、部分写入、配置顺序、回调、流准入、重连、断开连接处理和初始打开恢复。

测试：
- 在现有的 Linux 测试运行器中注册 Linux UART PTY 回归测试套件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将 Linux UART 迁移至串行化的非阻塞 I/O，并增强反压处理、延迟配置、写入保留和重连恢复能力。

新功能：
- 将 Linux UART 设备访问迁移至单个串行化的非阻塞 I/O 线程，由该线程协调发送、接收、配置和重连。
- 支持延迟 UART 配置，并在初始失败和设备重连后进行恢复，同时保留符合条件的排队写入请求。

错误修复：
- 通过应用反压防止 RX 队列溢出，并在消费者释放空间后恢复读取。
- 在临时故障和重连期间保留短写入及排队请求；仅在请求已部分发送且无法重放时使其失败。
- 跳过不受支持的低延迟串行调优，避免使用未初始化的 ioctl 数据。

增强功能：
- 确保只有已释放的写入请求才会驱动传输和可写轮询，从而避免未提交的流阻塞配置或触发输出轮询。

测试：
- 新增八个 Linux PTY 回归测试用例，覆盖 RX 反压、部分 TX 与配置顺序、超时、回调写入、流接入、重连处理、部分断开和初始打开恢复。
- 将 Linux UART 回归测试套件注册到现有测试运行器中。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将 Linux UART 迁移到串行化的非阻塞 I/O，支持稳健的背压、延迟配置、请求保留和重连恢复。

新功能：
- 将 Linux UART 设备访问迁移到单个串行化的非阻塞 I/O 线程，涵盖发送、接收、配置和重连。
- 支持延迟 UART 配置：在待发送数据和内核输出耗尽后应用配置。
- 在初始打开/配置失败以及设备断开后恢复 UART 操作，同时保留可重放的请求。

错误修复：
- 通过应用背压防止 RX 队列溢出，并在消费者释放空间后恢复接收。
- 在临时错误和重连期间保留短写入的剩余部分及排队请求；仅对无法重放的部分请求执行失败处理。
- 跳过不受支持的低延迟串行调优，避免使用未初始化的 ioctl 数据。

增强功能：
- 确保只有已释放的写入请求才会驱动传输和可写轮询，从而避免未提交的流阻塞配置或触发输出活动。

测试：
- 新增八个 Linux PTY 回归测试用例，覆盖 RX 背压、部分 TX 与配置顺序、超时行为、回调写入、未提交流、重连、部分断开以及初始打开恢复。
- 将 Linux UART 回归测试套件注册到现有测试运行器中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate Linux UART to serialized nonblocking I/O with robust backpressure, deferred configuration, request retention, and reconnect recovery.

New Features:
- Migrate Linux UART device access to a single serialized nonblocking I/O thread covering transmission, reception, configuration, and reconnection.
- Support deferred UART configuration that is applied after pending transmission and kernel output have drained.
- Recover UART operation after initial open/configuration failures and device disconnects while retaining replayable requests.

Bug Fixes:
- Prevent RX queue overflow by applying backpressure and resuming reception when consumers release space.
- Preserve short-write suffixes and queued requests across temporary errors and reconnects, failing only unreplayable partial requests.
- Skip unsupported low-latency serial tuning without using uninitialized ioctl data.

Enhancements:
- Ensure only released write requests drive transmission and writable polling, so uncommitted streams do not block configuration or trigger output activity.

Tests:
- Add eight Linux PTY regression cases covering RX backpressure, partial TX and configuration ordering, timeout behavior, callback writes, uncommitted streams, reconnects, partial disconnects, and initial-open recovery.
- Register the Linux UART regression suite with the existing test runner.

</details>

</details>

</details>

</details>