### PR TITLE
feat: migrate CH32 and STM32 UART to queue scopes

### DIFF
--- a/driver/ch/ch32_atomic_shim.c
+++ b/driver/ch/ch32_atomic_shim.c
@@ -1,0 +1,63 @@
+#include <stdint.h>
+
+#include "ch32_interrupt_guard.h"
+
+#if !defined(__riscv_zaamo)
+#error "CH32 QingKe V4 requires the RISC-V Zaamo extension"
+#endif
+
+#if defined(__riscv_zalrsc) || defined(__riscv_atomic)
+#error "CH32 QingKe V4 must be compiled with Zaamo, not the full RISC-V A extension"
+#endif
+
+/* QingKe V4 的 LR/SC 不提供标准保留语义；字 AMO 使用原生指令，CAS 通过短暂屏蔽中断实现。
+ * QingKe V4 LR/SC lacks reservation semantics. Keep native word AMOs and guard CAS
+ * with a bounded single-core interrupt mask. */
+typedef uint32_t libxr_atomic_fallback_guard_state_t;
+
+static inline libxr_atomic_fallback_guard_state_t libxr_atomic_fallback_enter(void)
+{
+  const uint32_t interrupt_state = libxr_ch32_interrupt_save_and_disable();
+  __asm volatile("fence rw, rw" ::: "memory");
+  return interrupt_state;
+}
+
+static inline void libxr_atomic_fallback_exit(
+    libxr_atomic_fallback_guard_state_t interrupt_state)
+{
+  __asm volatile("fence rw, rw" ::: "memory");
+  libxr_ch32_interrupt_restore(interrupt_state);
+}
+
+/* GCC 定长运行时接口有五个参数，执行强 CAS。
+ * The sized GCC runtime helper has five arguments and performs a strong CAS. */
+__attribute__((used, noinline)) _Bool libxr_atomic_compare_exchange_4(
+    volatile void* ptr, void* expected, unsigned int desired, int success_memorder,
+    int failure_memorder) __asm__("__atomic_compare_exchange_4");
+
+__attribute__((used, noinline)) _Bool
+libxr_atomic_compare_exchange_4(volatile void* ptr, void* expected, unsigned int desired,
+                                int success_memorder, int failure_memorder)
+{
+  (void)success_memorder;
+  (void)failure_memorder;
+
+  volatile unsigned int* const value = (volatile unsigned int*)ptr;
+  unsigned int* const expected_value = (unsigned int*)expected;
+  const libxr_atomic_fallback_guard_state_t interrupt_state =
+      libxr_atomic_fallback_enter();
+  const unsigned int observed = *value;
+  const _Bool matched = observed == *expected_value;
+
+  if (matched)
+  {
+    *value = desired;
+  }
+  else
+  {
+    *expected_value = observed;
+  }
+
+  libxr_atomic_fallback_exit(interrupt_state);
+  return matched;
+}

--- a/driver/ch/ch32_interrupt_guard.h
+++ b/driver/ch/ch32_interrupt_guard.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdint.h>
+
+#if !defined(__riscv_zicsr) || !defined(__riscv_zifencei)
+#error "CH32 interrupt guards require the RISC-V Zicsr and Zifencei extensions"
+#endif
+
+enum
+{
+  LIBXR_CH32_INTERRUPT_ENABLE_MASK = 0x88U,
+};
+
+// 保存并屏蔽中断，随后同步取指 / Save and mask interrupts, then synchronize instructions.
+static inline uint32_t libxr_ch32_interrupt_save_and_disable(void)
+{
+  uint32_t interrupt_state;
+  const uint32_t mask = LIBXR_CH32_INTERRUPT_ENABLE_MASK;
+  __asm volatile("csrrc %0, 0x800, %1\n\tfence.i"
+                 : "=r"(interrupt_state)
+                 : "r"(mask)
+                 : "memory");
+  return interrupt_state;
+}
+
+// 只恢复原本启用的中断位 / Restore only interrupt bits that were previously enabled.
+static inline void libxr_ch32_interrupt_restore(uint32_t interrupt_state)
+{
+  const uint32_t restore = interrupt_state & LIBXR_CH32_INTERRUPT_ENABLE_MASK;
+  if (restore != 0U)
+  {
+    __asm volatile("csrs 0x800, %0" : : "r"(restore) : "memory");
+  }
+}

--- a/driver/ch/ch32_uart.cpp
+++ b/driver/ch/ch32_uart.cpp
@@ -1,17 +1,37 @@
 // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast,performance-no-int-to-ptr)
-// ch32_uart.cpp
 
 #include "ch32_uart.hpp"
+
+#include <algorithm>
 
 #include "ch32_dma.hpp"
 #include "ch32_gpio.hpp"
 
 using namespace LibXR;
 
-// Static instance map.
+namespace
+{
+
+bool Ch32DataBitsSupported(const UART::Configuration& config)
+{
+  if (config.parity == UART::Parity::NO_PARITY)
+  {
+    return config.data_bits == 8U;
+  }
+
+  return (config.parity == UART::Parity::EVEN || config.parity == UART::Parity::ODD) &&
+         (config.data_bits == 7U || config.data_bits == 8U);
+}
+
+bool Ch32StopBitsSupported(const UART::Configuration& config)
+{
+  return config.stop_bits == 1U || config.stop_bits == 2U;
+}
+
+}  // namespace
+
 CH32UART* CH32UART::map_[ch32_uart_id_t::CH32_UART_NUMBER] = {nullptr};
 
-// Constructor: USART, DMA, and GPIO initialization.
 CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
                    GPIO_TypeDef* tx_gpio_port, uint16_t tx_gpio_pin,
                    GPIO_TypeDef* rx_gpio_port, uint16_t rx_gpio_pin, uint32_t pin_remap,
@@ -34,6 +54,7 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
   ASSERT(tx_enable || rx_enable);
   if (tx_enable)
   {
+    REQUIRE(tx_queue_size > 0U);
     ASSERT(dma_tx_channel_ != nullptr);
     ASSERT(CH32_UART_TX_DMA_IT_MAP[id] != 0);
   }
@@ -44,7 +65,7 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
     ASSERT(CH32_UART_RX_DMA_IT_HT_MAP[id] != 0);
   }
 
-  /* GPIO配置（TX: 推挽输出，RX: 悬空输入） */
+  // TX 使用复用推挽，RX 使用浮空输入 / TX alternate push-pull; RX floating input.
   GPIO_InitTypeDef gpio_init = {};
   gpio_init.GPIO_Speed = GPIO_Speed_50MHz;
 
@@ -63,17 +84,16 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
     gpio_init.GPIO_Pin = rx_gpio_pin;
     gpio_init.GPIO_Mode = GPIO_Mode_IN_FLOATING;
     GPIO_Init(rx_gpio_port, &gpio_init);
-    (*read_port_) = ReadFun;
   }
 
-  /* 可选：引脚重映射 */
+  // 可选引脚重映射 / Optional pin remapping.
   if (pin_remap != 0)
   {
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
     GPIO_PinRemapConfig(pin_remap, ENABLE);
   }
 
-  /* 串口外设时钟使能 */
+  // 开启串口外设时钟 / Enable the UART peripheral clock.
   if (CH32_UART_APB_MAP[id] == 1)
   {
     RCC_APB1PeriphClockCmd(CH32_UART_RCC_PERIPH_MAP[id], ENABLE);
@@ -88,7 +108,10 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
   }
   RCC_AHBPeriphClockCmd(CH32_UART_RCC_PERIPH_MAP_DMA[id], ENABLE);
 
-  // 3. USART 配置
+  // 设置初始串口参数 / Apply initial UART settings.
+  REQUIRE(config.baudrate > 0U);
+  REQUIRE(Ch32DataBitsSupported(config));
+  REQUIRE(Ch32StopBitsSupported(config));
   USART_InitTypeDef usart_cfg = {};
   usart_cfg.USART_BaudRate = config.baudrate;
   usart_cfg.USART_StopBits =
@@ -101,11 +124,13 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
       break;
     case UART::Parity::EVEN:
       usart_cfg.USART_Parity = USART_Parity_Even;
-      usart_cfg.USART_WordLength = USART_WordLength_9b;
+      usart_cfg.USART_WordLength =
+          config.data_bits == 7U ? USART_WordLength_8b : USART_WordLength_9b;
       break;
     case UART::Parity::ODD:
       usart_cfg.USART_Parity = USART_Parity_Odd;
-      usart_cfg.USART_WordLength = USART_WordLength_9b;
+      usart_cfg.USART_WordLength =
+          config.data_bits == 7U ? USART_WordLength_8b : USART_WordLength_9b;
       break;
     default:
       ASSERT(false);
@@ -117,7 +142,7 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
   uart_mode_ = usart_cfg.USART_Mode;
   USART_Init(instance_, &usart_cfg);
 
-  /* DMA 配置 */
+  // 配置收发 DMA / Configure RX and TX DMA.
   DMA_InitTypeDef dma_init = {};
   dma_init.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
   dma_init.DMA_MemoryInc = DMA_MemoryInc_Enable;
@@ -165,7 +190,7 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
     USART_DMACmd(instance_, USART_DMAReq_Tx, ENABLE);
   }
 
-  // 6. USART和相关中断
+  // 开启串口及对应中断 / Enable the UART and its interrupts.
   USART_Cmd(instance_, ENABLE);
 
   if (rx_enable)
@@ -182,9 +207,51 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
   NVIC_EnableIRQ(CH32_UART_IRQ_MAP[id]);
 }
 
-// Runtime USART configuration.
-ErrorCode CH32UART::SetConfig(UART::Configuration config)
+ErrorCode CH32UART::SetConfig(UART::Configuration config, bool in_isr)
 {
+  if (config.baudrate == 0U)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  switch (config.parity)
+  {
+    case UART::Parity::NO_PARITY:
+    case UART::Parity::EVEN:
+    case UART::Parity::ODD:
+      break;
+    default:
+      return ErrorCode::NOT_SUPPORT;
+  }
+
+  if (!Ch32DataBitsSupported(config))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (!Ch32StopBitsSupported(config))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  ConfigState expected = ConfigState::EMPTY;
+  if (!config_state_.compare_exchange_strong(expected, ConfigState::RESERVED,
+                                             std::memory_order_acq_rel,
+                                             std::memory_order_acquire))
+  {
+    return ErrorCode::BUSY;
+  }
+
+  pending_config_ = config;
+  tx_service_.Invoke(TX_EVENT_CONFIG, in_isr, [this](uint32_t events, bool owner_in_isr)
+                     { HandleTxService(events, owner_in_isr); });
+  return ErrorCode::OK;
+}
+
+void CH32UART::ApplyConfig(UART::Configuration config)
+{
+  USART_ITConfig(instance_, USART_IT_TC, DISABLE);
+
   USART_InitTypeDef usart_cfg = {};
   usart_cfg.USART_BaudRate = config.baudrate;
   usart_cfg.USART_StopBits =
@@ -198,19 +265,21 @@ ErrorCode CH32UART::SetConfig(UART::Configuration config)
       break;
     case UART::Parity::EVEN:
       usart_cfg.USART_Parity = USART_Parity_Even;
-      usart_cfg.USART_WordLength = USART_WordLength_9b;
+      usart_cfg.USART_WordLength =
+          config.data_bits == 7U ? USART_WordLength_8b : USART_WordLength_9b;
       break;
     case UART::Parity::ODD:
       usart_cfg.USART_Parity = USART_Parity_Odd;
-      usart_cfg.USART_WordLength = USART_WordLength_9b;
+      usart_cfg.USART_WordLength =
+          config.data_bits == 7U ? USART_WordLength_8b : USART_WordLength_9b;
       break;
     default:
-      return ErrorCode::NOT_SUPPORT;
+      REQUIRE(false);
+      return;
   }
 
   usart_cfg.USART_Mode = uart_mode_;
   usart_cfg.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
-  USART_DeInit(instance_);
   USART_Init(instance_, &usart_cfg);
 
   if (uart_mode_ & USART_Mode_Rx)
@@ -225,196 +294,265 @@ ErrorCode CH32UART::SetConfig(UART::Configuration config)
   }
 
   USART_Cmd(instance_, ENABLE);
-
-  if (tx_busy_.IsSet())
-  {
-    dma_tx_channel_->CNTR = dma_buff_tx_.GetActiveLength();
-    dma_tx_channel_->MADDR = reinterpret_cast<uint32_t>(dma_buff_tx_.ActiveBuffer());
-    DMA_Cmd(dma_tx_channel_, ENABLE);
-  }
-
-  return ErrorCode::OK;
 }
 
-// Write callback (DMA-based transfer).
-ErrorCode CH32UART::WriteFun(WritePort& port, bool)
+void CH32UART::WriteFun(WritePort& port, bool in_isr)
 {
   auto* uart = LibXR::ContainerOf(&port, &CH32UART::_write_port);
 
-  if (uart->in_tx_isr.IsSet())
+  uart->tx_service_.Invoke(TX_EVENT_WRITE, in_isr,
+                           [uart](uint32_t events, bool owner_in_isr)
+                           { uart->HandleTxService(events, owner_in_isr); });
+}
+
+void CH32UART::HandleTxService(uint32_t events, bool in_isr)
+{
+  if ((events & TX_EVENT_CONFIG) != 0U)
   {
-    return ErrorCode::PENDING;
-  }
-
-  if (!uart->dma_buff_tx_.HasPending())
-  {
-    WriteInfoBlock info;
-    if (port.queue_info_->Peek(info) != ErrorCode::OK)
+    ConfigState state = config_state_.load(std::memory_order_acquire);
+    if (state == ConfigState::RESERVED)
     {
-      return ErrorCode::PENDING;
-    }
-
-    uint8_t* buffer = nullptr;
-    bool use_pending = false;
-
-    // DMA空闲判断
-    bool dma_ready = uart->dma_tx_channel_->CNTR == 0;
-    if (dma_ready)
-    {
-      buffer = reinterpret_cast<uint8_t*>(uart->dma_buff_tx_.ActiveBuffer());
+      config_state_.store(ConfigState::PUBLISHED, std::memory_order_release);
     }
     else
     {
-      buffer = reinterpret_cast<uint8_t*>(uart->dma_buff_tx_.PendingBuffer());
-      use_pending = true;
+      REQUIRE_FROM_CALLBACK(state == ConfigState::PUBLISHED, in_isr);
     }
-
-    if (port.queue_data_->PopBatch(buffer, info.data.size_) != ErrorCode::OK)
-    {
-      ASSERT(false);
-      return ErrorCode::EMPTY;
-    }
-
-    if (use_pending)
-    {
-      uart->dma_buff_tx_.SetPendingLength(info.data.size_);
-      uart->dma_buff_tx_.EnablePending();
-      // 检查当前DMA是否可切换
-      bool dma_ready = uart->dma_tx_channel_->CNTR == 0;
-      if (dma_ready && uart->dma_buff_tx_.HasPending())
-      {
-        uart->dma_buff_tx_.Switch();
-      }
-      else
-      {
-        return ErrorCode::PENDING;
-      }
-    }
-
-    port.queue_info_->Pop(uart->write_info_active_);
-
-    DMA_Cmd(uart->dma_tx_channel_, DISABLE);
-    uart->dma_tx_channel_->MADDR =
-        reinterpret_cast<uint32_t>(uart->dma_buff_tx_.ActiveBuffer());
-    uart->dma_tx_channel_->CNTR = info.data.size_;
-    uart->dma_buff_tx_.SetActiveLength(info.data.size_);
-    uart->tx_busy_.Set();
-    DMA_Cmd(uart->dma_tx_channel_, ENABLE);
-
-    return ErrorCode::OK;
   }
-  return ErrorCode::PENDING;
+
+  if ((events & TX_EVENT_DMA_DONE) != 0U)
+  {
+    HandleTxDone(in_isr);
+  }
+
+  if ((events & TX_EVENT_RX_WORK) != 0U)
+  {
+    HandleRxData(in_isr);
+  }
+
+  if ((events & (TX_EVENT_CONFIG | TX_EVENT_DMA_DONE | TX_EVENT_TC)) != 0U)
+  {
+    TryApplyConfig(in_isr);
+  }
+
+  if ((uart_mode_ & USART_Mode_Tx) != 0U &&
+      (events & (TX_EVENT_WRITE | TX_EVENT_DMA_DONE | TX_EVENT_CONFIG | TX_EVENT_TC)) !=
+          0U &&
+      config_state_.load(std::memory_order_acquire) == ConfigState::EMPTY)
+  {
+    FillTx(in_isr);
+  }
 }
 
-// Read callback (interrupt-driven).
-ErrorCode CH32UART::ReadFun(ReadPort&, bool)
+void CH32UART::FillTx(bool in_isr)
 {
-  // 接收由 IDLE 中断驱动，读取在 ISR 中完成
-  return ErrorCode::PENDING;
+  if (!tx_busy_.IsSet())
+  {
+    if (dma_buff_tx_.HasPending())
+    {
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+      const size_t size = dma_buff_tx_.GetPendingLength();
+      dma_buff_tx_.Switch();
+      dma_buff_tx_.SetActiveLength(size);
+      StartTxDma(in_isr);
+    }
+    else if (dma_buff_tx_.GetActiveLength() != 0U)
+    {
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+      StartTxDma(in_isr);
+    }
+    else
+    {
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+      size_t size = 0U;
+      {
+        auto queue = _write_port.GetWriteQueue(in_isr);
+        if (queue.Empty())
+        {
+          return;
+        }
+        size = queue.AvailableSize();
+        REQUIRE_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
+        queue.PopAll(dma_buff_tx_.ActiveBuffer());
+        dma_buff_tx_.SetActiveLength(size);
+      }
+
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+      StartTxDma(in_isr);
+    }
+  }
+
+  if (tx_busy_.IsSet() && !dma_buff_tx_.HasPending() &&
+      config_state_.load(std::memory_order_acquire) == ConfigState::EMPTY)
+  {
+    auto queue = _write_port.GetWriteQueue(in_isr);
+    if (!queue.Empty())
+    {
+      const size_t size = queue.AvailableSize();
+      REQUIRE_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
+      queue.PopAll(dma_buff_tx_.PendingBuffer());
+      dma_buff_tx_.SetPendingLength(size);
+      dma_buff_tx_.EnablePending();
+    }
+  }
 }
 
-void ch32_uart_rx_isr_handler(LibXR::CH32UART* uart)
+void CH32UART::HandleTxDone(bool in_isr)
 {
-  auto rx_buf = static_cast<uint8_t*>(uart->dma_buff_rx_.addr_);
-  size_t dma_size = uart->dma_buff_rx_.size_;
-  size_t curr_pos = dma_size - uart->dma_rx_channel_->CNTR;
-  size_t last_pos = uart->last_rx_pos_;
+  UNUSED(in_isr);
+  if (!tx_busy_.IsSet())
+  {
+    return;
+  }
+
+  tx_busy_.Clear();
+  dma_buff_tx_.SetActiveLength(0U);
+}
+
+void CH32UART::TryApplyConfig(bool in_isr)
+{
+  if (config_state_.load(std::memory_order_acquire) != ConfigState::PUBLISHED)
+  {
+    return;
+  }
+
+  if (tx_busy_.IsSet())
+  {
+    return;
+  }
+
+  if ((uart_mode_ & USART_Mode_Tx) != 0U &&
+      USART_GetFlagStatus(instance_, USART_FLAG_TC) == RESET)
+  {
+    USART_ITConfig(instance_, USART_IT_TC, ENABLE);
+    return;
+  }
+
+  const UART::Configuration config = pending_config_;
+  ApplyConfig(config);
+
+  if ((uart_mode_ & USART_Mode_Rx) != 0U && dma_buff_rx_.size_ != 0U)
+  {
+    const size_t remaining = dma_rx_channel_->CNTR;
+    REQUIRE_FROM_CALLBACK(remaining <= dma_buff_rx_.size_, in_isr);
+    const size_t position =
+        remaining == 0U ? dma_buff_rx_.size_ : dma_buff_rx_.size_ - remaining;
+    last_rx_pos_ = position == dma_buff_rx_.size_ ? 0U : position;
+  }
+
+  config_state_.store(ConfigState::EMPTY, std::memory_order_release);
+  UNUSED(in_isr);
+}
+
+void CH32UART::StartTxDma(bool in_isr)
+{
+  const size_t size = dma_buff_tx_.GetActiveLength();
+  REQUIRE_FROM_CALLBACK(size != 0U && size <= dma_buff_tx_.Size(), in_isr);
+
+  DMA_Cmd(dma_tx_channel_, DISABLE);
+  dma_tx_channel_->MADDR = reinterpret_cast<uint32_t>(dma_buff_tx_.ActiveBuffer());
+  dma_tx_channel_->CNTR = size;
+  tx_busy_.Set();
+  DMA_Cmd(dma_tx_channel_, ENABLE);
+}
+
+void CH32UART::HandleRxData(bool in_isr)
+{
+  const size_t dma_size = dma_buff_rx_.size_;
+  if (dma_size == 0U)
+  {
+    return;
+  }
+
+  const size_t remaining = dma_rx_channel_->CNTR;
+  REQUIRE_FROM_CALLBACK(remaining <= dma_size, in_isr);
+  const size_t curr_pos = remaining == 0U ? dma_size : dma_size - remaining;
+  const size_t last_pos = last_rx_pos_;
+  REQUIRE_FROM_CALLBACK(last_pos < dma_size, in_isr);
 
   if (curr_pos != last_pos)
   {
-    if (curr_pos > last_pos)
+    const size_t first_size =
+        curr_pos > last_pos ? curr_pos - last_pos : dma_size - last_pos;
+    const size_t second_size = curr_pos > last_pos ? 0U : curr_pos;
+    auto queue = _read_port.GetReadQueue(in_isr);
+    size_t accepted = std::min(first_size + second_size, queue.EmptySize());
+
+    if (accepted != 0U)
     {
-      // 普通区间
-      uart->_read_port.queue_data_->PushBatch(&rx_buf[last_pos], curr_pos - last_pos);
+      const size_t first_accepted = std::min(first_size, accepted);
+      if (first_accepted != 0U)
+      {
+        REQUIRE_FROM_CALLBACK(
+            queue.PushBatch(static_cast<const uint8_t*>(dma_buff_rx_.addr_) + last_pos,
+                            first_accepted) == ErrorCode::OK,
+            in_isr);
+        accepted -= first_accepted;
+      }
+      if (accepted != 0U)
+      {
+        REQUIRE_FROM_CALLBACK(
+            queue.PushBatch(static_cast<const uint8_t*>(dma_buff_rx_.addr_), accepted) ==
+                ErrorCode::OK,
+            in_isr);
+      }
+    }
+
+    last_rx_pos_ = curr_pos == dma_size ? 0U : curr_pos;
+    queue.Publish();
+  }
+}
+
+void CH32UART::UartIRQHandler()
+{
+  const bool idle = USART_GetITStatus(instance_, USART_IT_IDLE) != RESET;
+  const bool tc = USART_GetITStatus(instance_, USART_IT_TC) != RESET;
+
+  if (idle)
+  {
+    USART_ReceiveData(instance_);
+    tx_service_.Invoke(TX_EVENT_RX_WORK, true, [this](uint32_t events, bool in_isr)
+                       { HandleTxService(events, in_isr); });
+  }
+
+  if (tc)
+  {
+    if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+    {
+      USART_ITConfig(instance_, USART_IT_TC, DISABLE);
+      tx_service_.Invoke(TX_EVENT_TC, true, [this](uint32_t events, bool in_isr)
+                         { HandleTxService(events, in_isr); });
     }
     else
     {
-      // 回卷区
-      uart->_read_port.queue_data_->PushBatch(&rx_buf[last_pos], dma_size - last_pos);
-      uart->_read_port.queue_data_->PushBatch(&rx_buf[0], curr_pos);
+      USART_ITConfig(instance_, USART_IT_TC, DISABLE);
     }
-    uart->last_rx_pos_ = curr_pos;
-    uart->_read_port.ProcessPendingReads(true);
   }
 }
 
-// USART IDLE interrupt handler.
 extern "C" void ch32_uart_isr_handler_idle(ch32_uart_id_t id)
 {
   auto uart = CH32UART::map_[id];
-  if (!uart)
+  if (uart)
   {
-    return;
+    uart->UartIRQHandler();
   }
-
-  // 检查和清除IDLE标志
-  if (!USART_GetITStatus(uart->instance_, USART_IT_IDLE))
-  {
-    return;
-  }
-
-  USART_ReceiveData(uart->instance_);
-
-  ch32_uart_rx_isr_handler(uart);
 }
 
-// DMA TX completion interrupt handler.
-extern "C" void ch32_uart_isr_handler_tx_cplt(CH32UART* uart)
-{
-  DMA_ClearITPendingBit(CH32_UART_TX_DMA_IT_MAP[uart->id_]);
+extern "C" void ch32_uart_isr_handler_tx_cplt(CH32UART* uart) { uart->TxDmaIRQHandler(); }
 
-  uart->tx_busy_.Clear();
-
-  Flag::ScopedRestore tx_flag(uart->in_tx_isr);
-
-  size_t pending_len = uart->dma_buff_tx_.GetPendingLength();
-
-  if (pending_len == 0)
-  {
-    return;
-  }
-
-  uart->dma_buff_tx_.Switch();
-
-  auto* buf = reinterpret_cast<uint8_t*>(uart->dma_buff_tx_.ActiveBuffer());
-  DMA_Cmd(uart->dma_tx_channel_, DISABLE);
-  uart->dma_tx_channel_->MADDR = (uint32_t)buf;
-  uart->dma_tx_channel_->CNTR = pending_len;
-  uart->dma_buff_tx_.SetActiveLength(pending_len);
-  DMA_Cmd(uart->dma_tx_channel_, ENABLE);
-
-  WriteInfoBlock& current_info = uart->write_info_active_;
-
-  // 有pending包，继续取下一包
-  if (uart->_write_port.queue_info_->Pop(current_info) != ErrorCode::OK)
-  {
-    ASSERT(false);
-    return;
-  }
-
-  uart->write_port_->Finish(true, ErrorCode::OK, current_info);
-
-  // 预装pending区
-  WriteInfoBlock next_info;
-  if (uart->write_port_->queue_info_->Peek(next_info) != ErrorCode::OK)
-  {
-    return;
-  }
-
-  if (uart->write_port_->queue_data_->PopBatch(
-          reinterpret_cast<uint8_t*>(uart->dma_buff_tx_.PendingBuffer()),
-          next_info.data.size_) != ErrorCode::OK)
-  {
-    ASSERT(false);
-    return;
-  }
-
-  uart->dma_buff_tx_.SetPendingLength(next_info.data.size_);
-
-  uart->dma_buff_tx_.EnablePending();
-}
-
-// DMA channel IRQ callbacks.
 void CH32UART::TxDmaIRQHandler()
 {
   if (DMA_GetITStatus(CH32_UART_TX_DMA_IT_MAP[id_]) == RESET)
@@ -424,34 +562,33 @@ void CH32UART::TxDmaIRQHandler()
 
   if (dma_tx_channel_->CNTR == 0)
   {
-    ch32_uart_isr_handler_tx_cplt(this);
+    DMA_ClearITPendingBit(CH32_UART_TX_DMA_IT_MAP[id_]);
+    tx_service_.Invoke(TX_EVENT_DMA_DONE, true, [this](uint32_t events, bool in_isr)
+                       { HandleTxService(events, in_isr); });
   }
 }
 
 /**
- * @brief  DMA中断处理函数
- *
- * 如果DMA中断触发，且中断状态为半满或传输完成，清除中断标志，
- * 并调用对应的中断处理函数
- *
- * @param[in] id  UART的ID
+ * @brief 清除接收 DMA 中断标志并通知后端 / Clear RX DMA flags and notify the backend.
+ * @param id 串口编号 / UART identifier.
  */
 void CH32UART::RxDmaIRQHandler()
 {
   if (DMA_GetITStatus(CH32_UART_RX_DMA_IT_HT_MAP[id_]) == SET)
   {
     DMA_ClearITPendingBit(CH32_UART_RX_DMA_IT_HT_MAP[id_]);
-    ch32_uart_rx_isr_handler(this);
+    tx_service_.Invoke(TX_EVENT_RX_WORK, true, [this](uint32_t events, bool in_isr)
+                       { HandleTxService(events, in_isr); });
   }
 
   if (DMA_GetITStatus(CH32_UART_RX_DMA_IT_TC_MAP[id_]) == SET)
   {
     DMA_ClearITPendingBit(CH32_UART_RX_DMA_IT_TC_MAP[id_]);
-    ch32_uart_rx_isr_handler(this);
+    tx_service_.Invoke(TX_EVENT_RX_WORK, true, [this](uint32_t events, bool in_isr)
+                       { HandleTxService(events, in_isr); });
   }
 }
 
-// USART IRQ entry adapters.
 #if defined(USART1)
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" void USART1_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));

--- a/driver/ch/ch32_uart.hpp
+++ b/driver/ch/ch32_uart.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "libxr.hpp"
 #include DEF2STR(LIBXR_CH32_CONFIG_FILE)
 
@@ -7,52 +9,133 @@
 #include "double_buffer.hpp"
 #include "libxr_def.hpp"
 #include "libxr_rw.hpp"
+#include "serialized_service.hpp"
 #include "uart.hpp"
 
 namespace LibXR
 {
 
 /**
- * @brief CH32 UART 驱动实现 / CH32 UART driver implementation
+ * @brief 使用循环接收 DMA 和双缓冲发送的 CH32 串口
+ *        / CH32 UART with circular RX DMA and double-buffered TX.
+ *
+ * 写请求完整复制到发送缓冲半区后完成，DMA 完成仅释放半区。接收持续运行，
+ * 按 DMA 位置变化向 ReadPort 发布数据；软件队列放不下的部分作为接收溢出丢弃。
+ * Writes complete once copied into a TX half; DMA completion only releases that half.
+ * RX runs continuously and publishes observed DMA bytes to ReadPort, discarding any
+ * overflow beyond available software capacity.
+ *
+ * @pre 调用遵守 ReadPort/WritePort 约定；DMA 缓冲区满足平台访问和对齐要求，运行期间有效。
+ *      Follow the port contracts. DMA buffers must meet platform access/alignment
+ *      requirements and remain valid throughout operation.
  */
 class CH32UART : public UART
 {
  public:
   /**
-   * @brief 构造 UART 对象 / Construct UART object
+   * @brief 构造串口并关联 DMA 缓冲区 / Construct a UART with DMA buffers.
+   * @param id 串口编号 / UART identifier.
+   * @param dma_rx 接收 DMA 缓冲区 / RX DMA buffer.
+   * @param dma_tx 双缓冲发送存储，每半区容纳一个请求 / TX storage, one request per half.
+   * @param tx_gpio_port 发送引脚端口 / TX GPIO port.
+   * @param tx_gpio_pin 发送引脚 / TX GPIO pin.
+   * @param rx_gpio_port 接收引脚端口 / RX GPIO port.
+   * @param rx_gpio_pin 接收引脚 / RX GPIO pin.
+   * @param pin_remap 引脚重映射配置，默认零 / Pin remapping, zero by default.
+   * @param tx_queue_size 写请求队列容量，启用发送时须大于零 / Positive TX request
+   * capacity.
+   * @param config 初始串口配置 / Initial UART configuration.
    */
   CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx, GPIO_TypeDef* tx_gpio_port,
            uint16_t tx_gpio_pin, GPIO_TypeDef* rx_gpio_port, uint16_t rx_gpio_pin,
            uint32_t pin_remap = 0, uint32_t tx_queue_size = 5,
            UART::Configuration config = {115200, UART::Parity::NO_PARITY, 8, 1});
 
-  ErrorCode SetConfig(UART::Configuration config);
+  /**
+   * @brief 提交串口配置请求 / Submit a UART configuration request.
+   * @param config 目标配置 / Requested configuration.
+   * @param in_isr 当前调用是否在中断中 / Whether this call is in an ISR.
+   * @return 接纳返回 OK，配置槽被占用返回 BUSY，参数不支持返回 ARG_ERR 或 NOT_SUPPORT。
+   *         OK on admission, BUSY for an occupied slot, ARG_ERR or NOT_SUPPORT for
+   *         unsupported settings.
+   * @note 接纳后在发送空闲时应用，期间保留已准备的 DMA 数据；不保证返回前已经生效。
+   *       Applies when TX is idle while preserving prepared DMA data. May apply after
+   * return.
+   */
+  ErrorCode SetConfig(UART::Configuration config, bool in_isr = false) override;
 
-  static ErrorCode WriteFun(WritePort& port, bool in_isr);
-  static ErrorCode ReadFun(ReadPort& port, bool in_isr);
+  /// 通知后端处理已提交的写请求 / Notify the backend of released writes.
+  static void WriteFun(WritePort& port, bool in_isr);
 
+  /// 处理发送 DMA 完成通知 / Handle TX DMA completion.
   void TxDmaIRQHandler();
+  /// 处理接收 DMA 进展通知 / Handle RX DMA progress.
   void RxDmaIRQHandler();
+  /// 处理接收空闲和发送完成中断 / Handle RX idle and TX complete interrupts.
+  void UartIRQHandler();
 
   ch32_uart_id_t id_;
   uint16_t uart_mode_;
 
+  /// 接收字节队列与读请求 / RX byte queue and read requests.
   ReadPort _read_port;
+  /// 写请求及发送字节队列 / Write requests and TX byte queue.
   WritePort _write_port;
 
+  /// 调用者提供的接收 DMA 缓冲区 / Caller-provided RX DMA buffer.
   RawData dma_buff_rx_;
+  /// 当前与待发送的 DMA 半区 / Active and pending TX DMA halves.
   DoubleBuffer dma_buff_tx_;
-  WriteInfoBlock write_info_active_;
 
+  /// 上次已处理的 DMA 接收位置 / Last processed RX DMA position.
   size_t last_rx_pos_ = 0;
 
   USART_TypeDef* instance_;
   DMA_Channel_TypeDef* dma_rx_channel_;
   DMA_Channel_TypeDef* dma_tx_channel_;
 
-  Flag::Plain in_tx_isr, tx_busy_;
+  /// 发送半区是否在使用，仅后端处理器访问 / TX half in use; service-only access.
+  Flag::Plain tx_busy_;
 
   static CH32UART* map_[CH32_UART_NUMBER];
+
+ private:
+  /// 待应用配置的发布阶段 / Pending configuration publication phase.
+  enum class ConfigState : uint32_t
+  {
+    EMPTY = 0U,
+    RESERVED = 1U,
+    PUBLISHED = 2U,
+  };
+
+  static constexpr uint32_t TX_EVENT_WRITE = 1U << 0U;
+  static constexpr uint32_t TX_EVENT_DMA_DONE = 1U << 1U;
+  static constexpr uint32_t TX_EVENT_CONFIG = 1U << 2U;
+  static constexpr uint32_t TX_EVENT_TC = 1U << 3U;
+  static constexpr uint32_t TX_EVENT_RX_WORK = 1U << 4U;
+
+  /// 串行处理收发和配置通知 / Serialize RX, TX, and configuration progress.
+  void HandleTxService(uint32_t events, bool in_isr);
+  /// 填充空闲发送半区并启动 DMA / Fill available TX halves and start DMA.
+  void FillTx(bool in_isr);
+  /// 释放已发送半区，不重复完成写请求 / Release the sent half without completing again.
+  void HandleTxDone(bool in_isr);
+  /// 启动当前半区发送 / Start transmitting the active half.
+  void StartTxDma(bool in_isr);
+  /// 应用已验证配置 / Apply validated configuration.
+  void ApplyConfig(UART::Configuration config);
+  /// 在发送空闲边界尝试应用配置 / Try applying configuration at the TX idle boundary.
+  void TryApplyConfig(bool in_isr);
+  /// 复制可容纳的接收前缀，更新游标后发布 / Copy fitting RX bytes, advance, then publish.
+  void HandleRxData(bool in_isr);
+
+  /// 共享的收发与配置处理器 / Shared RX, TX, and configuration service.
+  SerializedService tx_service_;
+  /// 配置槽的并发发布状态 / Concurrent configuration slot state.
+  std::atomic<ConfigState> config_state_{ConfigState::EMPTY};
+  /// 由调用者发布、后端应用的配置 / Caller-published configuration for backend
+  /// application.
+  UART::Configuration pending_config_{};
 };
 
 }  // namespace LibXR

--- a/driver/esp/esp_cdc_jtag.cpp
+++ b/driver/esp/esp_cdc_jtag.cpp
@@ -57,7 +57,7 @@ ESP32CDCJtag::ESP32CDCJtag(size_t rx_buffer_size, size_t tx_buffer_size,
 }
 
 // USB Serial/JTAG 只支持固定 8N1 / USB Serial/JTAG only supports fixed 8N1.
-ErrorCode ESP32CDCJtag::SetConfig(UART::Configuration config)
+ErrorCode ESP32CDCJtag::SetConfig(UART::Configuration config, bool)
 {
   if ((config.data_bits != 8) || (config.stop_bits != 1) ||
       (config.parity != UART::Parity::NO_PARITY))

--- a/driver/esp/esp_cdc_jtag.hpp
+++ b/driver/esp/esp_cdc_jtag.hpp
@@ -92,7 +92,7 @@ class ESP32CDCJtag : public UART
   /**
    * @brief 应用 UART 帧格式配置 / Apply a UART framing configuration to the backend
    */
-  ErrorCode SetConfig(UART::Configuration config) override;
+  ErrorCode SetConfig(UART::Configuration config, bool in_isr = false) override;
 
   /**
    * @brief 用于 TX 启动的 WritePort 跳板函数 / WritePort trampoline for TX startup

--- a/driver/esp/esp_uart.cpp
+++ b/driver/esp/esp_uart.cpp
@@ -182,7 +182,7 @@ void ESP32UART::ConfigureRxInterruptPath()
 // a synthetic BUSY state.
 // 原地重配帧格式，同时保持软件队列模型不变。若 TX 已在进行，则恢复后端，
 // 而不是人为抛出 BUSY 状态。
-ErrorCode ESP32UART::SetConfig(UART::Configuration config)
+ErrorCode ESP32UART::SetConfig(UART::Configuration config, bool)
 {
   if (!uart_hw_enabled_)
   {

--- a/driver/esp/esp_uart.hpp
+++ b/driver/esp/esp_uart.hpp
@@ -93,7 +93,7 @@ class ESP32UART : public UART
    * @brief Apply a new UART framing and baud configuration.
    * @brief 应用新的 UART 帧格式和波特率配置。
    */
-  ErrorCode SetConfig(UART::Configuration config) override;
+  ErrorCode SetConfig(UART::Configuration config, bool in_isr = false) override;
 
   /**
    * @brief Toggle UART peripheral internal loopback mode.

--- a/driver/linux/linux_uart.hpp
+++ b/driver/linux/linux_uart.hpp
@@ -403,7 +403,7 @@ class LinuxUART : public UART
    *       kernel output before applying. Pending configuration survives disconnect or
    *       application failure and is used on reopen.
    */
-  ErrorCode SetConfig(UART::Configuration config) override
+  ErrorCode SetConfig(UART::Configuration config, bool = false) override
   {
     if (ValidateConfig(config) != ErrorCode::OK)
     {

--- a/driver/mspm0/mspm0_uart.cpp
+++ b/driver/mspm0/mspm0_uart.cpp
@@ -92,7 +92,7 @@ UART::Configuration MSPM0UART::BuildConfigFromSysCfg(UART_Regs* instance,
   return config;
 }
 
-ErrorCode MSPM0UART::SetConfig(UART::Configuration config)
+ErrorCode MSPM0UART::SetConfig(UART::Configuration config, bool)
 {
   if (config.baudrate == 0)
   {

--- a/driver/mspm0/mspm0_uart.hpp
+++ b/driver/mspm0/mspm0_uart.hpp
@@ -29,7 +29,7 @@ class MSPM0UART : public UART
             uint32_t tx_buffer_size = 128,
             UART::Configuration config = {115200, UART::Parity::NO_PARITY, 8, 1});
 
-  ErrorCode SetConfig(UART::Configuration config) override;
+  ErrorCode SetConfig(UART::Configuration config, bool in_isr = false) override;
 
   static ErrorCode WriteFun(WritePort& port, bool in_isr);
 

--- a/driver/st/stm32_uart.cpp
+++ b/driver/st/stm32_uart.cpp
@@ -1,9 +1,32 @@
 #include "stm32_uart.hpp"
 
+#include <algorithm>
+
 #include "stm32_dcache.hpp"
 #ifdef HAL_UART_MODULE_ENABLED
 
 using namespace LibXR;
+
+namespace
+{
+
+bool Stm32DataBitsSupported(const UART::Configuration& config)
+{
+  if (config.parity == UART::Parity::NO_PARITY)
+  {
+    return config.data_bits == 8U;
+  }
+
+  return (config.parity == UART::Parity::EVEN || config.parity == UART::Parity::ODD) &&
+         (config.data_bits == 7U || config.data_bits == 8U);
+}
+
+bool Stm32StopBitsSupported(const UART::Configuration& config)
+{
+  return config.stop_bits == 1U || config.stop_bits == 2U;
+}
+
+}  // namespace
 
 STM32UART* STM32UART::map[STM32_UART_NUMBER] = {nullptr};
 
@@ -193,83 +216,138 @@ stm32_uart_id_t stm32_uart_get_id(USART_TypeDef* addr)
   }
 }
 
-ErrorCode STM32UART::WriteFun(WritePort& port, bool)
+void STM32UART::WriteFun(WritePort& port, bool in_isr)
 {
   auto* uart = LibXR::ContainerOf(&port, &STM32UART::_write_port);
 
-  if (uart->in_tx_isr.IsSet())
-  {
-    return ErrorCode::PENDING;
-  }
-
-  if (!uart->dma_buff_tx_.HasPending())
-  {
-    WriteInfoBlock info;
-    if (port.queue_info_->Peek(info) != ErrorCode::OK)
-    {
-      return ErrorCode::PENDING;
-    }
-
-    uint8_t* buffer = nullptr;
-    bool use_pending = false;
-
-    if (uart->uart_handle_->gState == HAL_UART_STATE_READY)
-    {
-      buffer = reinterpret_cast<uint8_t*>(uart->dma_buff_tx_.ActiveBuffer());
-    }
-    else
-    {
-      buffer = reinterpret_cast<uint8_t*>(uart->dma_buff_tx_.PendingBuffer());
-      use_pending = true;
-    }
-
-    if (port.queue_data_->PopBatch(reinterpret_cast<uint8_t*>(buffer), info.data.size_) !=
-        ErrorCode::OK)
-    {
-      ASSERT(false);
-      return ErrorCode::EMPTY;
-    }
-
-    if (use_pending)
-    {
-      uart->dma_buff_tx_.SetPendingLength(info.data.size_);
-      uart->dma_buff_tx_.EnablePending();
-      if (uart->uart_handle_->gState == HAL_UART_STATE_READY &&
-          uart->dma_buff_tx_.HasPending())
-      {
-        uart->dma_buff_tx_.Switch();
-      }
-      else
-      {
-        return ErrorCode::PENDING;
-      }
-    }
-
-    port.queue_info_->Pop(uart->write_info_active_);
-
-    STM32_CleanDCacheByAddr(uart->dma_buff_tx_.ActiveBuffer(), info.data.size_);
-
-    uart->dma_buff_tx_.SetActiveLength(info.data.size_);
-    uart->tx_busy_.Set();
-    auto ans = HAL_UART_Transmit_DMA(
-        uart->uart_handle_, static_cast<uint8_t*>(uart->dma_buff_tx_.ActiveBuffer()),
-        info.data.size_);
-
-    if (ans != HAL_OK)
-    {
-      uart->tx_busy_.Clear();
-      return ErrorCode::FAILED;
-    }
-    else
-    {
-      return ErrorCode::OK;
-    }
-  }
-
-  return ErrorCode::PENDING;
+  uart->tx_service_.Invoke(TX_EVENT_WRITE, in_isr,
+                           [uart](uint32_t events, bool owner_in_isr)
+                           { uart->HandleTxService(events, owner_in_isr); });
 }
 
-ErrorCode STM32UART::ReadFun(ReadPort&, bool) { return ErrorCode::PENDING; }
+void STM32UART::HandleTxService(uint32_t events, bool in_isr)
+{
+  if ((events & TX_EVENT_CONFIG) != 0U)
+  {
+    ConfigState state = config_state_.load(std::memory_order_acquire);
+    if (state == ConfigState::RESERVED)
+    {
+      config_state_.store(ConfigState::PUBLISHED, std::memory_order_release);
+    }
+    else
+    {
+      REQUIRE_FROM_CALLBACK(state == ConfigState::PUBLISHED, in_isr);
+    }
+  }
+
+  if ((events & TX_EVENT_DONE) != 0U)
+  {
+    HandleTxDone(in_isr);
+  }
+
+  if ((events & TX_EVENT_ABORT) != 0U)
+  {
+    last_rx_pos_ = 0U;
+    SetRxDMA(in_isr);
+    HandleTxDone(in_isr);
+  }
+
+  if ((events & TX_EVENT_RX_WORK) != 0U)
+  {
+    HandleRxData(in_isr);
+  }
+
+  if ((events & (TX_EVENT_CONFIG | TX_EVENT_DONE | TX_EVENT_ABORT)) != 0U)
+  {
+    TryApplyConfig(in_isr);
+  }
+
+  if ((uart_handle_->Init.Mode & UART_MODE_TX) != 0U &&
+      (events & (TX_EVENT_WRITE | TX_EVENT_DONE | TX_EVENT_CONFIG | TX_EVENT_ABORT)) !=
+          0U &&
+      config_state_.load(std::memory_order_acquire) == ConfigState::EMPTY)
+  {
+    FillTx(in_isr);
+  }
+}
+
+void STM32UART::FillTx(bool in_isr)
+{
+  if (!tx_busy_.IsSet())
+  {
+    if (dma_buff_tx_.HasPending())
+    {
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+      const size_t size = dma_buff_tx_.GetPendingLength();
+      dma_buff_tx_.Switch();
+      dma_buff_tx_.SetActiveLength(size);
+      StartTxDma(in_isr);
+    }
+    else if (dma_buff_tx_.GetActiveLength() != 0U)
+    {
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+      StartTxDma(in_isr);
+    }
+    else
+    {
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+
+      size_t size = 0U;
+      {
+        auto queue = _write_port.GetWriteQueue(in_isr);
+        if (queue.Empty())
+        {
+          return;
+        }
+        size = queue.AvailableSize();
+        REQUIRE_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
+        queue.PopAll(dma_buff_tx_.ActiveBuffer());
+        dma_buff_tx_.SetActiveLength(size);
+      }
+
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+      StartTxDma(in_isr);
+    }
+  }
+
+  if (tx_busy_.IsSet() && !dma_buff_tx_.HasPending() &&
+      config_state_.load(std::memory_order_acquire) == ConfigState::EMPTY)
+  {
+    auto queue = _write_port.GetWriteQueue(in_isr);
+    if (!queue.Empty())
+    {
+      const size_t size = queue.AvailableSize();
+      REQUIRE_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
+      queue.PopAll(dma_buff_tx_.PendingBuffer());
+      dma_buff_tx_.SetPendingLength(size);
+      dma_buff_tx_.EnablePending();
+    }
+  }
+}
+
+void STM32UART::HandleTxDone(bool in_isr)
+{
+  UNUSED(in_isr);
+  if (!tx_busy_.IsSet())
+  {
+    return;
+  }
+
+  tx_busy_.Clear();
+  dma_buff_tx_.SetActiveLength(0U);
+}
 
 STM32UART::STM32UART(UART_HandleTypeDef* uart_handle, RawData dma_buff_rx,
                      RawData dma_buff_tx, uint32_t tx_queue_size)
@@ -287,16 +365,57 @@ STM32UART::STM32UART(UART_HandleTypeDef* uart_handle, RawData dma_buff_rx,
 
   if ((uart_handle->Init.Mode & UART_MODE_TX) == UART_MODE_TX)
   {
+    REQUIRE(tx_queue_size > 0U);
     ASSERT(uart_handle_->hdmatx != NULL);
     _write_port = WriteFun;
   }
 
-  SetRxDMA();
+  SetRxDMA(false);
 }
 
-ErrorCode STM32UART::SetConfig(UART::Configuration config)
+ErrorCode STM32UART::SetConfig(UART::Configuration config, bool in_isr)
 {
-  HAL_UART_DeInit(uart_handle_);
+  if (config.baudrate == 0U)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  switch (config.parity)
+  {
+    case UART::Parity::NO_PARITY:
+    case UART::Parity::EVEN:
+    case UART::Parity::ODD:
+      break;
+    default:
+      return ErrorCode::NOT_SUPPORT;
+  }
+
+  if (!Stm32DataBitsSupported(config))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (!Stm32StopBitsSupported(config))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  ConfigState expected = ConfigState::EMPTY;
+  if (!config_state_.compare_exchange_strong(expected, ConfigState::RESERVED,
+                                             std::memory_order_acq_rel,
+                                             std::memory_order_acquire))
+  {
+    return ErrorCode::BUSY;
+  }
+
+  pending_config_ = config;
+  tx_service_.Invoke(TX_EVENT_CONFIG, in_isr, [this](uint32_t events, bool owner_in_isr)
+                     { HandleTxService(events, owner_in_isr); });
+  return ErrorCode::OK;
+}
+
+void STM32UART::ApplyConfig(UART::Configuration config, bool in_isr)
+{
   uart_handle_->Init.BaudRate = config.baudrate;
 
   switch (config.parity)
@@ -307,14 +426,17 @@ ErrorCode STM32UART::SetConfig(UART::Configuration config)
       break;
     case UART::Parity::EVEN:
       uart_handle_->Init.Parity = UART_PARITY_EVEN;
-      uart_handle_->Init.WordLength = UART_WORDLENGTH_9B;
+      uart_handle_->Init.WordLength =
+          config.data_bits == 7U ? UART_WORDLENGTH_8B : UART_WORDLENGTH_9B;
       break;
     case UART::Parity::ODD:
       uart_handle_->Init.Parity = UART_PARITY_ODD;
-      uart_handle_->Init.WordLength = UART_WORDLENGTH_9B;
+      uart_handle_->Init.WordLength =
+          config.data_bits == 7U ? UART_WORDLENGTH_8B : UART_WORDLENGTH_9B;
       break;
     default:
-      ASSERT(false);
+      REQUIRE_FROM_CALLBACK(false, in_isr);
+      return;
   }
 
   switch (config.stop_bits)
@@ -326,137 +448,131 @@ ErrorCode STM32UART::SetConfig(UART::Configuration config)
       uart_handle_->Init.StopBits = UART_STOPBITS_2;
       break;
     default:
-      ASSERT(false);
+      REQUIRE_FROM_CALLBACK(false, in_isr);
+      return;
   }
 
-  if (HAL_UART_Init(uart_handle_) != HAL_OK)
+  REQUIRE_FROM_CALLBACK(HAL_UART_Init(uart_handle_) == HAL_OK, in_isr);
+}
+
+void STM32UART::TryApplyConfig(bool in_isr)
+{
+  if (config_state_.load(std::memory_order_acquire) != ConfigState::PUBLISHED)
   {
-    return ErrorCode::INIT_ERR;
+    return;
   }
-
-  last_rx_pos_ = 0;
-
-  SetRxDMA();
 
   if (tx_busy_.IsSet())
   {
-    HAL_UART_Transmit_DMA(uart_handle_, dma_buff_tx_.ActiveBuffer(),
-                          dma_buff_tx_.GetActiveLength());
+    return;
   }
 
-  return ErrorCode::OK;
+  ApplyConfig(pending_config_, in_isr);
+  last_rx_pos_ = 0U;
+  SetRxDMA(in_isr);
+  config_state_.store(ConfigState::EMPTY, std::memory_order_release);
 }
 
-void STM32UART::SetRxDMA()
+void STM32UART::SetRxDMA(bool in_isr)
 {
   if ((uart_handle_->Init.Mode & UART_MODE_RX) == UART_MODE_RX)
   {
     ASSERT(uart_handle_->hdmarx != NULL);
 
     uart_handle_->hdmarx->Init.Mode = DMA_CIRCULAR;
-    HAL_DMA_Init(uart_handle_->hdmarx);
+    REQUIRE_FROM_CALLBACK(HAL_DMA_Init(uart_handle_->hdmarx) == HAL_OK, in_isr);
 
-    HAL_UARTEx_ReceiveToIdle_DMA(
-        uart_handle_, reinterpret_cast<uint8_t*>(dma_buff_rx_.addr_), dma_buff_rx_.size_);
-    _read_port = ReadFun;
+    REQUIRE_FROM_CALLBACK(
+        HAL_UARTEx_ReceiveToIdle_DMA(uart_handle_,
+                                     reinterpret_cast<uint8_t*>(dma_buff_rx_.addr_),
+                                     dma_buff_rx_.size_) == HAL_OK,
+        in_isr);
   }
 }
 
-// NOLINTNEXTLINE
-static inline void STM32_UART_RX_ISR_Handler(UART_HandleTypeDef* uart_handle)
+void STM32UART::HandleRxData(bool in_isr)
 {
-  auto uart = STM32UART::map[stm32_uart_get_id(uart_handle->Instance)];
-  auto rx_buf = static_cast<uint8_t*>(uart->dma_buff_rx_.addr_);
-  size_t dma_size = uart->dma_buff_rx_.size_;
+  const size_t dma_size = dma_buff_rx_.size_;
+  if (dma_size == 0U)
+  {
+    return;
+  }
 
-  size_t curr_pos =
-      dma_size - __HAL_DMA_GET_COUNTER(uart_handle->hdmarx);  // 当前 DMA 写入位置
-  size_t last_pos = uart->last_rx_pos_;
+  auto* const rx_buf = static_cast<uint8_t*>(dma_buff_rx_.addr_);
+  REQUIRE_FROM_CALLBACK(rx_buf != nullptr, in_isr);
+
+  const size_t remaining = __HAL_DMA_GET_COUNTER(uart_handle_->hdmarx);
+  REQUIRE_FROM_CALLBACK(remaining <= dma_size, in_isr);
+  const size_t curr_pos = remaining == 0U ? dma_size : dma_size - remaining;
+  const size_t last_pos = last_rx_pos_;
+  REQUIRE_FROM_CALLBACK(last_pos < dma_size, in_isr);
 
   STM32_InvalidateDCacheByAddr(rx_buf, dma_size);
 
   if (curr_pos != last_pos)
   {
-    if (curr_pos > last_pos)
+    const size_t first_size =
+        curr_pos > last_pos ? curr_pos - last_pos : dma_size - last_pos;
+    const size_t second_size = curr_pos > last_pos ? 0U : curr_pos;
+    auto queue = _read_port.GetReadQueue(in_isr);
+    size_t accepted = std::min(first_size + second_size, queue.EmptySize());
+
+    if (accepted != 0U)
     {
-      // 线性接收区
-      uart->read_port_->queue_data_->PushBatch(&rx_buf[last_pos], curr_pos - last_pos);
-    }
-    else
-    {
-      // 回卷区：last→end，再从0→curr
-      uart->read_port_->queue_data_->PushBatch(&rx_buf[last_pos], dma_size - last_pos);
-      uart->read_port_->queue_data_->PushBatch(&rx_buf[0], curr_pos);
+      const size_t first_accepted = std::min(first_size, accepted);
+      if (first_accepted != 0U)
+      {
+        REQUIRE_FROM_CALLBACK(
+            queue.PushBatch(rx_buf + last_pos, first_accepted) == ErrorCode::OK, in_isr);
+        accepted -= first_accepted;
+      }
+      if (accepted != 0U)
+      {
+        REQUIRE_FROM_CALLBACK(queue.PushBatch(rx_buf, accepted) == ErrorCode::OK, in_isr);
+      }
     }
 
-    uart->last_rx_pos_ = curr_pos;
-    uart->read_port_->ProcessPendingReads(true);
+    last_rx_pos_ = curr_pos == dma_size ? 0U : curr_pos;
+    queue.Publish();
   }
 }
 
-// NOLINTNEXTLINE
+void STM32UART::TxCompleteIRQHandler()
+{
+  tx_service_.Invoke(TX_EVENT_DONE, true, [this](uint32_t events, bool in_isr)
+                     { HandleTxService(events, in_isr); });
+}
+
+void STM32UART::RxEventIRQHandler()
+{
+  tx_service_.Invoke(TX_EVENT_RX_WORK, true, [this](uint32_t events, bool in_isr)
+                     { HandleTxService(events, in_isr); });
+}
+
+void STM32UART::AbortCompleteIRQHandler()
+{
+  tx_service_.Invoke(TX_EVENT_ABORT, true, [this](uint32_t events, bool in_isr)
+                     { HandleTxService(events, in_isr); });
+}
+
+// HAL 在串口发送完成后调用此入口，此处只通知后端处理器。
+// HAL invokes this entry at UART transmission completion; only notify the service.
 void STM32_UART_ISR_Handler_TX_CPLT(stm32_uart_id_t id)
 {
   auto uart = STM32UART::map[id];
-
-  uart->tx_busy_.Clear();
-
-  Flag::ScopedRestore tx_flag(uart->in_tx_isr);
-
-  size_t pending_len = uart->dma_buff_tx_.GetPendingLength();
-
-  if (pending_len == 0)
+  if (uart != nullptr)
   {
-    return;
+    uart->TxCompleteIRQHandler();
   }
-
-  uart->dma_buff_tx_.Switch();
-
-  STM32_CleanDCacheByAddr(uart->dma_buff_tx_.ActiveBuffer(), pending_len);
-
-  uart->dma_buff_tx_.SetActiveLength(pending_len);
-  uart->tx_busy_.Set();
-
-  auto ans = HAL_UART_Transmit_DMA(
-      uart->uart_handle_, static_cast<uint8_t*>(uart->dma_buff_tx_.ActiveBuffer()),
-      pending_len);
-
-  ASSERT(ans == HAL_OK);
-
-  WriteInfoBlock& current_info = uart->write_info_active_;
-
-  if (uart->write_port_->queue_info_->Pop(current_info) != ErrorCode::OK)
-  {
-    ASSERT(false);
-    return;
-  }
-
-  uart->write_port_->Finish(true, ans == HAL_OK ? ErrorCode::OK : ErrorCode::BUSY,
-                            current_info);
-
-  WriteInfoBlock next_info;
-
-  if (uart->write_port_->queue_info_->Peek(next_info) != ErrorCode::OK)
-  {
-    return;
-  }
-
-  if (uart->write_port_->queue_data_->PopBatch(
-          reinterpret_cast<uint8_t*>(uart->dma_buff_tx_.PendingBuffer()),
-          next_info.data.size_) != ErrorCode::OK)
-  {
-    ASSERT(false);
-    return;
-  }
-
-  uart->dma_buff_tx_.SetPendingLength(next_info.data.size_);
-
-  uart->dma_buff_tx_.EnablePending();
 }
 
 extern "C" void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef* huart, uint16_t)
 {
-  STM32_UART_RX_ISR_Handler(huart);
+  auto uart = STM32UART::map[stm32_uart_get_id(huart->Instance)];
+  if (uart != nullptr)
+  {
+    uart->RxEventIRQHandler();
+  }
 }
 
 extern "C" void HAL_UART_TxCpltCallback(UART_HandleTypeDef* huart)
@@ -472,13 +588,22 @@ extern "C" __attribute__((used)) void HAL_UART_ErrorCallback(UART_HandleTypeDef*
 extern "C" void HAL_UART_AbortCpltCallback(UART_HandleTypeDef* huart)
 {
   auto uart = STM32UART::map[stm32_uart_get_id(huart->Instance)];
-  uart->last_rx_pos_ = 0;
-  HAL_UARTEx_ReceiveToIdle_DMA(huart, huart->pRxBuffPtr, uart->dma_buff_rx_.size_);
-  if (uart->tx_busy_.IsSet())
+  if (uart != nullptr)
   {
-    HAL_UART_Transmit_DMA(huart, uart->dma_buff_tx_.ActiveBuffer(),
-                          uart->dma_buff_tx_.GetActiveLength());
+    uart->AbortCompleteIRQHandler();
   }
+}
+
+void STM32UART::StartTxDma(bool in_isr)
+{
+  const size_t size = dma_buff_tx_.GetActiveLength();
+  REQUIRE_FROM_CALLBACK(size != 0U && size <= dma_buff_tx_.Size(), in_isr);
+
+  STM32_CleanDCacheByAddr(dma_buff_tx_.ActiveBuffer(), size);
+  tx_busy_.Set();
+  const HAL_StatusTypeDef status = HAL_UART_Transmit_DMA(
+      uart_handle_, static_cast<uint8_t*>(dma_buff_tx_.ActiveBuffer()), size);
+  REQUIRE_FROM_CALLBACK(status == HAL_OK, in_isr);
 }
 
 #endif

--- a/driver/st/stm32_uart.hpp
+++ b/driver/st/stm32_uart.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "main.h"
 
 #ifdef HAL_UART_MODULE_ENABLED
@@ -12,6 +14,7 @@
 #include "flag.hpp"
 #include "libxr_def.hpp"
 #include "libxr_rw.hpp"
+#include "serialized_service.hpp"
 #include "uart.hpp"
 
 typedef enum : uint8_t
@@ -112,41 +115,119 @@ stm32_uart_id_t stm32_uart_get_id(USART_TypeDef* addr);
 namespace LibXR
 {
 /**
- * @brief STM32 UART 驱动实现 / STM32 UART driver implementation
+ * @brief 使用循环接收 DMA 和双缓冲发送的 STM32 串口
+ *        / STM32 UART with circular RX DMA and double-buffered TX.
+ *
+ * 写请求完整复制到发送缓冲半区后完成，DMA 完成仅释放半区。接收持续运行，
+ * 按 DMA 位置变化向 ReadPort 发布数据；软件队列放不下的部分作为接收溢出丢弃。
+ * Writes complete once copied into a TX half; DMA completion only releases that half.
+ * RX runs continuously and publishes observed DMA bytes to ReadPort, discarding any
+ * overflow beyond available software capacity.
+ *
+ * @pre 调用遵守 ReadPort/WritePort 约定；DMA 缓冲区满足平台访问和对齐要求，运行期间有效。
+ *      Follow the port contracts. DMA buffers must meet platform access/alignment
+ *      requirements and remain valid throughout operation.
  */
 class STM32UART : public UART
 {
  public:
-  static ErrorCode WriteFun(WritePort& port, bool in_isr);
-
-  static ErrorCode ReadFun(ReadPort& port, bool in_isr);
+  /// 通知后端处理已提交的写请求 / Notify the backend of released writes.
+  static void WriteFun(WritePort& port, bool in_isr);
 
   /**
-   * @brief 构造 UART 对象 / Construct UART object
+   * @brief 构造串口并关联 DMA 缓冲区 / Construct a UART with DMA buffers.
+   * @param uart_handle 已初始化的 HAL 句柄 / Initialized HAL handle.
+   * @param dma_buff_rx 接收 DMA 缓冲区 / RX DMA buffer.
+   * @param dma_buff_tx 双缓冲发送存储，每半区容纳一个请求 / TX storage, one request per
+   * half.
+   * @param tx_queue_size 写请求队列容量，启用发送时须大于零 / Positive TX request
+   * capacity.
    */
   STM32UART(UART_HandleTypeDef* uart_handle, RawData dma_buff_rx, RawData dma_buff_tx,
             uint32_t tx_queue_size = 5);
 
-  ErrorCode SetConfig(UART::Configuration config);
+  /**
+   * @brief 提交串口配置请求 / Submit a UART configuration request.
+   * @param config 目标配置 / Requested configuration.
+   * @param in_isr 当前调用是否在中断中 / Whether this call is in an ISR.
+   * @return 接纳返回 OK，配置槽被占用返回 BUSY，参数不支持返回 ARG_ERR 或 NOT_SUPPORT。
+   *         OK on admission, BUSY for an occupied slot, ARG_ERR or NOT_SUPPORT for
+   *         unsupported settings.
+   * @note 接纳后在发送空闲时应用，期间保留已准备的 DMA 数据；不保证返回前已经生效。
+   *       Applies when TX is idle while preserving prepared DMA data. May apply after
+   * return.
+   */
+  ErrorCode SetConfig(UART::Configuration config, bool in_isr = false) override;
 
-  void SetRxDMA();
+  /// 初始化循环接收 DMA 并检查启动结果 / Initialize circular RX DMA and check startup.
+  void SetRxDMA(bool in_isr = false);
+  /// 通知发送完成，交给后端释放半区 / Notify TX completion to release the active half.
+  void TxCompleteIRQHandler();
+  /// 通知接收位置变化 / Notify RX position changes.
+  void RxEventIRQHandler();
+  /// 通知 HAL 中止完成，由后端恢复收发 / Notify HAL abort completion for backend
+  /// recovery.
+  void AbortCompleteIRQHandler();
 
+  /// 接收字节队列与读请求 / RX byte queue and read requests.
   ReadPort _read_port;
+  /// 写请求及发送字节队列 / Write requests and TX byte queue.
   WritePort _write_port;
 
+  /// 调用者提供的接收 DMA 缓冲区 / Caller-provided RX DMA buffer.
   RawData dma_buff_rx_;
+  /// 当前与待发送的 DMA 半区 / Active and pending TX DMA halves.
   DoubleBuffer dma_buff_tx_;
-  WriteInfoBlock write_info_active_;
 
+  /// 上次已处理的 DMA 接收位置 / Last processed RX DMA position.
   size_t last_rx_pos_ = 0;
 
   UART_HandleTypeDef* uart_handle_;
 
-  Flag::Plain in_tx_isr, tx_busy_;
+  /// 发送半区是否在使用，仅后端处理器访问 / TX half in use; service-only access.
+  Flag::Plain tx_busy_;
 
   stm32_uart_id_t id_ = STM32_UART_ID_ERROR;
 
   static STM32UART* map[STM32_UART_NUMBER];  // NOLINT
+
+ private:
+  /// 待应用配置的发布阶段 / Pending configuration publication phase.
+  enum class ConfigState : uint8_t
+  {
+    EMPTY = 0U,
+    RESERVED = 1U,
+    PUBLISHED = 2U,
+  };
+
+  static constexpr uint32_t TX_EVENT_WRITE = 1U << 0U;
+  static constexpr uint32_t TX_EVENT_DONE = 1U << 1U;
+  static constexpr uint32_t TX_EVENT_CONFIG = 1U << 2U;
+  static constexpr uint32_t TX_EVENT_RX_WORK = 1U << 3U;
+  static constexpr uint32_t TX_EVENT_ABORT = 1U << 4U;
+
+  /// 串行处理收发和配置通知 / Serialize RX, TX, and configuration progress.
+  void HandleTxService(uint32_t events, bool in_isr);
+  /// 填充空闲发送半区并启动 DMA / Fill available TX halves and start DMA.
+  void FillTx(bool in_isr);
+  /// 释放已发送半区，不重复完成写请求 / Release the sent half without completing again.
+  void HandleTxDone(bool in_isr);
+  /// 启动当前半区发送 / Start transmitting the active half.
+  void StartTxDma(bool in_isr);
+  /// 应用已验证配置并检查 HAL 结果 / Apply validated settings and check HAL results.
+  void ApplyConfig(UART::Configuration config, bool in_isr);
+  /// 在发送空闲边界尝试应用配置 / Try applying configuration at the TX idle boundary.
+  void TryApplyConfig(bool in_isr);
+  /// 复制可容纳的接收前缀，更新游标后发布 / Copy fitting RX bytes, advance, then publish.
+  void HandleRxData(bool in_isr);
+
+  /// 共享的收发与配置处理器 / Shared RX, TX, and configuration service.
+  SerializedService tx_service_;
+  /// 配置槽的并发发布状态 / Concurrent configuration slot state.
+  std::atomic<ConfigState> config_state_{ConfigState::EMPTY};
+  /// 由调用者发布、后端应用的配置 / Caller-published configuration for backend
+  /// application.
+  UART::Configuration pending_config_{};
 };
 
 }  // namespace LibXR

--- a/src/driver/uart.hpp
+++ b/src/driver/uart.hpp
@@ -55,9 +55,8 @@ class UART
 
   /**
    * @brief UART 构造函数 / UART constructor
-   * @param rx_buffer_size 接收缓冲区大小 / Receive buffer size
-   * @param tx_queue_size 发送队列大小 / Transmit queue size
-   * @param tx_buffer_size 发送缓冲区大小 / Transmit buffer size
+   * @param read_port 接收端口 / Read port
+   * @param write_port 发送端口 / Write port
    *
    * 该构造函数初始化 UART 的读取和写入端口。
    * This constructor initializes the read and write ports of the UART.
@@ -71,6 +70,9 @@ class UART
   /**
    * @brief 设置 UART 配置 / Sets the UART configuration
    * @param config UART 配置信息 / UART configuration settings
+   * @param in_isr 调用者是否位于中断上下文 / Whether the caller is in an ISR.
+   * @note 配置应用时机和允许的调用环境由具体后端规定。
+   *       Application timing and supported call contexts depend on the backend.
    * @return 返回操作状态，成功时返回 `ErrorCode::OK`，否则返回相应错误码 / Returns the
    * operation status, `ErrorCode::OK` if successful, otherwise an error code
    *
@@ -78,7 +80,7 @@ class UART
    * This is a pure virtual function. Subclasses must implement the specific UART
    * configuration logic.
    */
-  virtual ErrorCode SetConfig(Configuration config) = 0;
+  virtual ErrorCode SetConfig(Configuration config, bool in_isr = false) = 0;
 
   template <typename OperationType, typename = std::enable_if_t<std::is_base_of_v<
                                         WriteOperation, std::decay_t<OperationType>>>>

--- a/src/driver/usb/device/cdc/cdc_to_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_to_uart.hpp
@@ -128,8 +128,8 @@ class CDCToUart : public CDCUart
     // 5) LineCoding 回调：USB CDC 侧配置变化同步到 UART。
     // 5) LineCoding callback: forward CDC line-coding changes to UART configuration.
     set_line_coding_cb_ = LibXR::Callback<LibXR::UART::Configuration>::Create(
-        [](bool, CDCToUart* self, LibXR::UART::Configuration cfg)
-        { self->uart_.SetConfig(cfg); }, this);
+        [](bool in_isr, CDCToUart* self, LibXR::UART::Configuration cfg)
+        { self->uart_.SetConfig(cfg, in_isr); }, this);
 
     SetOnSetLineCodingCallback(set_line_coding_cb_);
 

--- a/src/driver/usb/device/cdc/cdc_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_uart.hpp
@@ -306,7 +306,7 @@ class CDCUart : public CDCBase, public LibXR::UART
    * @param cfg UART 配置 / UART configuration
    * @return 错误码 / Error code
    */
-  ErrorCode SetConfig(UART::Configuration cfg) override
+  ErrorCode SetConfig(UART::Configuration cfg, bool = false) override
   {
     auto& line_coding = GetLineCoding();
 


### PR DESCRIPTION
CH32 and STM32 UART still use the removed RW metadata and manual completion interfaces. This migrates their DMA paths to the frontend on `dev`: a complete write is copied into a stable DMA half and completed once through WriteQueue settlement; DMA completion releases that half and advances queued work.

- Serialize TX, RX publication, configuration, and STM32 abort recovery through SerializedService.
- Publish circular RX data through ReadQueue, copying only the prefix that fits and advancing the DMA observation position before callbacks. Overflow is finite backend loss, not replay or a new read error.
- Retain a single pending configuration until the TX/line-idle boundary. Preserve already prepared DMA data and keep configuration housekeeping outside public write admission.
- Restore the previously accepted QingKe 32-bit CAS fallback and interrupt guard; CH32 configuration state is 32-bit.

The **16-file dependency closure** contains four CH32/STM32 UART implementation files, two CH32 atomic support files, and ten common/signature/context adapters. `UART::SetConfig` now carries `bool in_isr = false`; every UART override is aligned and CDC-to-UART forwards its actual callback context. Existing one-argument calls remain valid. Linux, ESP, MSPM0 and CDC UART bodies are unchanged apart from signatures; their remaining backend migrations and USB lifecycle work stay separate.

Verification:

- **CH32V307:** WCH GCC 15.2.0, complete UART-only firmware compile/link against BSP `bba76c21e986ddbab51da65bec5c7045d5993745`, including FreeRTOS, real vendor SDK, current LibXR and public UART use. No undefined symbols. Uses the accepted Zaamo/ILP32F BSP flags.
- **STM32F401:** Arm GNU Toolchain 14.2.1, complete UART-only firmware compile/link against archived STM32 test BSP `bab83154a309ea76771e998703bdcc2453508f5a`, including real HAL and FreeRTOS. No undefined symbols.
- **Linux:** complete Debug build and test runner pass, including the eight Linux UART PTY tests.
- All 16 submitted files match the compiled snapshot after removing comments/formatting. clang-format 21.1.8 and `git diff --check` pass.

Target smoke applications and build scripts are task-local; no CMake/CI/test scaffolding is added to the repository. These checks prove target compilation/linkage and Linux regression results, not MCU DMA timing or physical UART behavior. No flashing was performed; STM32 families beyond the tested F401 remain unverified. TX/RX direction redesign and USB owner/lifecycle changes are excluded.

One commit on `dev`, draft pending manual review.

## Sourcery 总结

将 CH32 和 STM32 UART 后端从传统的 DMA 完成元数据迁移到面向队列范围的序列化处理，以支持传输、接收、配置和恢复。

新功能：
- 将 CH32 和 STM32 UART DMA 传输及循环接收迁移到基于队列的前端模型。
- 通过后端服务对 UART 数据处理、配置和 STM32 中止恢复进行序列化。
- 添加支持 ISR 感知的 UART 配置提交，并在安全的传输边界延迟应用配置。

错误修复：
- 通过在传输处于空闲状态前保留待处理配置，防止 UART 配置与 DMA 活动发生竞争。
- 将接收缓冲区溢出处理为有界数据丢失，同时推进 DMA 观测位置并安全发布已接收的数据。
- 恢复 CH32 QingKe 32 位原子比较交换回退实现和中断保护。

增强功能：
- 验证 CH32 和 STM32 UART 帧格式配置，并在配置更改待处理期间保留已准备的 DMA 数据。

构建：
- 添加更新后的 UART 实现所需的 CH32 原子操作支持和中断保护源文件。

杂项：
- 使所有 UART 实现和 CDC 转发与支持 ISR 感知的 SetConfig 接口保持一致，同时保留对现有单参数调用的兼容性。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将 CH32 和 STM32 UART 后端迁移到串行化的队列作用域 DMA 处理机制，并支持安全的延迟配置和有界循环 RX 数据发布。

新功能：
- 将 CH32 和 STM32 UART DMA 发送及循环接收路径迁移到基于队列的处理机制，并对后端通知进行串行化。
- 支持延迟接受 UART 配置，传播 ISR 感知的上下文，并在安全的发送边界应用配置。

错误修复：
- 防止配置更改与正在进行或已准备好的 DMA 传输发生竞争。
- 将循环 RX 队列溢出作为有界数据丢失处理，同时推进 DMA 观测位置。
- 恢复 CH32 QingKe 32 位原子比较交换的中断保护回退实现。

增强功能：
- 验证 CH32 和 STM32 UART 帧格式配置，并在配置待处理期间保留已准备好的 DMA 数据。
- 在数据复制到稳定的 DMA 存储区后完成写入，并在完成时释放 DMA 缓冲区，避免重复结算请求。
- 将 STM32 中止恢复与 TX、RX 及配置处理统一进行串行化。

构建：
- 添加 UART 后端所需的 CH32 原子操作和中断保护支持。

测试：
- 验证 CH32V307 和 STM32F401 UART 固件的完整编译与链接。
- 通过 Linux Debug 构建和 UART PTY 回归测试。

杂项：
- 使 UART 配置覆盖和 CDC 转发与 ISR 感知的配置接口保持一致，同时保留现有的单参数调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate CH32 and STM32 UART backends to serialized queue-scope DMA processing with safe deferred configuration and bounded circular-RX publication.

New Features:
- Migrate CH32 and STM32 UART DMA transmit and circular receive paths to queue-based processing with serialized backend notifications.
- Support deferred UART configuration admission with ISR-aware context propagation and application at safe transmission boundaries.

Bug Fixes:
- Prevent configuration changes from racing with active or prepared DMA transfers.
- Handle circular RX queue overflow as bounded data loss while advancing the DMA observation position.
- Restore the CH32 QingKe 32-bit atomic compare-exchange fallback with interrupt protection.

Enhancements:
- Validate CH32 and STM32 UART framing configurations and preserve prepared DMA data while configuration is pending.
- Complete writes when data is copied into stable DMA storage and release DMA buffers on completion without duplicate request settlement.
- Serialize STM32 abort recovery together with TX, RX, and configuration handling.

Build:
- Add CH32 atomic and interrupt-guard support required by the UART backend.

Tests:
- Verify complete CH32V307 and STM32F401 UART firmware compilation and linkage.
- Pass the Linux Debug build and UART PTY regression tests.

Chores:
- Align UART configuration overrides and CDC forwarding with the ISR-aware configuration interface while preserving existing one-argument calls.

</details>

</details>