### PR TITLE
fix: preserve SPSC producer ownership during reset

### DIFF
--- a/src/structure/queue/spsc_queue.hpp
+++ b/src/structure/queue/spsc_queue.hpp
@@ -279,8 +279,8 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>, public SPS
   }
 
   /**
-   * @brief 重置队列状态。
-   * @brief Reset the queue state.
+   * @brief 从 consumer 侧丢弃当前可见的全部 payload / Discard currently available
+   *        payloads from the consumer side
    */
   void Reset() { SPSCQueueBase::Reset(); }
 };

--- a/src/structure/queue/spsc_queue_base.hpp
+++ b/src/structure/queue/spsc_queue_base.hpp
@@ -506,12 +506,21 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
   }
 
   /**
-   * @brief 重置队列状态 / Reset the queue state
+   * @brief 从 consumer 侧丢弃当前可见的全部 payload / Discard all currently available
+   *        payloads from the consumer side
+   *
+   * 本方法读取 producer 已发布的 tail 快照，并将 consumer head 推进到该位置；不会
+   * 写入 tail，因此单个 producer 可以继续运行。与该快照并发发布的 payload 可能被
+   * 丢弃，也可能保留。
+   *
+   * This method snapshots the producer-published tail and advances the consumer
+   * head to it. It never writes tail, so the single producer may continue.
+   * Payloads published concurrently with the snapshot may be discarded or retained.
    */
   void Reset()
   {
-    head_.store(0, std::memory_order_relaxed);
-    tail_.store(0, std::memory_order_relaxed);
+    const auto current_tail = tail_.load(std::memory_order_acquire);
+    head_.store(current_tail, std::memory_order_release);
   }
 
   /**

--- a/test/base/structure/test_spsc_queue.cpp
+++ b/test/base/structure/test_spsc_queue.cpp
@@ -25,6 +25,13 @@ struct ProducerArg
   std::atomic<bool>* producer_done;
 };
 
+struct ResetProducerArg
+{
+  Queue* queue;
+  std::atomic<bool>* ready;
+  std::atomic<bool>* resume;
+};
+
 void ProducerTask(ProducerArg arg)
 {
   for (uint32_t value = 0; value < arg.total_items; ++value)
@@ -35,6 +42,25 @@ void ProducerTask(ProducerArg arg)
     }
   }
   arg.producer_done->store(true, std::memory_order_release);
+}
+
+void ResetProducerTask(ResetProducerArg arg)
+{
+  const size_t produced = arg.queue->ProduceWithWriter(
+      1U,
+      [&](uint32_t* first, size_t first_size, uint32_t*, size_t second_size)
+      {
+        ASSERT(first_size == 1U);
+        ASSERT(second_size == 0U);
+        first[0] = 99U;
+        arg.ready->store(true, std::memory_order_release);
+        while (!arg.resume->load(std::memory_order_acquire))
+        {
+          LibXR::Thread::Yield();
+        }
+        return 1U;
+      });
+  ASSERT(produced == 1U);
 }
 }  // namespace
 
@@ -154,6 +180,37 @@ void test_spsc_queue()
     ASSERT(queue.Push(pushed) == LibXR::ErrorCode::OK);
     ASSERT(queue.Pop(popped) == LibXR::ErrorCode::OK);
     ASSERT(popped.value == 88);
+  }
+
+  // Hold a producer after it writes an uncommitted slot, then reset from the consumer.
+  {
+    Queue queue(4);
+    ASSERT(queue.Push(10U) == LibXR::ErrorCode::OK);
+    ASSERT(queue.Push(11U) == LibXR::ErrorCode::OK);
+
+    uint32_t value = 0U;
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    ASSERT(value == 10U);
+
+    std::atomic<bool> producer_ready = false;
+    std::atomic<bool> resume_producer = false;
+    LibXR::Thread producer;
+    producer.Create<ResetProducerArg>(
+        ResetProducerArg{&queue, &producer_ready, &resume_producer}, ResetProducerTask,
+        "spsc_reset", 1024, LibXR::Thread::Priority::REALTIME);
+
+    while (!producer_ready.load(std::memory_order_acquire))
+    {
+      LibXR::Thread::Yield();
+    }
+    queue.Reset();
+    resume_producer.store(true, std::memory_order_release);
+
+    ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+    ASSERT(queue.Size() == 1U);
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    ASSERT(value == 99U);
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
   // Callback failures must not commit partially produced or consumed elements.


### PR DESCRIPTION
## Problem

`SPSCQueue::Reset()` reset both indexes to zero. A consumer-side clear could
race the sole producer after it had reserved an old tail position, causing
discarded slots to become visible again when that producer later published.

## Change

`Reset()` now snapshots `tail_` with acquire ordering and releases `head_` to
that snapshot. It remains a consumer-side discard and never writes `tail_`.
The typed wrapper documents the same contract.

The existing SPSC test suite now includes one controlled producer/consumer
interleaving: the producer reserves an old tail, the consumer resets, then the
producer publishes one value. Only that new value may be readable.

## Verification

- Linux Debug build and complete test runner passed: `All tests completed.`
- The same test against a container-local restoration of the old two-index
  reset fails at `test_spsc_queue.cpp:210`.
- `clang-format 21.1.8` and `git diff --check` passed.

## Sourcery 摘要

在生产者发布数据时消费者执行重置的情况下，保持 SPSC 队列的正确性。

错误修复：
- 保留 SPSC 生产者的所有权，并防止消费者并发重置队列时，过时的已预留槽位变得可见。

增强功能：
- 明确说明，重置会从消费者端丢弃当前可见的有效载荷，同时允许生产者继续运行。

测试：
- 添加受控的生产者/消费者重置交错测试，以验证只有新发布的值仍可读取。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve SPSC queue correctness when consumers reset while the producer is publishing.

Bug Fixes:
- Preserve the SPSC producer's ownership and prevent stale reserved slots from becoming visible when the consumer resets the queue concurrently.

Enhancements:
- Clarify that reset discards currently visible payloads from the consumer side while allowing the producer to continue running.

Tests:
- Add a controlled producer/consumer reset interleaving test to verify that only the newly published value remains readable.

</details>