### PR TITLE
feat: migrate MSPM0 UART to DMA queue scopes

### DIFF
--- a/driver/mspm0/mspm0_atomic_shim.c
+++ b/driver/mspm0/mspm0_atomic_shim.c
@@ -18,26 +18,22 @@ static inline void atomic_exit(uint32_t primask_state)
 #define UNUSED(x) (void)(x)
 
 /**
- * @brief  模拟实现 __atomic_compare_exchange_4 函数 / Simulate the
- * __atomic_compare_exchange_4 function
- * @param  ptr 指向原子变量的指针 / Pointer to the atomic variable
- * @param  expected 预期值的指针，如果比较失败会更新为实际值 / Pointer to the expected
- * value, updated with actual value if comparison fails
- * @param  desired 需要交换的新值 / The new value to be stored if the comparison succeeds
- * @param  weak 忽略参数，保留以兼容 / Ignored parameter, kept for compatibility
- * @param  success_memorder 成功时的内存顺序标志（忽略） / Memory order on success
- * (ignored)
- * @param  failure_memorder 失败时的内存顺序标志（忽略） / Memory order on failure
- * (ignored)
- * @retval 返回 1 表示成功，0 表示失败 / Returns 1 on success, 0 on failure
+ * @brief 提供单核 32 位强比较交换 / Provide single-core 32-bit strong compare-exchange.
+ * @param ptr 目标字地址 / Target word address.
+ * @param expected 预期值地址，失败时写回实际值 / Expected value, updated on failure.
+ * @param desired 成功时写入的新值 / New value on success.
+ * @param success_memorder 成功时内存顺序 / Success memory order.
+ * @param failure_memorder 失败时内存顺序 / Failure memory order.
+ * @return 比较相等时返回 true / True when the comparison matches.
+ * @note GCC 定长运行时 ABI 为五个参数，没有 weak 参数；沿用单核中断保护。
+ *       The sized GCC runtime ABI has five arguments, without weak; uses the IRQ guard.
  */
 __attribute__((weak)) _Bool __atomic_compare_exchange_4(volatile void* ptr,
                                                         void* expected,
                                                         unsigned int desired,  // NOLINT
-                                                        _Bool weak, int success_memorder,
+                                                        int success_memorder,
                                                         int failure_memorder)
 {
-  UNUSED(weak);
   UNUSED(success_memorder);
   UNUSED(failure_memorder);
 
@@ -61,6 +57,26 @@ __attribute__((weak)) _Bool __atomic_compare_exchange_4(volatile void* ptr,
 
   atomic_exit(primask);  // 恢复状态
   return result;
+}
+
+/**
+ * @brief 原子置位并返回原值 / Atomically set bits and return the previous value.
+ * @param ptr 目标字地址 / Target word address.
+ * @param val 待置位的掩码 / Bits to set.
+ * @param memorder 内存顺序，本实现使用现有单核临界区 / Ordering; uses the single-core
+ * guard.
+ * @return 更新前的值 / Value before the update.
+ */
+__attribute__((weak)) unsigned int __atomic_fetch_or_4(volatile void* ptr,
+                                                       unsigned int val, int memorder)
+{
+  UNUSED(memorder);
+  volatile unsigned int* addr = (volatile unsigned int*)ptr;
+  const uint32_t primask = atomic_enter();
+  const unsigned int previous = *addr;
+  *addr = previous | val;
+  atomic_exit(primask);
+  return previous;
 }
 
 /**

--- a/driver/mspm0/mspm0_uart.cpp
+++ b/driver/mspm0/mspm0_uart.cpp
@@ -1,58 +1,229 @@
 #include "mspm0_uart.hpp"
 
-#include <atomic>
+#include <algorithm>
+#include <cstdint>
+#include <limits>
 
 using namespace LibXR;
 
+namespace
+{
+
+constexpr uint64_t UART_UINT32_MAX = 0xFFFFFFFFULL;
+constexpr uint64_t UART_BAUD_DIVISOR_MIN = 1ULL << 6U;
+constexpr uint64_t UART_BAUD_DIVISOR_MAX = 0xFFFFULL << 6U;
+constexpr DL_DMA_Config UART_DMA_TX_CONFIG = {
+    .trigger = 0U,
+    .triggerType = DL_DMA_TRIGGER_TYPE_EXTERNAL,
+    .transferMode = DL_DMA_SINGLE_TRANSFER_MODE,
+    .extendedMode = DL_DMA_NORMAL_MODE,
+    .srcWidth = DL_DMA_WIDTH_BYTE,
+    .destWidth = DL_DMA_WIDTH_BYTE,
+    .srcIncrement = DL_DMA_ADDR_INCREMENT,
+    .destIncrement = DL_DMA_ADDR_UNCHANGED,
+};
+
+#if defined(DEVICE_HAS_DMA_FULL_CHANNEL)
+constexpr DL_DMA_Config UART_DMA_RX_CONFIG = {
+    .trigger = 0U,
+    .triggerType = DL_DMA_TRIGGER_TYPE_EXTERNAL,
+    .transferMode = DL_DMA_FULL_CH_REPEAT_SINGLE_TRANSFER_MODE,
+    .extendedMode = DL_DMA_NORMAL_MODE,
+    .srcWidth = DL_DMA_WIDTH_BYTE,
+    .destWidth = DL_DMA_WIDTH_BYTE,
+    .srcIncrement = DL_DMA_ADDR_UNCHANGED,
+    .destIncrement = DL_DMA_ADDR_INCREMENT,
+};
+#endif
+
+// 校验 DriverLib 分频算式及寄存器可表示范围 / Check divider arithmetic and register
+// range.
+bool BaudRateRepresentable(uint32_t clock_freq, uint32_t baudrate)
+{
+  if (baudrate == 0U || baudrate > (UART_UINT32_MAX / 16U))
+  {
+    return false;
+  }
+
+  const uint64_t clock = clock_freq;
+  const uint64_t baud = baudrate;
+  uint64_t divisor = 0U;
+  if ((baud * 8U) > clock)
+  {
+    if (clock > (UART_UINT32_MAX / 64U))
+    {
+      return false;
+    }
+    divisor = (clock * 64U) / (baud * 3U);
+  }
+  else if ((baud * 16U) > clock)
+  {
+    if (clock > (UART_UINT32_MAX / 8U))
+    {
+      return false;
+    }
+    const uint64_t half_baud = baud / 2U;
+    if (half_baud == 0U)
+    {
+      return false;
+    }
+    divisor = (((clock * 8U) / half_baud) + 1U) / 2U;
+  }
+  else
+  {
+    if (clock > (UART_UINT32_MAX / 8U))
+    {
+      return false;
+    }
+    divisor = (((clock * 8U) / baud) + 1U) / 2U;
+  }
+
+  return divisor >= UART_BAUD_DIVISOR_MIN && divisor <= UART_BAUD_DIVISOR_MAX;
+}
+
+// 间隔阈值覆盖最长帧内高电平和一个完整字符 / Cover the longest high span plus one
+// character.
+uint64_t GapCompare(uint32_t clock_freq, UART::Configuration config)
+{
+  if (clock_freq == 0U || config.baudrate == 0U)
+  {
+    return 0U;
+  }
+
+  const uint64_t parity_bits = config.parity == UART::Parity::NO_PARITY ? 0U : 1U;
+  const uint64_t high_bits = config.data_bits + parity_bits + config.stop_bits;
+  const uint64_t gap_bits = high_bits + (1U + high_bits);
+  const uint64_t numerator = static_cast<uint64_t>(clock_freq) * gap_bits;
+  return (numerator / config.baudrate) + ((numerator % config.baudrate) != 0U ? 1U : 0U);
+}
+
+}  // namespace
+
 MSPM0UART* MSPM0UART::instance_map_[MAX_UART_INSTANCES] = {nullptr};
 
-static constexpr uint32_t MSPM0_UART_RX_ERROR_INTERRUPT_MASK =
-    DL_UART_INTERRUPT_OVERRUN_ERROR | DL_UART_INTERRUPT_BREAK_ERROR |
-    DL_UART_INTERRUPT_PARITY_ERROR | DL_UART_INTERRUPT_FRAMING_ERROR |
-    DL_UART_INTERRUPT_NOISE_ERROR;
-
-static constexpr uint32_t MSPM0_UART_BASE_INTERRUPT_MASK =
-    // RX/TX + 地址匹配 + 错误中断；超时中断按需在 Read() 时动态开关 / RX, TX,
-    // address-match and error IRQs; timeout IRQ is enabled on demand in Read().
-    DL_UART_INTERRUPT_RX | DL_UART_INTERRUPT_TX | DL_UART_INTERRUPT_ADDRESS_MATCH |
-    MSPM0_UART_RX_ERROR_INTERRUPT_MASK;
-
-MSPM0UART::MSPM0UART(Resources res, RawData rx_stage_buffer, uint32_t tx_queue_size,
-                     uint32_t tx_buffer_size, UART::Configuration config)
+MSPM0UART::MSPM0UART(Resources res, RawData tx_dma_storage, RawData rx_dma_storage,
+                     uint32_t tx_queue_size, uint32_t rx_queue_capacity,
+                     UART::Configuration config)
     : UART(&_read_port, &_write_port),
-      _read_port(rx_stage_buffer.size_),
-      _write_port(tx_queue_size, tx_buffer_size),
-      res_(res)
+      _read_port(rx_queue_capacity),
+      _write_port(tx_queue_size, tx_dma_storage.size_ / 2U),
+      res_(res),
+      tx_dma_storage_(tx_dma_storage),
+      rx_dma_storage_(rx_dma_storage),
+      tx_half_size_(tx_dma_storage.size_ / 2U)
 {
-  ASSERT(res_.instance != nullptr);
-  ASSERT(res_.clock_freq > 0);
-  ASSERT(rx_stage_buffer.addr_ != nullptr);
-  ASSERT(rx_stage_buffer.size_ > 0);
-  ASSERT(tx_queue_size > 0);
-  ASSERT(tx_buffer_size > 0);
+  REQUIRE(res_.instance != nullptr);
+  REQUIRE(res_.clock_freq > 0U);
+  REQUIRE(res_.index < MAX_UART_INSTANCES);
+  REQUIRE(res_.index == ResolveIndex(res_.irqn));
+  REQUIRE(instance_map_[res_.index] == nullptr);
+  REQUIRE(tx_dma_storage_.addr_ != nullptr);
+  REQUIRE(tx_dma_storage_.size_ > 1U);
+  REQUIRE((tx_dma_storage_.size_ % 2U) == 0U);
+  REQUIRE((reinterpret_cast<uintptr_t>(tx_dma_storage_.addr_) % alignof(size_t)) == 0U);
+  REQUIRE((tx_dma_storage_.size_ % (2U * alignof(size_t))) == 0U);
+  REQUIRE(tx_half_size_ <= MSPM0_UART_DMA_MAX_TRANSFER_SIZE);
+  REQUIRE(tx_queue_size > 0U);
+  REQUIRE(rx_queue_capacity > 0U);
 
-  _read_port = ReadFun;
+  if (res_.rx_mode == RxMode::EXTEND_DMA)
+  {
+    REQUIRE(rx_dma_storage_.addr_ != nullptr);
+    REQUIRE(rx_dma_storage_.size_ > 1U);
+    REQUIRE((rx_dma_storage_.size_ % 2U) == 0U);
+    REQUIRE(rx_dma_storage_.size_ <= MSPM0_UART_DMA_MAX_TRANSFER_SIZE);
+    REQUIRE(res_.dma_rx_channel < DMA_SYS_N_DMA_FULL_CHANNEL);
+  }
+  else
+  {
+    REQUIRE(rx_dma_storage_.addr_ == nullptr);
+    REQUIRE(rx_dma_storage_.size_ == 0U);
+    REQUIRE(!res_.rx_half_interrupt);
+    REQUIRE(res_.dma_rx_channel == INVALID_DMA_CHANNEL);
+  }
+
+  REQUIRE(res_.dma_tx_channel < MAX_DMA_CHANNELS);
+  REQUIRE(res_.dma_tx_trigger != 0U);
+  if (res_.rx_mode == RxMode::EXTEND_DMA)
+  {
+    REQUIRE(res_.dma_rx_channel < MAX_DMA_CHANNELS);
+    REQUIRE(res_.dma_rx_channel != res_.dma_tx_channel);
+    REQUIRE(res_.dma_rx_trigger != 0U);
+    REQUIRE(res_.dma_rx_trigger != res_.dma_tx_trigger);
+    REQUIRE(!res_.rx_half_interrupt || res_.dma_rx_channel < 8U);
+  }
+
+  for (const MSPM0UART* other : instance_map_)
+  {
+    if (other == nullptr)
+    {
+      continue;
+    }
+
+    REQUIRE(res_.dma_tx_channel != other->res_.dma_tx_channel);
+    if (other->res_.rx_mode == RxMode::EXTEND_DMA)
+    {
+      REQUIRE(res_.dma_tx_channel != other->res_.dma_rx_channel);
+    }
+
+    if (res_.rx_mode == RxMode::EXTEND_DMA)
+    {
+      REQUIRE(res_.dma_rx_channel != other->res_.dma_tx_channel);
+      if (other->res_.rx_mode == RxMode::EXTEND_DMA)
+      {
+        REQUIRE(res_.dma_rx_channel != other->res_.dma_rx_channel);
+      }
+    }
+  }
+
+  REQUIRE(ValidateConfig(config) == ErrorCode::OK);
+  _read_port.SetOwner(this);
   _write_port = WriteFun;
 
-  ASSERT(res_.index < MAX_UART_INSTANCES);
-  ASSERT(instance_map_[res_.index] == nullptr);
-  instance_map_[res_.index] = this;
-
+  NVIC_DisableIRQ(res_.irqn);
   NVIC_ClearPendingIRQ(res_.irqn);
-  NVIC_EnableIRQ(res_.irqn);
+  ConfigureTxDma();
+  ApplyConfig(config);
+  if (res_.rx_mode == RxMode::EXTEND_DMA)
+  {
+    ConfigureRxDma();
+  }
+  instance_map_[res_.index] = this;
+  StartDataPath();
 
-  const ErrorCode SET_CFG_ANS = SetConfig(config);
-  ASSERT(SET_CFG_ANS == ErrorCode::OK);
+  NVIC_EnableIRQ(res_.irqn);
+}
+
+ErrorCode MSPM0UART::ValidateConfig(UART::Configuration config) const
+{
+  if (!BaudRateRepresentable(res_.clock_freq, config.baudrate) || config.data_bits < 5U ||
+      config.data_bits > 8U || (config.stop_bits != 1U && config.stop_bits != 2U))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+  if (config.parity != UART::Parity::NO_PARITY && config.parity != UART::Parity::EVEN &&
+      config.parity != UART::Parity::ODD)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+  if (res_.rx_mode == RxMode::EXTEND_DMA)
+  {
+    const uint64_t gap = GapCompare(res_.clock_freq, config);
+    if (gap == 0U || gap > std::numeric_limits<uint16_t>::max())
+    {
+      return ErrorCode::ARG_ERR;
+    }
+  }
+  return ErrorCode::OK;
 }
 
 UART::Configuration MSPM0UART::BuildConfigFromSysCfg(UART_Regs* instance,
                                                      uint32_t baudrate)
 {
-  ASSERT(instance != nullptr);
-  ASSERT(baudrate > 0U);
+  REQUIRE(instance != nullptr);
+  REQUIRE(baudrate > 0U);
 
   UART::Configuration config = {baudrate, UART::Parity::NO_PARITY, 8U, 1U};
-
   switch (DL_UART_getWordLength(instance))
   {
     case DL_UART_WORD_LENGTH_5_BITS:
@@ -82,564 +253,569 @@ UART::Configuration MSPM0UART::BuildConfigFromSysCfg(UART_Regs* instance,
       config.parity = UART::Parity::ODD;
       break;
     default:
-      // LibXR UART config only supports none/even/odd parity.
-      ASSERT(false);
-      config.parity = UART::Parity::NO_PARITY;
+      REQUIRE(false);
       break;
   }
-
-  config.stop_bits = (DL_UART_getStopBits(instance) == DL_UART_STOP_BITS_TWO) ? 2U : 1U;
+  config.stop_bits = DL_UART_getStopBits(instance) == DL_UART_STOP_BITS_TWO ? 2U : 1U;
   return config;
 }
 
-ErrorCode MSPM0UART::SetConfig(UART::Configuration config, bool)
+ErrorCode MSPM0UART::SetConfig(UART::Configuration config, bool in_isr)
 {
-  if (config.baudrate == 0)
+  const ErrorCode validation = ValidateConfig(config);
+  if (validation != ErrorCode::OK)
   {
-    return ErrorCode::ARG_ERR;
+    return validation;
   }
 
-  if (config.data_bits < 5 || config.data_bits > 8)
+  ConfigState expected = ConfigState::EMPTY;
+  if (!config_state_.compare_exchange_strong(expected, ConfigState::RESERVED,
+                                             std::memory_order_acq_rel,
+                                             std::memory_order_acquire))
   {
-    return ErrorCode::ARG_ERR;
+    return ErrorCode::BUSY;
   }
 
-  if (config.stop_bits != 1 && config.stop_bits != 2)
-  {
-    return ErrorCode::ARG_ERR;
-  }
-
-  DL_UART_WORD_LENGTH word_length = DL_UART_WORD_LENGTH_8_BITS;
-  switch (config.data_bits)
-  {
-    case 5:
-      word_length = DL_UART_WORD_LENGTH_5_BITS;
-      break;
-    case 6:
-      word_length = DL_UART_WORD_LENGTH_6_BITS;
-      break;
-    case 7:
-      word_length = DL_UART_WORD_LENGTH_7_BITS;
-      break;
-    case 8:
-      word_length = DL_UART_WORD_LENGTH_8_BITS;
-      break;
-    default:
-      return ErrorCode::ARG_ERR;
-  }
-
-  DL_UART_PARITY parity = DL_UART_PARITY_NONE;
-  switch (config.parity)
-  {
-    case UART::Parity::NO_PARITY:
-      parity = DL_UART_PARITY_NONE;
-      break;
-    case UART::Parity::EVEN:
-      parity = DL_UART_PARITY_EVEN;
-      break;
-    case UART::Parity::ODD:
-      parity = DL_UART_PARITY_ODD;
-      break;
-    default:
-      return ErrorCode::ARG_ERR;
-  }
-
-  const DL_UART_STOP_BITS STOP_BITS =
-      (config.stop_bits == 2) ? DL_UART_STOP_BITS_TWO : DL_UART_STOP_BITS_ONE;
-
-  DL_UART_changeConfig(res_.instance);
-
-  DL_UART_setWordLength(res_.instance, word_length);
-  DL_UART_setParityMode(res_.instance, parity);
-  DL_UART_setStopBits(res_.instance, STOP_BITS);
-
-  DL_UART_enableFIFOs(res_.instance);
-  DL_UART_setTXFIFOThreshold(res_.instance, DL_UART_TX_FIFO_LEVEL_ONE_ENTRY);
-
-  DL_UART_configBaudRate(res_.instance, res_.clock_freq, config.baudrate);
-
-  ApplyRxTimeoutMode();
-
-  DL_UART_clearInterruptStatus(res_.instance, 0xFFFFFFFF);
-  DL_UART_enableInterrupt(res_.instance, MSPM0_UART_BASE_INTERRUPT_MASK);
-  DL_UART_disableInterrupt(res_.instance,
-                           DL_UART_INTERRUPT_TX | GetTimeoutInterruptMask());
-
-  tx_active_valid_ = false;
-  tx_active_remaining_ = 0;
-  tx_active_total_ = 0;
-
-  DL_UART_enable(res_.instance);
-
+  // 配置内容通过下方事件发布，由处理器将槽标记为 PUBLISHED。
+  // Publish the payload through the event; the service marks the slot PUBLISHED.
+  pending_config_ = config;
+  service_.Invoke(EVENT_CONFIG, in_isr, [this](uint32_t events, bool owner_in_isr)
+                  { HandleService(events, owner_in_isr); });
   return ErrorCode::OK;
 }
 
-ErrorCode MSPM0UART::WriteFun(WritePort& port, bool)
+void MSPM0UART::WriteFun(WritePort& port, bool in_isr)
 {
   auto* uart = LibXR::ContainerOf(&port, &MSPM0UART::_write_port);
-  DL_UART_enableInterrupt(uart->res_.instance, DL_UART_INTERRUPT_TX);
-  uart->res_.instance->CPU_INT.ISET = DL_UART_INTERRUPT_TX;
-  return ErrorCode::PENDING;
+  uart->service_.Invoke(EVENT_WRITE, in_isr, [uart](uint32_t events, bool owner_in_isr)
+                        { uart->HandleService(events, owner_in_isr); });
 }
 
-ErrorCode MSPM0UART::ReadFun(ReadPort& port, bool)
+void MSPM0UART::NotifyReadSpace(bool in_isr)
 {
-  auto* uart = LibXR::ContainerOf(&port, &MSPM0UART::_read_port);
-  const uint32_t TIMEOUT_MASK = uart->GetTimeoutInterruptMask();
-  if (TIMEOUT_MASK != 0U)
+  service_.Invoke(EVENT_RX_WORK, in_isr, [this](uint32_t events, bool owner_in_isr)
+                  { HandleService(events, owner_in_isr); });
+}
+
+void MSPM0UART::HandleService(uint32_t events, bool in_isr)
+{
+  if ((events & EVENT_CONFIG) != 0U)
   {
-    // 仅在有挂起读请求时启用超时中断，避免空闲无效触发 / Enable timeout IRQ
-    // only when a read request is pending to avoid idle false triggers.
-    if (uart->rx_timeout_mode_ == RxTimeoutMode::LIN_COMPARE)
+    REQUIRE_FROM_CALLBACK(
+        config_state_.load(std::memory_order_acquire) == ConfigState::RESERVED, in_isr);
+    config_state_.store(ConfigState::PUBLISHED, std::memory_order_release);
+  }
+
+  if ((events & EVENT_DMA_DONE_TX) != 0U)
+  {
+    HandleTxDone(in_isr);
+  }
+
+  if ((events & EVENT_RX_WORK) != 0U)
+  {
+    HandleRxWork(in_isr);
+  }
+
+  if ((events & (EVENT_CONFIG | EVENT_DMA_DONE_TX | EVENT_EOT_DONE | EVENT_RX_WORK)) !=
+      0U)
+  {
+    TryApplyPublishedConfig(in_isr);
+  }
+
+  if (events != 0U && config_state_.load(std::memory_order_acquire) == ConfigState::EMPTY)
+  {
+    if ((events & (EVENT_WRITE | EVENT_DMA_DONE_TX | EVENT_CONFIG | EVENT_EOT_DONE)) !=
+        0U)
     {
-      // 以本次 Read 请求开始作为超时计时起点 / Start timeout timing from this
-      // Read request boundary.
-      uart->ResetLinCounter();
+      FillTx(in_isr);
     }
-
-    DL_UART_clearInterruptStatus(uart->res_.instance, TIMEOUT_MASK);
-    DL_UART_enableInterrupt(uart->res_.instance, TIMEOUT_MASK);
-  }
-
-  return ErrorCode::PENDING;
-}
-
-MSPM0UART::RxTimeoutMode MSPM0UART::ResolveRxTimeoutMode() const
-{
-  // 分发规则 / Dispatch rule:
-  // 1) [LIN路径 / LIN path] UART0 且存在 LIN compare 宏配置 -> LIN_COMPARE
-  // 2) [LIN路径 / LIN path] 运行时探测到 LIN counter+compare 已启用 -> LIN_COMPARE
-  // 3) [BYTE路径 / BYTE path] 其他情况 -> BYTE_INTERRUPT
-#if defined(UART_0_INST) && defined(UART_0_COUNTER_COMPARE_VALUE)
-  if (res_.instance == UART_0_INST)
-  {
-    // 本项目 UART0 在 SysConfig 中配置为 LIN 扩展实例 / UART0 is configured as a
-    // LIN extend instance by SysConfig in this project.
-    // [LIN路径 / LIN path] 固定走 LIN compare / Force LIN compare path.
-    return RxTimeoutMode::LIN_COMPARE;
-  }
-#endif
-
-  if (DL_UART_isLINCounterEnabled(res_.instance) &&
-      DL_UART_isLINCounterCompareMatchEnabled(res_.instance))
-  {
-    // [LIN路径 / LIN path] 非 UART0 按寄存器能力探测：若 LIN counter+compare
-    // 已启用则走 LIN /
-    // For non-UART0, use LIN path when LIN counter+compare are already enabled.
-    return RxTimeoutMode::LIN_COMPARE;
-  }
-
-  // [BYTE路径 / BYTE path] 不满足 LIN 条件时回落到按字节中断路径 /
-  // Fall back to byte-interrupt path when LIN conditions are not met.
-  return RxTimeoutMode::BYTE_INTERRUPT;
-}
-
-uint32_t MSPM0UART::GetTimeoutInterruptMask() const
-{
-  switch (rx_timeout_mode_)
-  {
-    // [LIN路径 / LIN path] 使用 LINC0 compare match 作为帧间超时事件 /
-    // Use LINC0 compare match as frame-gap timeout event.
-    case RxTimeoutMode::LIN_COMPARE:
-      return DL_UART_INTERRUPT_LINC0_MATCH;
-    // [BYTE路径 / BYTE path] 不使用硬件超时中断 /
-    // No hardware timeout interrupt in byte-interrupt mode.
-    case RxTimeoutMode::BYTE_INTERRUPT:
-    default:
-      return 0;
   }
 }
 
-uint32_t MSPM0UART::GetTimeoutInterruptEnabledMask() const
+void MSPM0UART::FillTx(bool in_isr)
 {
-  const uint32_t TIMEOUT_MASK = GetTimeoutInterruptMask();
-  if (TIMEOUT_MASK == 0U)
+  while (config_state_.load(std::memory_order_acquire) == ConfigState::EMPTY)
   {
-    return 0U;
-  }
-  return DL_UART_getEnabledInterrupts(res_.instance, TIMEOUT_MASK);
-}
-
-uint32_t MSPM0UART::GetTimeoutInterruptMaskedStatus() const
-{
-  const uint32_t TIMEOUT_MASK = GetTimeoutInterruptMask();
-  if (TIMEOUT_MASK == 0U)
-  {
-    return 0U;
-  }
-  return DL_UART_getEnabledInterruptStatus(res_.instance, TIMEOUT_MASK);
-}
-
-uint32_t MSPM0UART::GetTimeoutInterruptRawStatus() const
-{
-  const uint32_t TIMEOUT_MASK = GetTimeoutInterruptMask();
-  if (TIMEOUT_MASK == 0U)
-  {
-    return 0U;
-  }
-  return DL_UART_getRawInterruptStatus(res_.instance, TIMEOUT_MASK);
-}
-
-uint32_t MSPM0UART::GetRxInterruptTimeoutValue() const
-{
-  return DL_UART_getRXInterruptTimeout(res_.instance);
-}
-
-uint32_t MSPM0UART::GetRxFifoThresholdValue() const
-{
-  return static_cast<uint32_t>(DL_UART_getRXFIFOThreshold(res_.instance));
-}
-
-void MSPM0UART::ResetLinCounter()
-{
-  if (rx_timeout_mode_ == RxTimeoutMode::LIN_COMPARE)
-  {
-    DL_UART_setLINCounterValue(res_.instance, 0);
-  }
-}
-
-void MSPM0UART::ApplyRxTimeoutMode()
-{
-  rx_timeout_mode_ = ResolveRxTimeoutMode();
-
-  // 基础 UART 配置对 LIN/BYTE 两条路径一致，先统一配置后再处理模式差异 /
-  // Apply shared UART settings first, then patch mode-specific differences.
-  DL_UART_setCommunicationMode(res_.instance, DL_UART_MODE_NORMAL);
-  DL_UART_setAddressMask(res_.instance, 0U);
-  DL_UART_setAddress(res_.instance, 0U);
-  DL_UART_setRXFIFOThreshold(res_.instance, DL_UART_RX_FIFO_LEVEL_ONE_ENTRY);
-  DL_UART_setRXInterruptTimeout(res_.instance, 0U);
-
-  switch (rx_timeout_mode_)
-  {
-    // [LIN路径 / LIN path] 使能 LIN counter/compare，超时事件来自 LINC0_MATCH。
-    // [LIN路径 / LIN path] Enable LIN counter/compare; timeout event is LINC0_MATCH.
-    case RxTimeoutMode::LIN_COMPARE:
-      if (!DL_UART_isLINCounterEnabled(res_.instance))
+    if (active_half_ < 0)
+    {
+      for (uint8_t half = 0U; half < 2U; ++half)
       {
-        DL_UART_enableLINCounter(res_.instance);
-      }
-      if (!DL_UART_isLINCounterCompareMatchEnabled(res_.instance))
-      {
-        DL_UART_enableLINCounterCompareMatch(res_.instance);
-      }
-#if defined(UART_0_COUNTER_COMPARE_VALUE)
-      DL_UART_setLINCounterCompareValue(res_.instance, UART_0_COUNTER_COMPARE_VALUE);
-#endif
-      DL_UART_disableLINCountWhileLow(res_.instance);
-      ResetLinCounter();
-      break;
-
-    // [BYTE路径 / BYTE path] 仅保留按字节 RX 中断，不依赖超时中断。
-    // [BYTE路径 / BYTE path] Keep plain per-byte RX interrupt; no timeout IRQ.
-    case RxTimeoutMode::BYTE_INTERRUPT:
-    default:
-      break;
-  }
-}
-
-void MSPM0UART::OnInterrupt(uint8_t index)
-{
-  if (index >= MAX_UART_INSTANCES)
-  {
-    return;
-  }
-
-  auto* uart = instance_map_[index];
-  if (uart == nullptr)
-  {
-    return;
-  }
-
-  uart->HandleInterrupt();
-}
-
-void MSPM0UART::HandleInterrupt()
-{
-  const uint32_t TIMEOUT_MASK = GetTimeoutInterruptMask();
-  const uint32_t IRQ_MASK = MSPM0_UART_BASE_INTERRUPT_MASK | TIMEOUT_MASK;
-
-  uint32_t pending = DL_UART_getEnabledInterruptStatus(res_.instance, IRQ_MASK);
-  if (TIMEOUT_MASK != 0U)
-  {
-    // LIN compare 在部分路径需读取 RAW 位，避免漏掉超时事件 / For LIN
-    // compare, raw status is required on some paths to avoid missing timeout events.
-    pending |= DL_UART_getRawInterruptStatus(res_.instance, TIMEOUT_MASK);
-  }
-
-  const uint32_t PENDING = pending;
-  if (PENDING == 0U)
-  {
-    return;
-  }
-
-  constexpr uint32_t RX_PENDING_MASK =
-      DL_UART_INTERRUPT_RX | DL_UART_INTERRUPT_ADDRESS_MATCH;
-  if ((PENDING & RX_PENDING_MASK) != 0U)
-  {
-    HandleRxInterrupt(TIMEOUT_MASK);
-    if ((PENDING & DL_UART_INTERRUPT_ADDRESS_MATCH) != 0U)
-    {
-      DL_UART_clearInterruptStatus(res_.instance, DL_UART_INTERRUPT_ADDRESS_MATCH);
-    }
-  }
-
-  if (TIMEOUT_MASK != 0U)
-  {
-    HandleRxTimeoutInterrupt(PENDING, TIMEOUT_MASK);
-  }
-
-  if ((PENDING & DL_UART_INTERRUPT_OVERRUN_ERROR) != 0U)
-  {
-    HandleErrorInterrupt(DL_UART_IIDX_OVERRUN_ERROR);
-  }
-  if ((PENDING & DL_UART_INTERRUPT_BREAK_ERROR) != 0U)
-  {
-    HandleErrorInterrupt(DL_UART_IIDX_BREAK_ERROR);
-  }
-  if ((PENDING & DL_UART_INTERRUPT_PARITY_ERROR) != 0U)
-  {
-    HandleErrorInterrupt(DL_UART_IIDX_PARITY_ERROR);
-  }
-  if ((PENDING & DL_UART_INTERRUPT_FRAMING_ERROR) != 0U)
-  {
-    HandleErrorInterrupt(DL_UART_IIDX_FRAMING_ERROR);
-  }
-  if ((PENDING & DL_UART_INTERRUPT_NOISE_ERROR) != 0U)
-  {
-    HandleErrorInterrupt(DL_UART_IIDX_NOISE_ERROR);
-  }
-
-  if ((PENDING & DL_UART_INTERRUPT_TX) != 0U)
-  {
-    HandleTxInterrupt(true);
-  }
-}
-
-void MSPM0UART::HandleRxInterrupt(uint32_t timeout_mask)
-{
-  bool pushed = false;
-  bool received = false;
-
-  DrainRxFIFO(received, pushed);
-
-  if (received && rx_timeout_mode_ == RxTimeoutMode::LIN_COMPARE)
-  {
-    // [LIN路径 / LIN path] 连续接收时重置 LIN 计数器，避免帧内误超时 /
-    // Reset LIN counter on data reception to avoid in-frame timeout.
-    ResetLinCounter();
-  }
-
-  if (pushed)
-  {
-    read_port_->ProcessPendingReads(true);
-  }
-
-  if (timeout_mask != 0U &&
-      read_port_->busy_.load(std::memory_order_relaxed) != ReadPort::BusyState::PENDING)
-  {
-    // 无挂起读请求时关闭超时中断，减少无意义 IRQ / Disable timeout IRQ when no
-    // pending read remains.
-    DL_UART_disableInterrupt(res_.instance, timeout_mask);
-    DL_UART_clearInterruptStatus(res_.instance, timeout_mask);
-  }
-
-  DL_UART_clearInterruptStatus(res_.instance, DL_UART_INTERRUPT_RX);
-}
-
-void MSPM0UART::DrainRxFIFO(bool& received, bool& pushed)
-{
-  while (!DL_UART_isRXFIFOEmpty(res_.instance))
-  {
-    const uint8_t RX_BYTE = DL_UART_receiveData(res_.instance);
-    received = true;
-
-    if (read_port_->queue_data_->Push(RX_BYTE) == ErrorCode::OK)
-    {
-      pushed = true;
-    }
-    else
-    {
-      rx_drop_count_++;
-    }
-  }
-}
-
-void MSPM0UART::HandleRxTimeoutInterrupt(uint32_t pending, uint32_t timeout_mask)
-{
-  // [BYTE路径 / BYTE path] timeout_mask=0，直接返回；本函数实际只在 LIN 路径生效。
-  // In BYTE path timeout_mask is 0, so this function is effectively LIN-only.
-  if ((timeout_mask == 0U) || ((pending & timeout_mask) == 0U))
-  {
-    return;
-  }
-
-  rx_timeout_count_++;
-  DL_UART_clearInterruptStatus(res_.instance, pending & timeout_mask);
-
-  // FULL 阈值模式下短帧可能滞留在 HW FIFO，直到超时中断到来 / In
-  // FULL-threshold modes, short frames may remain in HW FIFO until timeout IRQ.
-  // 先拉取 FIFO，让已有数据先走正常队列完成路径 / Drain FIFO first so already
-  // received bytes take the normal queue-completion path.
-  bool pushed = false;
-  bool received = false;
-
-  DrainRxFIFO(received, pushed);
-
-  if (pushed)
-  {
-    read_port_->ProcessPendingReads(true);
-  }
-
-  if (rx_timeout_mode_ == RxTimeoutMode::LIN_COMPARE)
-  {
-    ResetLinCounter();
-  }
-
-  // Timeout is a frame/readiness boundary, not a read error. Read(size=0) waiters
-  // complete through ProcessPendingReads() once bytes are queued; exact-size reads keep
-  // waiting until enough bytes arrive or their own BLOCK timeout fires.
-  DL_UART_disableInterrupt(res_.instance, timeout_mask);
-}
-
-void MSPM0UART::HandleTxInterrupt(bool in_isr)
-{
-  // 发送状态机：取写请求并尽量填满 TX FIFO，直到该请求完成 / TX state machine:
-  // fetch one write request and keep filling TX FIFO until it completes.
-  while (true)
-  {
-    if (!tx_active_valid_)
-    {
-      if (write_port_->queue_info_->Pop(tx_active_info_) != ErrorCode::OK)
-      {
-        DisableTxInterrupt();
-
-        if (write_port_->queue_info_->Size() > 0)
+        if (tx_half_size_used_[half] != 0U)
         {
-          DL_UART_enableInterrupt(res_.instance, DL_UART_INTERRUPT_TX);
-          res_.instance->CPU_INT.ISET = DL_UART_INTERRUPT_TX;
+          if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+          {
+            return;
+          }
+          active_half_ = static_cast<int8_t>(half);
+          StartTxDma(half, tx_half_size_used_[half]);
+          break;
         }
-
-        return;
       }
-
-      tx_active_total_ = tx_active_info_.data.size_;
-      tx_active_remaining_ = tx_active_total_;
-      tx_active_valid_ = true;
     }
 
-    while (tx_active_remaining_ > 0 && !DL_UART_isTXFIFOFull(res_.instance))
+    uint8_t free_half = INVALID_DMA_CHANNEL;
+    for (uint8_t i = 0U; i < 2U; ++i)
     {
-      uint8_t tx_byte = 0;
-      if (write_port_->queue_data_->Pop(tx_byte) != ErrorCode::OK)
+      if (tx_half_size_used_[i] == 0U)
       {
-        write_port_->Finish(in_isr, ErrorCode::FAILED, tx_active_info_);
-        tx_active_valid_ = false;
-        tx_active_remaining_ = 0;
-        tx_active_total_ = 0;
-        DisableTxInterrupt();
-        return;
+        free_half = i;
+        break;
       }
-
-      DL_UART_transmitData(res_.instance, tx_byte);
-      tx_active_remaining_--;
     }
-
-    if (tx_active_remaining_ > 0)
+    if (free_half == INVALID_DMA_CHANNEL)
     {
       return;
     }
 
-    write_port_->Finish(in_isr, ErrorCode::OK, tx_active_info_);
-    tx_active_valid_ = false;
-    tx_active_remaining_ = 0;
-    tx_active_total_ = 0;
+    size_t size = 0U;
+    {
+      auto queue = _write_port.GetWriteQueue(in_isr);
+      if (queue.Empty())
+      {
+        return;
+      }
+      if (config_state_.load(std::memory_order_acquire) != ConfigState::EMPTY)
+      {
+        return;
+      }
+
+      size = queue.AvailableSize();
+      REQUIRE_FROM_CALLBACK(size > 0U && size <= tx_half_size_, in_isr);
+      queue.PopAll(TxHalf(free_half));
+      tx_half_size_used_[free_half] = size;
+    }
+
+    if (active_half_ < 0 &&
+        config_state_.load(std::memory_order_acquire) == ConfigState::EMPTY)
+    {
+      active_half_ = static_cast<int8_t>(free_half);
+      StartTxDma(free_half, size);
+    }
   }
 }
 
-void MSPM0UART::HandleErrorInterrupt(DL_UART_IIDX iidx)
+void MSPM0UART::HandleTxDone(bool in_isr)
 {
-  uint32_t clear_mask = 0;
+  REQUIRE_FROM_CALLBACK(active_half_ >= 0 && active_half_ < 2, in_isr);
+  const uint8_t completed = static_cast<uint8_t>(active_half_);
+  tx_half_size_used_[completed] = 0U;
+  active_half_ = -1;
 
-  switch (iidx)
+  const uint8_t next = completed ^ 1U;
+  if (tx_half_size_used_[next] != 0U &&
+      config_state_.load(std::memory_order_acquire) == ConfigState::EMPTY)
   {
-    case DL_UART_IIDX_OVERRUN_ERROR:
-      clear_mask = DL_UART_INTERRUPT_OVERRUN_ERROR;
-      break;
+    active_half_ = static_cast<int8_t>(next);
+    StartTxDma(next, tx_half_size_used_[next]);
+  }
+  else
+  {
+    DL_UART_disableInterrupt(res_.instance, TX_DONE_INTERRUPT_MASK);
+    DL_UART_disableDMATransmitEvent(res_.instance);
+  }
+}
 
-    case DL_UART_IIDX_BREAK_ERROR:
-      clear_mask = DL_UART_INTERRUPT_BREAK_ERROR;
-      break;
+void MSPM0UART::HandleRxWork(bool in_isr)
+{
+  if (res_.rx_mode == RxMode::MAIN_BYTE_IRQ)
+  {
+    HandleMainRx(in_isr);
+  }
+  else
+  {
+    HandleExtendRx(in_isr);
+  }
+}
 
-    case DL_UART_IIDX_PARITY_ERROR:
-      clear_mask = DL_UART_INTERRUPT_PARITY_ERROR;
-      break;
+void MSPM0UART::HandleMainRx(bool in_isr)
+{
+  auto queue = _read_port.GetReadQueue(in_isr);
+  if (queue.EmptySize() != 0U)
+  {
+    DL_UART_enableInterrupt(res_.instance, RX_INTERRUPT_MASK);
+  }
 
-    case DL_UART_IIDX_FRAMING_ERROR:
-      clear_mask = DL_UART_INTERRUPT_FRAMING_ERROR;
+  while (!DL_UART_isRXFIFOEmpty(res_.instance))
+  {
+    if (queue.EmptySize() == 0U)
+    {
+      DL_UART_disableInterrupt(res_.instance, RX_INTERRUPT_MASK);
       break;
+    }
 
-    case DL_UART_IIDX_NOISE_ERROR:
-      clear_mask = DL_UART_INTERRUPT_NOISE_ERROR;
+    const uint8_t byte = DL_UART_receiveData(res_.instance);
+    REQUIRE_FROM_CALLBACK(queue.PushBatch(&byte, 1U) == ErrorCode::OK, in_isr);
+  }
+  queue.Publish();
+}
+
+void MSPM0UART::HandleExtendRx(bool in_isr)
+{
+  const size_t capacity = RxCapacity();
+  REQUIRE_FROM_CALLBACK(capacity > 1U, in_isr);
+
+  const uint32_t remaining = DL_DMA_getTransferSize(DMA, res_.dma_rx_channel);
+  REQUIRE_FROM_CALLBACK(remaining <= capacity, in_isr);
+
+  const size_t position = remaining == 0U ? capacity : capacity - remaining;
+  const size_t cursor = rx_dma_cursor_;
+  REQUIRE_FROM_CALLBACK(cursor < capacity, in_isr);
+
+  const size_t first_size = position >= cursor ? position - cursor : capacity - cursor;
+  const size_t second_size = position >= cursor ? 0U : position;
+  const size_t observed = first_size + second_size;
+
+  auto queue = _read_port.GetReadQueue(in_isr);
+  size_t accepted = std::min(observed, queue.EmptySize());
+  size_t first_accepted = std::min(first_size, accepted);
+  if (first_accepted != 0U)
+  {
+    auto* source = static_cast<const uint8_t*>(rx_dma_storage_.addr_) + cursor;
+    REQUIRE_FROM_CALLBACK(queue.PushBatch(source, first_accepted) == ErrorCode::OK,
+                          in_isr);
+    accepted -= first_accepted;
+  }
+  if (accepted != 0U)
+  {
+    REQUIRE_FROM_CALLBACK(
+        queue.PushBatch(static_cast<const uint8_t*>(rx_dma_storage_.addr_), accepted) ==
+            ErrorCode::OK,
+        in_isr);
+  }
+
+  // 超出软件容量的尾部作为溢出丢弃，回调前先推进游标。
+  // Drop excess bytes and advance the cursor before callbacks can run.
+  rx_dma_cursor_ = position == capacity ? 0U : position;
+  queue.Publish();
+}
+
+void MSPM0UART::HandleUartInterrupt()
+{
+  constexpr uint32_t MASK = RX_ERROR_INTERRUPT_MASK | RX_INTERRUPT_MASK |
+                            RX_TIMEOUT_INTERRUPT_MASK | TX_DONE_INTERRUPT_MASK |
+                            EOT_INTERRUPT_MASK | RX_GAP_INTERRUPT_MASK;
+  const uint32_t pending = DL_UART_getEnabledInterruptStatus(res_.instance, MASK);
+  if (pending == 0U)
+  {
+    return;
+  }
+
+  if ((pending & RX_TIMEOUT_INTERRUPT_MASK) != 0U)
+  {
+    DL_UART_disableInterrupt(res_.instance, RX_TIMEOUT_INTERRUPT_MASK);
+  }
+  DL_UART_clearInterruptStatus(res_.instance, pending & MASK);
+
+  uint32_t events = 0U;
+  if ((pending &
+       (RX_INTERRUPT_MASK | RX_TIMEOUT_INTERRUPT_MASK | RX_GAP_INTERRUPT_MASK)) != 0U)
+  {
+    events |= EVENT_RX_WORK;
+  }
+  if ((pending & TX_DONE_INTERRUPT_MASK) != 0U)
+  {
+    events |= EVENT_DMA_DONE_TX;
+  }
+  if ((pending & EOT_INTERRUPT_MASK) != 0U)
+  {
+    events |= EVENT_EOT_DONE;
+  }
+
+  if (events != 0U)
+  {
+    service_.Invoke(events, true, [this](uint32_t handled, bool in_isr)
+                    { HandleService(handled, in_isr); });
+  }
+}
+
+void MSPM0UART::HandleRxDmaInterrupt()
+{
+  service_.Invoke(EVENT_RX_WORK, true, [this](uint32_t events, bool in_isr)
+                  { HandleService(events, in_isr); });
+}
+
+void MSPM0UART::OnInterrupt(uint8_t index)
+{
+  if (index < MAX_UART_INSTANCES && instance_map_[index] != nullptr)
+  {
+    instance_map_[index]->HandleUartInterrupt();
+  }
+}
+
+void MSPM0UART::OnDmaInterrupt()
+{
+  uint32_t owned_mask = 0U;
+  for (MSPM0UART* uart : instance_map_)
+  {
+    if (uart != nullptr && uart->res_.rx_mode == RxMode::EXTEND_DMA)
+    {
+      owned_mask |= DmaRawMask(uart->res_.dma_rx_channel, uart->res_.rx_half_interrupt);
+    }
+  }
+
+  if (owned_mask == 0U)
+  {
+    return;
+  }
+
+  const uint32_t pending = DL_DMA_getEnabledInterruptStatus(DMA, owned_mask);
+  for (MSPM0UART* uart : instance_map_)
+  {
+    if (uart == nullptr || uart->res_.rx_mode != RxMode::EXTEND_DMA)
+    {
+      continue;
+    }
+
+    const uint32_t mask =
+        DmaRawMask(uart->res_.dma_rx_channel, uart->res_.rx_half_interrupt);
+    const uint32_t hit = pending & mask;
+    if (hit != 0U)
+    {
+      DL_DMA_clearInterruptStatus(DMA, hit);
+      uart->HandleRxDmaInterrupt();
+    }
+  }
+  __DSB();
+}
+
+void MSPM0UARTReadPort::OnReadQueueSpaceAvailable(bool in_isr)
+{
+  REQUIRE_FROM_CALLBACK(owner_ != nullptr, in_isr);
+  owner_->NotifyReadSpace(in_isr);
+}
+
+void MSPM0UART::ConfigureTxDma()
+{
+  DL_DMA_Config config = UART_DMA_TX_CONFIG;
+  config.trigger = res_.dma_tx_trigger;
+  DL_DMA_disableChannel(DMA, res_.dma_tx_channel);
+  DL_DMA_clearInterruptStatus(DMA, DmaCompleteMask(res_.dma_tx_channel));
+  DL_DMA_initChannel(DMA, res_.dma_tx_channel, &config);
+}
+
+void MSPM0UART::ConfigureRxDma()
+{
+#if defined(DEVICE_HAS_DMA_FULL_CHANNEL)
+  if (res_.rx_mode != RxMode::EXTEND_DMA)
+  {
+    return;
+  }
+
+  DL_DMA_Config config = UART_DMA_RX_CONFIG;
+  config.trigger = res_.dma_rx_trigger;
+  DL_DMA_disableChannel(DMA, res_.dma_rx_channel);
+  DL_DMA_initChannel(DMA, res_.dma_rx_channel, &config);
+  DL_DMA_setSrcAddr(
+      DMA, res_.dma_rx_channel,
+      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&res_.instance->RXDATA)));
+  DL_DMA_setDestAddr(
+      DMA, res_.dma_rx_channel,
+      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(rx_dma_storage_.addr_)));
+  DL_DMA_setTransferSize(DMA, res_.dma_rx_channel,
+                         static_cast<uint16_t>(rx_dma_storage_.size_));
+  if (res_.rx_half_interrupt)
+  {
+    DL_DMA_Full_Ch_setEarlyInterruptThreshold(DMA, res_.dma_rx_channel,
+                                              DL_DMA_EARLY_INTERRUPT_THRESHOLD_HALF);
+  }
+#else
+  REQUIRE(false);
+#endif
+}
+
+void MSPM0UART::ApplyConfig(UART::Configuration config)
+{
+  DL_UART_changeConfig(res_.instance);
+
+  DL_UART_WORD_LENGTH word_length = DL_UART_WORD_LENGTH_8_BITS;
+  switch (config.data_bits)
+  {
+    case 5U:
+      word_length = DL_UART_WORD_LENGTH_5_BITS;
       break;
-
+    case 6U:
+      word_length = DL_UART_WORD_LENGTH_6_BITS;
+      break;
+    case 7U:
+      word_length = DL_UART_WORD_LENGTH_7_BITS;
+      break;
+    case 8U:
+      break;
     default:
+      REQUIRE(false);
       break;
   }
 
-  if (clear_mask != 0)
+  DL_UART_PARITY parity = DL_UART_PARITY_NONE;
+  if (config.parity == UART::Parity::EVEN)
   {
-    DL_UART_clearInterruptStatus(res_.instance, clear_mask);
+    parity = DL_UART_PARITY_EVEN;
+  }
+  else if (config.parity == UART::Parity::ODD)
+  {
+    parity = DL_UART_PARITY_ODD;
+  }
+
+  DL_UART_setWordLength(res_.instance, word_length);
+  DL_UART_setParityMode(res_.instance, parity);
+  DL_UART_setStopBits(res_.instance, config.stop_bits == 2U ? DL_UART_STOP_BITS_TWO
+                                                            : DL_UART_STOP_BITS_ONE);
+  DL_UART_setCommunicationMode(res_.instance, DL_UART_MODE_NORMAL);
+  DL_UART_setDirection(res_.instance, DL_UART_DIRECTION_TX_RX);
+  DL_UART_enableFIFOs(res_.instance);
+  DL_UART_setTXFIFOThreshold(res_.instance, DL_UART_TX_FIFO_LEVEL_ONE_ENTRY);
+  DL_UART_setRXFIFOThreshold(res_.instance, DL_UART_RX_FIFO_LEVEL_ONE_ENTRY);
+  DL_UART_setRXInterruptTimeout(res_.instance, 0U);
+  DL_UART_configBaudRate(res_.instance, res_.clock_freq, config.baudrate);
+
+  if (res_.rx_mode == RxMode::EXTEND_DMA)
+  {
+    DL_UART_setLINCounterValue(res_.instance, 0U);
+    DL_UART_setLINCounterCompareValue(
+        res_.instance, static_cast<uint16_t>(GapCompare(res_.clock_freq, config)));
+    DL_UART_enableLINCounterCompareMatch(res_.instance);
+    DL_UART_disableLINCountWhileLow(res_.instance);
+    DL_UART_enableLINCounterClearOnFallingEdge(res_.instance);
+    DL_UART_enableLINCounter(res_.instance);
   }
 }
 
-void MSPM0UART::DisableTxInterrupt()
+void MSPM0UART::StartDataPath()
 {
-  DL_UART_disableInterrupt(res_.instance, DL_UART_INTERRUPT_TX);
-  DL_UART_clearInterruptStatus(res_.instance, DL_UART_INTERRUPT_TX);
-  NVIC_ClearPendingIRQ(res_.irqn);
+  DL_UART_disableInterrupt(res_.instance, 0xFFFFFFFFU);
+  DL_UART_clearInterruptStatus(res_.instance, 0xFFFFFFFFU);
+  DL_UART_clearDMATransmitEventStatus(res_.instance);
+  DL_UART_clearDMAReceiveEventStatus(res_.instance, DL_UART_DMA_INTERRUPT_RX);
+  DL_UART_disableDMAReceiveEvent(res_.instance, DL_UART_DMA_INTERRUPT_RX);
+  DL_UART_disableDMATransmitEvent(res_.instance);
+  DL_UART_enableInterrupt(res_.instance, RX_ERROR_INTERRUPT_MASK);
+
+  if (res_.rx_mode == RxMode::MAIN_BYTE_IRQ)
+  {
+    DL_UART_enableInterrupt(res_.instance, RX_INTERRUPT_MASK);
+  }
+  else
+  {
+    const uint32_t dma_mask = DmaRawMask(res_.dma_rx_channel, res_.rx_half_interrupt);
+    DL_DMA_clearInterruptStatus(DMA, dma_mask);
+    DL_DMA_enableInterrupt(DMA, dma_mask);
+    DL_DMA_enableChannel(DMA, res_.dma_rx_channel);
+    DL_UART_enableInterrupt(res_.instance, RX_GAP_INTERRUPT_MASK);
+    DL_UART_enableDMAReceiveEvent(res_.instance, DL_UART_DMA_INTERRUPT_RX);
+    rx_dma_cursor_ = 0U;
+  }
+
+  __DMB();
+  DL_UART_enable(res_.instance);
+}
+
+void MSPM0UART::StopDataPath()
+{
+  DL_UART_disableInterrupt(res_.instance, RX_ERROR_INTERRUPT_MASK | RX_INTERRUPT_MASK |
+                                              RX_TIMEOUT_INTERRUPT_MASK |
+                                              TX_DONE_INTERRUPT_MASK |
+                                              EOT_INTERRUPT_MASK | RX_GAP_INTERRUPT_MASK);
+  DL_UART_disableDMAReceiveEvent(res_.instance, DL_UART_DMA_INTERRUPT_RX);
+  DL_UART_disableDMATransmitEvent(res_.instance);
+  if (res_.rx_mode == RxMode::EXTEND_DMA)
+  {
+    DL_DMA_disableChannel(DMA, res_.dma_rx_channel);
+    DL_DMA_disableInterrupt(DMA, DmaRawMask(res_.dma_rx_channel, res_.rx_half_interrupt));
+  }
+  DL_UART_disable(res_.instance);
+}
+
+void MSPM0UART::DiscardRxFifo()
+{
+  while (!DL_UART_isRXFIFOEmpty(res_.instance))
+  {
+    (void)DL_UART_receiveData(res_.instance);
+  }
+}
+
+void MSPM0UART::StartTxDma(uint8_t half, size_t size)
+{
+  REQUIRE(half < 2U);
+  REQUIRE(size > 0U && size <= tx_half_size_);
+
+  DL_DMA_disableChannel(DMA, res_.dma_tx_channel);
+  DL_DMA_clearInterruptStatus(DMA, DmaCompleteMask(res_.dma_tx_channel));
+  DL_DMA_setSrcAddr(DMA, res_.dma_tx_channel,
+                    static_cast<uint32_t>(reinterpret_cast<uintptr_t>(TxHalf(half))));
+  DL_DMA_setDestAddr(
+      DMA, res_.dma_tx_channel,
+      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&res_.instance->TXDATA)));
+  DL_DMA_setTransferSize(DMA, res_.dma_tx_channel, static_cast<uint16_t>(size));
+  DL_UART_clearInterruptStatus(res_.instance,
+                               TX_DONE_INTERRUPT_MASK | EOT_INTERRUPT_MASK);
+  DL_UART_enableInterrupt(res_.instance, TX_DONE_INTERRUPT_MASK);
+  DL_UART_enableDMATransmitEvent(res_.instance);
+  __DMB();
+  DL_DMA_enableChannel(DMA, res_.dma_tx_channel);
+}
+
+void MSPM0UART::TryApplyPublishedConfig(bool in_isr)
+{
+  if (config_state_.load(std::memory_order_acquire) != ConfigState::PUBLISHED)
+  {
+    return;
+  }
+
+  if (active_half_ >= 0)
+  {
+    return;
+  }
+
+  if (DL_UART_isBusy(res_.instance))
+  {
+    DL_UART_enableInterrupt(res_.instance, EOT_INTERRUPT_MASK);
+    if (res_.rx_mode == RxMode::MAIN_BYTE_IRQ)
+    {
+      DL_UART_disableInterrupt(res_.instance, RX_TIMEOUT_INTERRUPT_MASK);
+      DL_UART_clearInterruptStatus(res_.instance, RX_TIMEOUT_INTERRUPT_MASK);
+      DL_UART_setRXInterruptTimeout(res_.instance, CONFIG_RX_TIMEOUT);
+      DL_UART_enableInterrupt(res_.instance, RX_TIMEOUT_INTERRUPT_MASK);
+    }
+    return;
+  }
+
+  const UART::Configuration config = pending_config_;
+  StopDataPath();
+  DiscardRxFifo();
+  ApplyConfig(config);
+  if (res_.rx_mode == RxMode::EXTEND_DMA)
+  {
+    ConfigureRxDma();
+  }
+  config_state_.store(ConfigState::EMPTY, std::memory_order_release);
+  StartDataPath();
+  // 当前处理器仍持有执行权，会在本轮结束后处理这些通知。
+  // The active service will process these hints after this pass.
+  service_.Publish(EVENT_WRITE | EVENT_RX_WORK);
+  UNUSED(in_isr);
 }
 
 #if defined(UART0_BASE)
-extern "C" void UART0_IRQHandler(void)  // NOLINT
-{
-  LibXR::MSPM0UART::OnInterrupt(0);
-}
+extern "C" void UART0_IRQHandler(void) { MSPM0UART::OnInterrupt(0U); }
 #endif
-
 #if defined(UART1_BASE)
-extern "C" void UART1_IRQHandler(void)  // NOLINT
-{
-  LibXR::MSPM0UART::OnInterrupt(1);
-}
+extern "C" void UART1_IRQHandler(void) { MSPM0UART::OnInterrupt(1U); }
 #endif
-
 #if defined(UART2_BASE)
-extern "C" void UART2_IRQHandler(void)  // NOLINT
-{
-  LibXR::MSPM0UART::OnInterrupt(2);
-}
+extern "C" void UART2_IRQHandler(void) { MSPM0UART::OnInterrupt(2U); }
 #endif
-
 #if defined(UART3_BASE)
-extern "C" void UART3_IRQHandler(void)  // NOLINT
-{
-  LibXR::MSPM0UART::OnInterrupt(3);
-}
+extern "C" void UART3_IRQHandler(void) { MSPM0UART::OnInterrupt(3U); }
 #endif
-
 #if defined(UART4_BASE)
-extern "C" void UART4_IRQHandler(void) { LibXR::MSPM0UART::OnInterrupt(4); }
+extern "C" void UART4_IRQHandler(void) { MSPM0UART::OnInterrupt(4U); }
 #endif
-
 #if defined(UART5_BASE)
-extern "C" void UART5_IRQHandler(void) { LibXR::MSPM0UART::OnInterrupt(5); }
+extern "C" void UART5_IRQHandler(void) { MSPM0UART::OnInterrupt(5U); }
 #endif
-
 #if defined(UART6_BASE)
-extern "C" void UART6_IRQHandler(void) { LibXR::MSPM0UART::OnInterrupt(6); }
+extern "C" void UART6_IRQHandler(void) { MSPM0UART::OnInterrupt(6U); }
 #endif
-
 #if defined(UART7_BASE)
-extern "C" void UART7_IRQHandler(void) { LibXR::MSPM0UART::OnInterrupt(7); }
+extern "C" void UART7_IRQHandler(void) { MSPM0UART::OnInterrupt(7U); }
 #endif

--- a/driver/mspm0/mspm0_uart.hpp
+++ b/driver/mspm0/mspm0_uart.hpp
@@ -1,143 +1,449 @@
 #pragma once
 
+#include <ti/driverlib/dl_dma.h>
 #include <ti/driverlib/dl_uart_main.h>
 
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "libxr_type.hpp"
+#include "serialized_service.hpp"
 #include "ti_msp_dl_config.h"
 #include "uart.hpp"
 
 namespace LibXR
 {
 
-class MSPM0UART : public UART
+class MSPM0UART;
+
+/**
+ * @brief 通知串口恢复接收的读端口 / Read port that resumes UART reception.
+ */
+class MSPM0UARTReadPort : public ReadPort
 {
  public:
-  enum class RxTimeoutMode : uint8_t
+  /// 按字节容量构造接收队列 / Construct an RX queue with the byte capacity.
+  explicit MSPM0UARTReadPort(size_t capacity) : ReadPort(capacity) {}
+
+  /// 在串口初始化时绑定后端 / Bind the backend during UART initialization.
+  void SetOwner(MSPM0UART* owner) { owner_ = owner; }
+
+ protected:
+  /// 发布接收空间可用通知 / Publish RX space availability.
+  void OnReadQueueSpaceAvailable(bool in_isr) override;
+
+ private:
+  MSPM0UART* owner_ = nullptr;  ///< 初始化时绑定的后端 / Backend bound at initialization.
+};
+
+/**
+ * @brief 使用双缓冲 DMA 发送的 MSPM0 串口 / MSPM0 UART with double-buffered DMA TX.
+ *
+ * 主 UART 按字节中断接收，扩展 UART 使用循环 DMA。写请求复制到空闲发送半区后完成，
+ * DMA 完成仅释放半区；配置在当前发送结束且 UART 空闲后应用。
+ * Main RX uses byte interrupts; Extend RX uses circular DMA. Writes complete after
+ * copying into a free TX half; DMA completion only releases that half. Configuration
+ * waits for the active transfer and UART idle boundary.
+ *
+ * @pre BSP 串行初始化实例并独占分配 DMA 通道；UART 和相关 DMA 中断位于同一核心，
+ *      使用兼容的抢占优先级。对象及借用缓冲区在运行期间须保持有效。
+ *      The BSP initializes instances serially, reserves distinct DMA channels, and
+ *      routes UART/DMA IRQs to one core with compatible preemption priorities.
+ *      Keep the object and borrowed buffers valid throughout operation.
+ * @note 软件接收队列满时，Main 保留 FIFO 字节，Extend 丢弃放不下的 DMA 尾部。
+ *       硬件仍持续接收；没有流控时不保证无限输入不丢失。
+ *       On a full software queue, Main retains FIFO bytes and Extend drops excess DMA
+ *       bytes. Hardware keeps receiving; unbounded input requires external flow control.
+ */
+class MSPM0UART : public UART
+{
+  friend class MSPM0UARTReadPort;
+
+ public:
+  /// 接收路径 / RX path.
+  enum class RxMode : uint8_t
   {
-    LIN_COMPARE,
-    BYTE_INTERRUPT
+    MAIN_BYTE_IRQ,  ///< 主 UART 字节中断 / Main UART byte interrupts.
+    EXTEND_DMA,     ///< 扩展 UART DMA / Extend UART DMA.
   };
 
+  /// 由 BSP 提供的 UART 与 DMA 绑定 / UART and DMA bindings supplied by the BSP.
   struct Resources
   {
+    /// UART 寄存器 / UART registers.
     UART_Regs* instance;
+    /// UART 中断号 / UART interrupt number.
     IRQn_Type irqn;
+    /// UART 输入时钟频率 / UART input clock frequency.
     uint32_t clock_freq;
+    /// ResolveIndex 返回的编号 / Index returned by ResolveIndex.
     uint8_t index;
+    /// 选择的接收路径 / Selected RX path.
+    RxMode rx_mode;
+    /// 是否使用接收半传输中断 / Enable RX half-transfer interrupts.
+    bool rx_half_interrupt;
+    /// 发送 DMA 通道 / TX DMA channel.
+    uint8_t dma_tx_channel;
+    /// UART 发送 DMA 触发源 / UART TX DMA trigger.
+    uint8_t dma_tx_trigger;
+    /// 接收 FULL-DMA 通道，Main 使用无效编号 / RX full channel, invalid for Main.
+    uint8_t dma_rx_channel;
+    /// UART 接收 DMA 触发源，Main 为零 / RX DMA trigger, zero for Main.
+    uint8_t dma_rx_trigger;
   };
 
-  MSPM0UART(Resources res, RawData rx_stage_buffer, uint32_t tx_queue_size = 5,
-            uint32_t tx_buffer_size = 128,
-            UART::Configuration config = {115200, UART::Parity::NO_PARITY, 8, 1});
+  /// 无 DMA 通道的标记 / Sentinel for no DMA channel.
+  static constexpr uint8_t INVALID_DMA_CHANNEL = 0xFFU;
 
+  /**
+   * @brief 构造串口并配置所选 DMA 路径 / Construct the UART and selected DMA paths.
+   * @param res UART 与 DMA 资源绑定 / UART and DMA resource bindings.
+   * @param tx_dma_storage 调用者提供的连续 2N 字节存储，分为两个 N 字节半区；
+   *        地址和半区边界按 sizeof(size_t) 对齐，N 不超过 65535。
+   *        Caller-owned contiguous 2N bytes, split into N-byte halves aligned to
+   *        sizeof(size_t), with N no greater than 65535.
+   * @param rx_dma_storage Main 传空视图；Extend 提供连续、偶数字节数的接收环。
+   *        Empty for Main; a contiguous even-sized RX ring for Extend.
+   * @param tx_queue_size 写请求队列容量，必须大于零 / Positive write request capacity.
+   * @param rx_queue_capacity 软件接收队列字节容量，必须大于零 / Positive RX queue
+   * capacity.
+   * @param config 初始串口配置 / Initial UART configuration.
+   * @note WritePort 字节容量为 N；配置错误和资源冲突在构造时检查。
+   *       WritePort byte capacity is N; checks configuration and resource conflicts.
+   */
+  MSPM0UART(Resources res, RawData tx_dma_storage, RawData rx_dma_storage,
+            uint32_t tx_queue_size = 5U, uint32_t rx_queue_capacity = 128U,
+            UART::Configuration config = {115200, UART::Parity::NO_PARITY, 8U, 1U});
+
+  /**
+   * @brief 提交串口配置 / Submit a UART configuration.
+   * @param config 目标配置 / Requested configuration.
+   * @param in_isr 当前是否在中断中 / Whether called in an ISR.
+   * @return 接纳返回 OK，配置槽被占用返回 BUSY，参数不可表示返回 ARG_ERR。
+   *         OK on admission, BUSY for an occupied slot, ARG_ERR for unsupported values.
+   * @note 等发送和 UART 空闲后生效；保留已发布的读数据和待发送请求。
+   *       切换时丢弃硬件 FIFO 及未发布 DMA 接收数据。
+   *       Applies after TX and UART become idle, preserving published RX and pending
+   *       writes. Discards hardware FIFO and unpublished DMA RX data at the boundary.
+   */
   ErrorCode SetConfig(UART::Configuration config, bool in_isr = false) override;
 
-  static ErrorCode WriteFun(WritePort& port, bool in_isr);
-
-  static ErrorCode ReadFun(ReadPort& port, bool in_isr);
-
+  /// 通知已提交的写请求 / Notify released write requests.
+  static void WriteFun(WritePort& port, bool in_isr);
+  /// 按实例编号分派 UART 中断 / Dispatch a UART IRQ by instance index.
   static void OnInterrupt(uint8_t index);
+
+  /**
+   * @brief 分派本驱动登记的接收 DMA 中断 / Dispatch registered UART RX DMA interrupts.
+   * @note BSP 在共享 DMA 向量中调用本函数；其他 DMA 来源仍由 BSP 处理。
+   *       只确认登记的 Extend RX 通道，不安装或接管共享向量。
+   *       Called by the BSP shared DMA vector, which still handles other sources.
+   *       Acknowledges only registered Extend RX channels; does not install the vector.
+   */
+  static void OnDmaInterrupt();
+
+  /// 从已初始化硬件读取帧格式，使用给定波特率 / Read framing and use the supplied baud
+  /// rate.
   static UART::Configuration BuildConfigFromSysCfg(UART_Regs* instance,
                                                    uint32_t baudrate);
 
-  RxTimeoutMode GetRxTimeoutMode() const { return rx_timeout_mode_; }
-  uint32_t GetRxTimeoutCount() const { return rx_timeout_count_; }
-  uint32_t GetRxDropCount() const { return rx_drop_count_; }
-  uint32_t GetTimeoutInterruptEnabledMask() const;
-  uint32_t GetTimeoutInterruptMaskedStatus() const;
-  uint32_t GetTimeoutInterruptRawStatus() const;
-  uint32_t GetRxInterruptTimeoutValue() const;
-  uint32_t GetRxFifoThresholdValue() const;
+  /// 获取构造时选择的接收路径 / Get the selected RX path.
+  [[nodiscard]] RxMode GetRxMode() const { return res_.rx_mode; }
+  /// 查询是否使用接收半传输通知 / Check RX half-transfer notification use.
+  [[nodiscard]] bool RxHalfInterruptEnabled() const { return res_.rx_half_interrupt; }
 
-  ReadPort _read_port;    // NOLINT
-  WritePort _write_port;  // NOLINT
+  MSPM0UARTReadPort _read_port;  // NOLINT(readability-identifier-naming)
+  WritePort _write_port;         // NOLINT(readability-identifier-naming)
 
+  /// 根据 UART 中断号取得实例编号 / Resolve an instance index from its UART IRQ.
   static constexpr uint8_t ResolveIndex(IRQn_Type irqn)
   {
     switch (irqn)
     {
 #if defined(UART0_BASE)
       case UART0_INT_IRQn:
-        return 0;
+        return 0U;
 #endif
 #if defined(UART1_BASE)
       case UART1_INT_IRQn:
-        return 1;
+        return 1U;
 #endif
 #if defined(UART2_BASE)
       case UART2_INT_IRQn:
-        return 2;
+        return 2U;
 #endif
 #if defined(UART3_BASE)
       case UART3_INT_IRQn:
-        return 3;
+        return 3U;
 #endif
 #if defined(UART4_BASE)
       case UART4_INT_IRQn:
-        return 4;
+        return 4U;
 #endif
 #if defined(UART5_BASE)
       case UART5_INT_IRQn:
-        return 5;
+        return 5U;
 #endif
 #if defined(UART6_BASE)
       case UART6_INT_IRQn:
-        return 6;
+        return 6U;
 #endif
 #if defined(UART7_BASE)
       case UART7_INT_IRQn:
-        return 7;
+        return 7U;
 #endif
       default:
-        return INVALID_INSTANCE_INDEX;
+        return INVALID_DMA_CHANNEL;
     }
   }
 
  private:
-  static constexpr uint8_t MAX_UART_INSTANCES = 8;
-  static constexpr uint8_t INVALID_INSTANCE_INDEX = 0xFF;
+  /// 配置槽的发布状态 / Configuration slot publication state.
+  enum class ConfigState : uint32_t
+  {
+    EMPTY = 0U,
+    RESERVED = 1U,
+    PUBLISHED = 2U,
+  };
 
-  void HandleInterrupt();
+  static constexpr uint8_t MAX_UART_INSTANCES = 8U;
+  static_assert(DMA_SYS_N_DMA_CHANNEL <= 16U);
+  static constexpr uint8_t MAX_DMA_CHANNELS = static_cast<uint8_t>(DMA_SYS_N_DMA_CHANNEL);
+  static constexpr uint32_t MSPM0_UART_DMA_MAX_TRANSFER_SIZE = 0xFFFFU;
 
-  void HandleRxInterrupt(uint32_t timeout_mask);
+  static constexpr uint32_t EVENT_WRITE = 1U << 0U;
+  static constexpr uint32_t EVENT_DMA_DONE_TX = 1U << 1U;
+  static constexpr uint32_t EVENT_EOT_DONE = 1U << 2U;
+  static constexpr uint32_t EVENT_CONFIG = 1U << 3U;
+  static constexpr uint32_t EVENT_RX_WORK = 1U << 4U;
 
-  void HandleRxTimeoutInterrupt(uint32_t pending, uint32_t timeout_mask);
+  static constexpr uint32_t RX_ERROR_INTERRUPT_MASK =
+      DL_UART_INTERRUPT_OVERRUN_ERROR | DL_UART_INTERRUPT_BREAK_ERROR |
+      DL_UART_INTERRUPT_PARITY_ERROR | DL_UART_INTERRUPT_FRAMING_ERROR |
+      DL_UART_INTERRUPT_NOISE_ERROR;
 
-  void DrainRxFIFO(bool& received, bool& pushed);
+  static constexpr uint32_t RX_INTERRUPT_MASK = DL_UART_INTERRUPT_RX;
+  static constexpr uint32_t RX_TIMEOUT_INTERRUPT_MASK =
+      DL_UART_INTERRUPT_RX_TIMEOUT_ERROR;
+  static constexpr uint32_t CONFIG_RX_TIMEOUT = 1U;
+  static constexpr uint32_t RX_GAP_INTERRUPT_MASK = DL_UART_INTERRUPT_LINC0_MATCH;
+  static constexpr uint32_t TX_DONE_INTERRUPT_MASK = DL_UART_INTERRUPT_DMA_DONE_TX;
+  static constexpr uint32_t EOT_INTERRUPT_MASK = DL_UART_INTERRUPT_EOT_DONE;
 
-  void HandleTxInterrupt(bool in_isr);
+  /// 串行处理收发和配置进展 / Serialize RX, TX, and configuration progress.
+  void HandleService(uint32_t events, bool in_isr);
+  /// 填充空闲发送半区并按需启动 DMA / Fill free TX halves and start DMA as needed.
+  void FillTx(bool in_isr);
+  /// 释放发送半区并切换已准备数据 / Release the sent half and switch prepared data.
+  void HandleTxDone(bool in_isr);
+  /// 按所选模式推进接收 / Advance the selected RX path.
+  void HandleRxWork(bool in_isr);
+  /// 软件队列有空间时才读取 RXDATA / Read RXDATA only when software space exists.
+  void HandleMainRx(bool in_isr);
+  /// 复制 DMA 接收前缀，推进游标后发布 / Copy DMA RX, advance the cursor, then publish.
+  void HandleExtendRx(bool in_isr);
+  /// 通知接收空间释放 / Notify RX space release.
+  void NotifyReadSpace(bool in_isr);
+  /// 确认 UART 中断快照并发布进展 / Acknowledge UART status and publish progress.
+  void HandleUartInterrupt();
+  /// 发布接收 DMA 进展 / Publish RX DMA progress.
+  void HandleRxDmaInterrupt();
 
-  void HandleErrorInterrupt(DL_UART_IIDX iidx);
+  /// 验证帧格式、波特率和间隔计数范围 / Validate framing, baud, and gap-counter range.
+  [[nodiscard]] ErrorCode ValidateConfig(UART::Configuration config) const;
+  /// 在处理器内应用已验证参数 / Apply validated parameters inside the service.
+  void ApplyConfig(UART::Configuration config);
+  /// UART 空闲时应用配置并恢复数据路径 / Apply at UART idle and resume data paths.
+  void TryApplyPublishedConfig(bool in_isr);
+  /// 配置发送 DMA 通道 / Configure the TX DMA channel.
+  void ConfigureTxDma();
+  /// 配置 Extend 循环接收 DMA / Configure Extend circular RX DMA.
+  void ConfigureRxDma();
+  /// 开启所选接收路径和 UART / Enable the selected RX path and UART.
+  void StartDataPath();
+  /// 暂停收发请求源及选定的接收 DMA / Stop request sources and selected RX DMA.
+  void StopDataPath();
+  /// 配置切换时丢弃未读硬件字节 / Discard unread hardware bytes during configuration.
+  void DiscardRxFifo();
+  /// 启动指定半区，配置后屏障保证数据可见 / Start a half after the publication barrier.
+  void StartTxDma(uint8_t half, size_t size);
 
-  void ApplyRxTimeoutMode();
+  /// 获取发送半区地址 / Get a TX half address.
+  [[nodiscard]] uint8_t* TxHalf(uint8_t half) const
+  {
+    return static_cast<uint8_t*>(tx_dma_storage_.addr_) +
+           static_cast<size_t>(half) * tx_half_size_;
+  }
 
-  RxTimeoutMode ResolveRxTimeoutMode() const;
+  /// 获取接收 DMA 环容量 / Get RX DMA ring capacity.
+  [[nodiscard]] size_t RxCapacity() const { return rx_dma_storage_.size_; }
 
-  uint32_t GetTimeoutInterruptMask() const;
+  /// 生成 DMA 完成中断掩码 / Build a DMA completion mask.
+  static uint32_t DmaCompleteMask(uint8_t channel)
+  {
+    return channel < MAX_DMA_CHANNELS ? (1UL << channel) : 0U;
+  }
 
-  void ResetLinCounter();
+  /// 生成前八个通道的提前中断掩码 / Build an early-interrupt mask for channels 0–7.
+  static uint32_t DmaEarlyMask(uint8_t channel)
+  {
+    return channel < 8U ? (1UL << (16U + channel)) : 0U;
+  }
 
-  void DisableTxInterrupt();
+  /// 组合完成和可选半传输掩码 / Combine completion and optional half-transfer masks.
+  static uint32_t DmaRawMask(uint8_t channel, bool half)
+  {
+    return DmaCompleteMask(channel) | (half ? DmaEarlyMask(channel) : 0U);
+  }
 
-  Resources res_;
-  WriteInfoBlock tx_active_info_;
-  bool tx_active_valid_ = false;
-  size_t tx_active_remaining_ = 0;
-  size_t tx_active_total_ = 0;
-  RxTimeoutMode rx_timeout_mode_ = RxTimeoutMode::BYTE_INTERRUPT;
-  uint32_t rx_drop_count_ = 0;
-  uint32_t rx_timeout_count_ = 0;
+  /// 固定资源绑定 / Fixed resource bindings.
+  Resources res_{};
+  /// 借用的发送双缓冲 / Borrowed TX double buffer.
+  RawData tx_dma_storage_{};
+  /// 借用的 Extend 接收环 / Borrowed Extend RX ring.
+  RawData rx_dma_storage_{};
+  /// 单个发送半区容量 / TX half capacity.
+  size_t tx_half_size_ = 0U;
+  /// 每半区有效长度，零表示空闲 / Per-half length; zero means free.
+  std::array<size_t, 2U> tx_half_size_used_{};
+  /// 当前发送半区，负值表示 DMA 空闲 / Active half, negative when DMA is idle.
+  int8_t active_half_ = -1;
+  /// 上次已处理的接收位置 / Last processed RX position.
+  size_t rx_dma_cursor_ = 0U;
 
+  /// 唯一收发与配置处理器 / Sole I/O and configuration service.
+  SerializedService service_{};
+  /// 配置发布与占用状态 / Configuration publication and occupancy.
+  std::atomic<ConfigState> config_state_{ConfigState::EMPTY};
+  /// 等待应用的配置 / Configuration awaiting application.
+  UART::Configuration pending_config_{};
+
+  /// 初始化时登记的中断路由表 / IRQ routing table populated at initialization.
   static MSPM0UART* instance_map_[MAX_UART_INSTANCES];
 };
 
-// Helper macro to initialize MSPM0UART from SysConfig in one shot
-#define MSPM0_UART_INIT(name, rx_stage_addr, rx_stage_size, tx_queue_size,               \
-                        tx_buffer_size)                                                  \
-  ::LibXR::MSPM0UART::Resources{name##_INST, name##_INST_INT_IRQN,                       \
-                                name##_INST_FREQUENCY,                                   \
-                                ::LibXR::MSPM0UART::ResolveIndex(name##_INST_INT_IRQN)}, \
-      ::LibXR::RawData{(rx_stage_addr), (rx_stage_size)}, (tx_queue_size),               \
-      (tx_buffer_size),                                                                  \
+namespace Detail
+{
+
+// 以下构造辅助函数检查 BSP 声明的 DMA 归属，不增加运行时资源状态。
+// These helpers check BSP-declared DMA ownership without adding runtime state.
+template <IRQn_Type UartIrqn, uint32_t TxDmaChannel, IRQn_Type TxDmaOwnerIrqn,
+          bool TxBinding>
+MSPM0UART::Resources MakeMSPM0MainUartResources(UART_Regs* instance, uint32_t clock_freq,
+                                                uint8_t tx_dma_trigger)
+{
+  static_assert(TxBinding);
+  static_assert(TxDmaOwnerIrqn == UartIrqn);
+  static_assert(TxDmaChannel < DMA_SYS_N_DMA_CHANNEL);
+  return {instance,
+          UartIrqn,
+          clock_freq,
+          MSPM0UART::ResolveIndex(UartIrqn),
+          MSPM0UART::RxMode::MAIN_BYTE_IRQ,
+          false,
+          static_cast<uint8_t>(TxDmaChannel),
+          tx_dma_trigger,
+          MSPM0UART::INVALID_DMA_CHANNEL,
+          0U};
+}
+
+template <IRQn_Type UartIrqn, uint32_t TxDmaChannel, IRQn_Type TxDmaOwnerIrqn,
+          bool TxBinding, uint32_t RxDmaChannel, IRQn_Type RxDmaOwnerIrqn, bool RxBinding,
+          bool ExtendCapable, bool FullRxChannel, bool HalfRxInterrupt>
+MSPM0UART::Resources MakeMSPM0ExtendUartResources(UART_Regs* instance,
+                                                  uint32_t clock_freq,
+                                                  uint8_t tx_dma_trigger,
+                                                  uint8_t rx_dma_trigger)
+{
+  static_assert(TxBinding);
+  static_assert(RxBinding);
+  static_assert(TxDmaOwnerIrqn == UartIrqn);
+  static_assert(RxDmaOwnerIrqn == UartIrqn);
+  static_assert(TxDmaChannel < DMA_SYS_N_DMA_CHANNEL);
+  static_assert(RxDmaChannel < DMA_SYS_N_DMA_FULL_CHANNEL);
+  static_assert(TxDmaChannel != RxDmaChannel);
+  static_assert(ExtendCapable);
+  static_assert(FullRxChannel);
+  static_assert(!HalfRxInterrupt || RxDmaChannel < 8U);
+  return {instance,
+          UartIrqn,
+          clock_freq,
+          MSPM0UART::ResolveIndex(UartIrqn),
+          MSPM0UART::RxMode::EXTEND_DMA,
+          HalfRxInterrupt,
+          static_cast<uint8_t>(TxDmaChannel),
+          tx_dma_trigger,
+          static_cast<uint8_t>(RxDmaChannel),
+          rx_dma_trigger};
+}
+
+}  // namespace Detail
+
+#define LIBXR_MSPM0_UART_CAT_IMPL(left, right) left##right
+#define LIBXR_MSPM0_UART_CAT(left, right) LIBXR_MSPM0_UART_CAT_IMPL(left, right)
+#define LIBXR_MSPM0_UART_PROPERTY(name, suffix) LIBXR_MSPM0_UART_CAT(name, suffix)
+#define LIBXR_MSPM0_UART_DMA_CHANNEL(name) LIBXR_MSPM0_UART_CAT(name, _CHAN_ID)
+#define LIBXR_MSPM0_UART_DMA_PROPERTY(name, suffix) LIBXR_MSPM0_UART_CAT(name, suffix)
+#define LIBXR_MSPM0_UART_DMA_TRIGGER_IMPL(instance, direction) \
+  DMA_##instance##_##direction##_TRIG
+#define LIBXR_MSPM0_UART_DMA_TRIGGER(instance, direction) \
+  LIBXR_MSPM0_UART_DMA_TRIGGER_IMPL(instance, direction)
+
+/**
+ * @brief 使用 SysConfig 名称构造 Main 资源参数 / Build Main arguments from SysConfig
+ * names.
+ *
+ * BSP 须提供 tx_dma_CHAN_ID、tx_dma_LIBXR_UART_IRQN、tx_dma_LIBXR_UART_TX 标注。
+ * _LIBXR_ 标注由 BSP 声明，不是 TI SysConfig 默认生成项。可直接使用 Resources 构造。
+ * The BSP supplies tx_dma_CHAN_ID, tx_dma_LIBXR_UART_IRQN and tx_dma_LIBXR_UART_TX.
+ * _LIBXR_ annotations are BSP declarations, not default TI-generated fields.
+ * Direct construction with Resources is also available.
+ */
+#define MSPM0_UART_MAIN_INIT(name, tx_dma, tx_storage_addr, tx_storage_size,             \
+                             tx_queue_size, rx_queue_capacity)                           \
+  ::LibXR::Detail::MakeMSPM0MainUartResources<                                           \
+      name##_INST_INT_IRQN, static_cast<uint32_t>(LIBXR_MSPM0_UART_DMA_CHANNEL(tx_dma)), \
+      LIBXR_MSPM0_UART_DMA_PROPERTY(tx_dma, _LIBXR_UART_IRQN),                           \
+      static_cast<bool>(LIBXR_MSPM0_UART_DMA_PROPERTY(tx_dma, _LIBXR_UART_TX))>(         \
+      name##_INST, name##_INST_FREQUENCY,                                                \
+      static_cast<uint8_t>(LIBXR_MSPM0_UART_DMA_TRIGGER(name##_INST, TX))),              \
+      ::LibXR::RawData{static_cast<void*>(tx_storage_addr), (tx_storage_size)},          \
+      ::LibXR::RawData{}, (tx_queue_size), (rx_queue_capacity),                          \
+      ::LibXR::MSPM0UART::BuildConfigFromSysCfg(name##_INST,                             \
+                                                static_cast<uint32_t>(name##_BAUD_RATE))
+
+/**
+ * @brief 使用 SysConfig 名称构造 Extend 资源参数 / Build Extend arguments from SysConfig
+ * names.
+ *
+ * 除 Main 的发送标注外，BSP 须声明 rx_dma_CHAN_ID、rx_dma_LIBXR_UART_IRQN、
+ * rx_dma_LIBXR_UART_RX、rx_dma_LIBXR_FULL_CHANNEL、rx_dma_LIBXR_HALF_INTERRUPT，
+ * 以及 name_LIBXR_EXTEND_CAPABLE。收发通道须不同，RX 必须为 FULL-DMA 通道。
+ * In addition to TX annotations, declare RX channel, UART ownership, RX binding,
+ * FULL-channel and half-interrupt annotations, plus name_LIBXR_EXTEND_CAPABLE.
+ * TX and RX channels must differ, and RX requires a FULL-DMA channel.
+ */
+#define MSPM0_UART_EXTEND_INIT(name, tx_dma, rx_dma, tx_storage_addr, tx_storage_size,   \
+                               tx_queue_size, rx_dma_storage_addr, rx_dma_storage_size,  \
+                               rx_queue_capacity)                                        \
+  ::LibXR::Detail::MakeMSPM0ExtendUartResources<                                         \
+      name##_INST_INT_IRQN, static_cast<uint32_t>(LIBXR_MSPM0_UART_DMA_CHANNEL(tx_dma)), \
+      LIBXR_MSPM0_UART_DMA_PROPERTY(tx_dma, _LIBXR_UART_IRQN),                           \
+      static_cast<bool>(LIBXR_MSPM0_UART_DMA_PROPERTY(tx_dma, _LIBXR_UART_TX)),          \
+      static_cast<uint32_t>(LIBXR_MSPM0_UART_DMA_CHANNEL(rx_dma)),                       \
+      LIBXR_MSPM0_UART_DMA_PROPERTY(rx_dma, _LIBXR_UART_IRQN),                           \
+      static_cast<bool>(LIBXR_MSPM0_UART_DMA_PROPERTY(rx_dma, _LIBXR_UART_RX)),          \
+      static_cast<bool>(LIBXR_MSPM0_UART_PROPERTY(name, _LIBXR_EXTEND_CAPABLE)),         \
+      static_cast<bool>(LIBXR_MSPM0_UART_DMA_PROPERTY(rx_dma, _LIBXR_FULL_CHANNEL)),     \
+      static_cast<bool>(LIBXR_MSPM0_UART_DMA_PROPERTY(rx_dma, _LIBXR_HALF_INTERRUPT))>(  \
+      name##_INST, name##_INST_FREQUENCY,                                                \
+      static_cast<uint8_t>(LIBXR_MSPM0_UART_DMA_TRIGGER(name##_INST, TX)),               \
+      static_cast<uint8_t>(LIBXR_MSPM0_UART_DMA_TRIGGER(name##_INST, RX))),              \
+      ::LibXR::RawData{static_cast<void*>(tx_storage_addr), (tx_storage_size)},          \
+      ::LibXR::RawData{static_cast<void*>(rx_dma_storage_addr), (rx_dma_storage_size)},  \
+      (tx_queue_size), (rx_queue_capacity),                                              \
       ::LibXR::MSPM0UART::BuildConfigFromSysCfg(name##_INST,                             \
                                                 static_cast<uint32_t>(name##_BAUD_RATE))
 


### PR DESCRIPTION
MSPM0 UART still uses removed RW metadata and read-triggered receive handling. This migrates it to continuous Main/Extend RX and DMA TX using the frontend on `dev`, with one SerializedService coordinating writes, interrupts, receive-space notifications and configuration.

- TX copies one complete WriteQueue request into a stable DMA half and completes once. DMA completion releases the half; configuration waits for the active transfer and UART idle boundary.
- Main RX checks software capacity before reading RXDATA and resumes through the read-space hook. Extend RX copies the fitting DMA prefix and advances the cursor before publication; excess is finite overrun loss, not replay.
- Preserve the accepted single pending-config slot, Main RTOUT configuration wake, Extend gap/half/full notifications, and configuration-boundary discard of unpublished hardware RX data.
- Construction now takes explicit DMA resources and caller-owned TX 2N storage. `MSPM0_UART_MAIN_INIT` and `MSPM0_UART_EXTEND_INIT` replace the old initialization macro; legacy timeout/debug accessors are removed. Header comments document required BSP annotations, direct Resources construction, interrupt ownership and shared DMA-vector dispatch.
- Align `__atomic_compare_exchange_4` with the five-argument GCC runtime ABI and provide the missing `__atomic_fetch_or_4` needed by SerializedService, using the existing single-core interrupt guard.

**Three files, one commit:** MSPM0 UART header/source and its atomic shim. No common RW changes, other backends, product CMake/CI/test scaffolding or hardware writes.

Validation on Ubuntu24, Arm GNU 14.2.1 and TI MSPM0 SDK 2.10.00.04:

- Full MSPM0G3507 UART-only firmware compile/link for both Main and Extend using real DriverLib and task-local SysConfig/BSP fixtures. Both atomic helper symbols resolve; final ELF undefined-symbol lists are empty.
- UART source compiles for G3519, C1104 and L1306. L1306 Main construction compiles without FULL-DMA support; G3507 Extend bindings compile.
- Four negative compile checks reject wrong TX ownership, missing TX binding, shared TX/RX channel and Extend on a device without FULL-DMA.
- The three tested source hashes match the submitted files. clang-format21.1.8 and `git diff --check` pass.

C1104 coverage is translation-unit compilation only; its SDK header has no dedicated UART TX DMA trigger, so no usable-driver construction or hardware support is claimed for that device. No flashing, physical DMA/FIFO/IRQ-priority/RTOUT/gap timing test or fresh independent concurrency certification was performed. BSP/application and negative compile fixtures remain task-local.

Draft for manual review; merge target is `dev`.

## Sourcery 摘要

将 MSPM0 UART 后端迁移至基于序列化 DMA 的传输和持续接收处理，并通过显式资源所有权与延迟配置进行管理。

新功能：
- 将 MSPM0 UART 传输迁移至双缓冲 DMA，并支持持续的 Main 字节中断接收路径和 Extend 环形 DMA 接收路径。
- 添加显式 DMA 资源和调用方拥有的缓冲区构造 API，并通过编译时 BSP 所有权验证支持 Main 和 Extend UART 变体。

错误修复：
- 修正 MSPM0 原子比较交换 shim，使其符合五参数 GCC ABI，并添加序列化 UART 服务所需的原子 fetch-or 操作。

增强功能：
- 通过单一的序列化服务协调写入、中断、接收空间通知和延迟配置。
- 使 UART 配置更改能够验证可表示的波特率和帧格式设置，等待传输完成和 UART 空闲边界，并在配置边界丢弃尚未发布的硬件接收数据。
- 显式处理接收端背压：暂停 Main FIFO 读取，并仅丢弃 Extend DMA 中超出容量且尚未发布的数据。

文档：
- 记录 MSPM0 UART DMA 资源注解、直接资源构造、中断所有权、共享 DMA 分发以及缓冲区生命周期要求。

日常维护：
- 移除旧版 UART 超时/调试访问器，并将原有初始化宏替换为 Main 和 Extend 初始化宏。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将 MSPM0 UART 后端迁移至基于序列化 DMA 的传输模式，并通过显式资源所有权和延迟配置实现持续接收。

新功能：
- 将 MSPM0 UART 传输迁移至双缓冲 DMA，并支持由 Main 中断驱动的持续接收和基于 Extend DMA 的持续接收。
- 为 Main 和 Extend 变体添加显式的 UART/DMA 资源及调用方所有缓冲区构造 API。

错误修复：
- 使 32 位原子比较交换适配层与 GCC 运行时 ABI 保持一致，并添加序列化 UART 处理所需的原子 fetch-or 操作。

增强功能：
- 通过单一的序列化服务协调写入、中断、接收空间通知和延迟配置。
- 添加配置验证，并仅在传输完成且 UART 处于空闲状态后应用更改；在切换过程中丢弃尚未发布的硬件 RX 数据。
- 通过暂停 Main FIFO 读取来处理接收背压；对于超出软件队列容量的数据，仅丢弃 Extend DMA 数据。

文档：
- 记录 MSPM0 UART DMA 资源注解、直接资源构造、中断所有权、共享 DMA 分发以及缓冲区生命周期要求。

日常维护：
- 替换旧版初始化宏，并移除过时的 UART 超时和调试访问器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the MSPM0 UART backend to serialized DMA-based transmission and continuous reception with explicit resource ownership and deferred configuration.

New Features:
- Migrate MSPM0 UART transmission to double-buffered DMA and support continuous Main interrupt-driven and Extend DMA-based reception.
- Add explicit UART/DMA resource and caller-owned buffer construction APIs for Main and Extend variants.

Bug Fixes:
- Align the 32-bit atomic compare-exchange shim with the GCC runtime ABI and add the atomic fetch-or operation required by serialized UART processing.

Enhancements:
- Coordinate writes, interrupts, receive-space notifications, and deferred configuration through a single serialized service.
- Add configuration validation and apply changes only after transmission and UART idle boundaries, discarding unpublished hardware RX data at the transition.
- Handle receive backpressure by pausing Main FIFO reads and dropping only Extend DMA data that exceeds software queue capacity.

Documentation:
- Document MSPM0 UART DMA resource annotations, direct resource construction, interrupt ownership, shared DMA dispatch, and buffer lifetime requirements.

Chores:
- Replace the legacy initialization macro and remove obsolete UART timeout and debug accessors.

</details>

</details>