### PR TITLE
refactor: align USB CDC with RW queue scopes

### DIFF
--- a/src/driver/usb/device/cdc/cdc_to_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_to_uart.hpp
@@ -52,7 +52,7 @@ class CDCToUart : public CDCUart
   {
     // CDC->UART：CDC RX 缓冲必须能写入 UART 的 data 队列。
     // CDC->UART: the UART TX data queue must accept at least rx_buffer_size bytes.
-    ASSERT(uart_.write_port_->queue_data_->MaxSize() >= rx_buffer_size);
+    ASSERT(uart_.write_port_->Capacity() >= rx_buffer_size);
 
     // 1) CDC 读完成回调：从 CDC 读一段数据并写入 UART。
     // 1) CDC read callback: read one chunk from CDC and write it into UART.

--- a/src/driver/usb/device/cdc/cdc_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_uart.hpp
@@ -6,262 +6,42 @@
 #include "libxr_def.hpp"
 #include "libxr_rw.hpp"
 
-namespace LibXR
-{
-/**
- * @brief WritePort（info 队列 + data 队列）的“单 op 不跨界”出队辅助器
- *        Dequeue helper for WritePort (info + data) without crossing op boundary
- */
-class CDCUartTxOpDequeueHelper final
-{
- public:
-  /**
-   * @brief 构造函数
-   *        Constructor
-   *
-   * @param port 写端口引用 / Write port reference
-   */
-  explicit CDCUartTxOpDequeueHelper(WritePort& port) : port_(port) {}
-
-  /**
-   * @brief 重置内部状态（head 缓存与偏移）
-   *        Reset internal state (cached head and offset)
-   */
-  void Reset()
-  {
-    head_valid_ = false;
-    offset_ = 0;
-  }
-
-  /**
-   * @brief 是否存在可处理的 op
-   *        Whether any op exists
-   *
-   * @return true 存在缓存 head 或 info 队列非空 / Cached head exists or info queue
-   * non-empty
-   * @return false 否则 / Otherwise
-   */
-  bool HasOp() { return head_valid_ || (port_.queue_info_->Size() > 0); }
-
-  /**
-   * @brief 从 data 队列搬运数据到目标 buffer，并推进 offset（不 pop info）
-   *        Dequeue bytes from data queue into destination buffer and advance offset (no
-   * info pop)
-   *
-   * @param dst     目标 buffer / Destination buffer
-   * @param cap     目标 buffer 容量（字节）/ Destination capacity (bytes)
-   * @param out_len 实际搬运长度（字节）/ Bytes moved
-   * @return ErrorCode::PENDING / ErrorCode::OK / 其它错误码 / Other error codes
-   */
-  ErrorCode Take(uint8_t* dst, std::size_t cap, std::size_t& out_len)
-  {
-    auto ec = EnsureHead();
-    if (ec != ErrorCode::OK)
-    {
-      out_len = 0;
-      return ec;  // EMPTY / FAILED
-    }
-
-    const std::size_t REMAINING = Remaining();
-    if (REMAINING == 0)
-    {
-      out_len = 0;
-      return ErrorCode::FAILED;
-    }
-
-    const std::size_t TAKE = (REMAINING < cap) ? REMAINING : cap;
-
-    if (port_.queue_data_->PopBatch(dst, TAKE) != ErrorCode::OK)
-    {
-      out_len = 0;
-      return ErrorCode::FAILED;
-    }
-
-    offset_ += TAKE;
-    out_len = TAKE;
-
-    return (offset_ == head_.data.size_) ? ErrorCode::OK : ErrorCode::PENDING;
-  }
-
-  /**
-   * @brief head op 是否已全部出队
-   *        Whether the cached head op is fully dequeued
-   *
-   * @return true 已完成 / Completed
-   * @return false 未完成 / Not completed
-   */
-  bool HeadCompleted() const { return head_valid_ && (offset_ == head_.data.size_); }
-
-  /**
-   * @brief 在 head 完成后 pop info 并重置状态
-   *        Pop info after head completes and reset state
-   *
-   * @param completed_info 可选输出：被 pop 的 info / Optional output: popped info
-   * @return ErrorCode::OK 成功 / Success
-   * @return ErrorCode::FAILED head 未完成 / Head not completed
-   */
-  ErrorCode PopCompleted(WriteInfoBlock* completed_info = nullptr)
-  {
-    if (!HeadCompleted())
-    {
-      return ErrorCode::FAILED;
-    }
-
-    WriteInfoBlock popped{};
-    auto ans = port_.queue_info_->Pop(popped);
-    ASSERT(ans == ErrorCode::OK);
-
-    if (completed_info)
-    {
-      *completed_info = popped;
-    }
-
-    Reset();
-    return ErrorCode::OK;
-  }
-
-  /**
-   * @brief 丢弃当前 head op 的剩余数据并 pop info
-   *        Drop the current head op's remaining bytes and pop its info.
-   *
-   * @param dropped_info 可选输出：被 pop 的 info / Optional output: popped info
-   * @return ErrorCode::OK 成功 / Success
-   * @return ErrorCode::EMPTY info 队列为空 / Info queue empty
-   * @return 其它错误码表示 data 队列丢弃失败 / Other errors indicate data drop failure
-   */
-  ErrorCode DropHead(WriteInfoBlock* dropped_info = nullptr)
-  {
-    auto ec = EnsureHead();
-    if (ec != ErrorCode::OK)
-    {
-      return ec;
-    }
-
-    const std::size_t REMAINING = Remaining();
-    if (REMAINING > 0)
-    {
-      auto drop_ans = port_.queue_data_->PopBatch(nullptr, REMAINING);
-      if (drop_ans != ErrorCode::OK)
-      {
-        return drop_ans;
-      }
-    }
-
-    WriteInfoBlock popped{};
-    auto pop_ans = port_.queue_info_->Pop(popped);
-    ASSERT(pop_ans == ErrorCode::OK);
-    if (pop_ans != ErrorCode::OK)
-    {
-      return pop_ans;
-    }
-
-    if (dropped_info)
-    {
-      *dropped_info = popped;
-    }
-
-    Reset();
-    return ErrorCode::OK;
-  }
-
- private:
-  /**
-   * @brief 确保 head 缓存可用（必要时 Peek info）
-   *        Ensure cached head is valid (Peek info if needed)
-   *
-   * @return ErrorCode::OK 成功 / Success
-   * @return ErrorCode::EMPTY info 队列为空 / Info queue empty
-   */
-  ErrorCode EnsureHead()
-  {
-    if (head_valid_)
-    {
-      return ErrorCode::OK;
-    }
-
-    WriteInfoBlock info{};
-    if (port_.queue_info_->Peek(info) != ErrorCode::OK)
-    {
-      return ErrorCode::EMPTY;
-    }
-
-    head_ = info;
-    head_valid_ = true;
-    offset_ = 0;
-    return ErrorCode::OK;
-  }
-
-  /**
-   * @brief 当前 op 剩余未出队字节数
-   *        Remaining bytes of current op
-   *
-   * @return 剩余字节数 / Remaining bytes
-   */
-  std::size_t Remaining() const
-  {
-    ASSERT(head_valid_);
-    ASSERT(head_.data.size_ >= offset_);
-    return head_.data.size_ - offset_;
-  }
-
- private:
-  WritePort& port_;          ///< 写端口引用 / Write port reference
-  bool head_valid_ = false;  ///< head 缓存有效标志 / Cached head valid flag
-  WriteInfoBlock head_{};    ///< 缓存的 head info / Cached head info
-  std::size_t offset_ = 0;   ///< 当前 op 已出队偏移 / Dequeued offset within current op
-};
-
-}  // namespace LibXR
-
 namespace LibXR::USB
 {
 
 class CDCUart;
 
 /**
- * @brief CDC UART 读端口（背压 + pending 缓存）
- *        CDC UART read port (backpressure + pending cache)
+ * @brief USB CDC 接收端口 / USB CDC receive port
  */
 class CDCUartReadPort : public ReadPort
 {
  public:
   /**
-   * @brief 构造函数
-   *        Constructor
-   *
-   * @param size  RX 缓冲区大小 / RX buffer size
-   * @param owner 所属 CDCUart 实例 / Owning CDCUart instance
+   * @brief 构造接收端口 / Construct the receive port
+   * @param size 接收缓冲区大小 / Receive buffer size
+   * @param owner 所属 CDC UART / Owning CDC UART
    */
   explicit CDCUartReadPort(uint32_t size, CDCUart& owner) : ReadPort(size), owner_(owner)
   {
   }
 
+ protected:
   /**
-   * @brief 数据队列被消费时回调（解除背压并尝试恢复 OUT rearm）
-   *        Called when RX queue is dequeued (lift backpressure and try to rearm OUT)
-   *
-   * @param in_isr 是否在 ISR 上下文 / In ISR context
+   * @brief 在接收队列腾出空间后恢复接收 / Resume reception when queue space is available
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
    */
-  void OnRxDequeue(bool in_isr) override;
+  void OnReadQueueSpaceAvailable(bool in_isr) override;
 
-  CDCUartReadPort& operator=(ReadFun fun)
-  {
-    ReadPort::operator=(fun);
-    return *this;
-  }
-
-  CDCUart& owner_;  ///< 所属 CDCUart / Owning CDCUart
-
-  bool recv_pause_ =
-      false;  ///< 背压标志：true 表示 OUT 未 rearm / Backpressure flag: OUT not rearmed
-  ConstRawData pending_data_{
-      nullptr,
-      0};  ///< pending 数据（指向底层 USB buffer）/ Pending data pointing to USB buffer
+ public:
+  CDCUart& owner_;           ///< 所属 CDC UART / Owning CDC UART
+  bool recv_pause_ = false;  ///< 接收暂停标志 / Receive pause flag
+  ConstRawData pending_data_{nullptr,
+                             0};  ///< 待入队的端点数据 / Endpoint data awaiting enqueue
 };
 
 /**
- * @brief USB CDC-ACM UART 适配器
- *        USB CDC-ACM UART adapter
+ * @brief USB CDC-ACM UART 适配器 / USB CDC-ACM UART adapter
  */
 class CDCUart : public CDCBase, public LibXR::UART
 {
@@ -272,15 +52,15 @@ class CDCUart : public CDCBase, public LibXR::UART
   using LibXR::UART::write_port_;
 
   /**
-   * @brief 构造函数
-   *        Constructor
-   *
-   * @param rx_buffer_size RX 缓冲区大小 / RX buffer size
-   * @param tx_buffer_size TX 端点缓冲区大小 / TX endpoint buffer size
-   * @param tx_queue_size  TX info 队列深度 / TX info queue depth
-   * @param data_in_ep_num  Data IN 端点号 / Data IN EP number
-   * @param data_out_ep_num Data OUT 端点号 / Data OUT EP number
-   * @param comm_ep_num     通信端点号 / Comm EP number
+   * @brief 构造 CDC UART / Construct the CDC UART
+   * @param data_in_ep_num 数据 IN 端点号 / Data IN endpoint number
+   * @param data_out_ep_num 数据 OUT 端点号 / Data OUT endpoint number
+   * @param comm_ep_num 通信端点号 / Communication endpoint number
+   * @param rx_buffer_size 接收队列容量 / Receive queue capacity
+   * @param tx_buffer_size 发送数据队列容量 / Transmit data queue capacity
+   * @param tx_queue_size 发送请求队列容量 / Transmit request queue capacity
+   * @param control_interface_string 控制接口名称 / Control interface name
+   * @param data_interface_string 数据接口名称 / Data interface name
    */
   CDCUart(
       Endpoint::EPNumber data_in_ep_num, Endpoint::EPNumber data_out_ep_num,
@@ -292,22 +72,21 @@ class CDCUart : public CDCBase, public LibXR::UART
                 data_interface_string),
         LibXR::UART(&read_port_cdc_, &write_port_cdc_),
         read_port_cdc_(rx_buffer_size, *this),
-        write_port_cdc_(tx_queue_size, tx_buffer_size),
-        tx_deq_(write_port_cdc_)
+        write_port_cdc_(tx_queue_size, tx_buffer_size)
   {
-    read_port_cdc_ = ReadFun;    // NOLINT
     write_port_cdc_ = WriteFun;  // NOLINT
   }
 
   /**
-   * @brief 设置 UART 配置（CDC Line Coding）
-   *        Set UART configuration (CDC Line Coding)
-   *
+   * @brief 设置 CDC 线路编码 / Set CDC line coding
    * @param cfg UART 配置 / UART configuration
-   * @return 错误码 / Error code
+   * @param in_isr 是否在中断中调用，本实现不使用 / ISR context, unused by this
+   * implementation
+   * @return 配置结果 / Configuration result
    */
-  ErrorCode SetConfig(UART::Configuration cfg, bool = false) override
+  ErrorCode SetConfig(UART::Configuration cfg, bool in_isr = false) override
   {
+    UNUSED(in_isr);
     auto& line_coding = GetLineCoding();
 
     switch (cfg.stop_bits)
@@ -356,431 +135,232 @@ class CDCUart : public CDCBase, public LibXR::UART
   }
 
   /**
-   * @brief 尝试 rearm OUT（背压恢复/持续接收）
-   *        Try to rearm OUT endpoint (backpressure recovery / continuous RX)
-   *
-   * @param in_isr 是否在 ISR 上下文 / In ISR context
-   * @return true 成功 rearm / Rearmed successfully
-   * @return false 未 rearm（忙/空间不足/端点不可用）/ Not rearmed (busy / insufficient
-   * space / endpoint unavailable)
+   * @brief 回填暂存数据并重新启动 OUT 接收 / Enqueue saved data and restart OUT reception
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
+   * @return 是否成功启动接收 / Whether reception was started
    */
   bool TryRearmOut(bool in_isr)
   {
-    auto ep_data_out = GetDataOutEndpoint();
-    if (ep_data_out == nullptr)
+    auto* ep = GetDataOutEndpoint();
+    if (ep == nullptr || ep->MaxPacketSize() == 0U || !read_port_cdc_.Readable())
     {
       return false;
     }
 
-    const std::size_t MPS = ep_data_out->MaxPacketSize();
-    if (MPS == 0 || read_port_cdc_.queue_data_ == nullptr)
+    if (read_port_cdc_.recv_pause_ && read_port_cdc_.pending_data_.size_ != 0U)
     {
-      return false;
-    }
-
-    if (read_port_cdc_.recv_pause_)
-    {
-      if (read_port_cdc_.queue_data_->EmptySize() >= read_port_cdc_.pending_data_.size_)
+      auto queue = read_port_cdc_.GetReadQueue(in_isr);
+      if (queue.EmptySize() < read_port_cdc_.pending_data_.size_)
       {
-        auto push_ans = read_port_cdc_.queue_data_->PushBatch(
-            reinterpret_cast<const uint8_t*>(read_port_cdc_.pending_data_.addr_),
-            read_port_cdc_.pending_data_.size_);
-        if (push_ans == ErrorCode::OK)
-        {
-          read_port_cdc_.ProcessPendingReads(in_isr);
-        }
-        else
-        {
-          return false;
-        }
-      }
-      else
-      {
+        queue.Publish();
         return false;
       }
+
+      const auto ans =
+          queue.PushBatch(static_cast<const uint8_t*>(read_port_cdc_.pending_data_.addr_),
+                          read_port_cdc_.pending_data_.size_);
+      ASSERT(ans == ErrorCode::OK);
+      read_port_cdc_.pending_data_ = {nullptr, 0};
+      queue.Publish();
     }
 
-    if (ep_data_out->GetState() == Endpoint::State::BUSY)
+    if (ep->GetState() != Endpoint::State::IDLE)
     {
       return false;
     }
 
-    auto ans = ep_data_out->Transfer(MPS);
+    const auto ans = ep->Transfer(ep->MaxPacketSize());
     if (ans == ErrorCode::OK)
     {
       read_port_cdc_.recv_pause_ = false;
       return true;
     }
-
     return false;
   }
 
  protected:
   /**
-   * @brief 解绑端点（清理队列、状态与背压标志）
-   *        Unbind endpoints (cleanup queues, states, and backpressure flags)
-   *
+   * @brief 解绑端点并清理接收暂存状态 / Unbind endpoints and clear saved receive state
    * @param endpoint_pool 端点池 / Endpoint pool
-   * @param in_isr        是否在 ISR 上下文 / In ISR context
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
    */
   void UnbindEndpoints(EndpointPool& endpoint_pool, bool in_isr) override
   {
     CDCBase::UnbindEndpoints(endpoint_pool, in_isr);
-    tx_deq_.Reset();
-    write_port_cdc_.FailAndClearAll(ErrorCode::INIT_ERR, in_isr);
-    read_port_cdc_.FailAndClearAll(ErrorCode::INIT_ERR, in_isr);
-
     need_write_zlp_ = false;
-
     read_port_cdc_.recv_pause_ = false;
     read_port_cdc_.pending_data_ = {nullptr, 0};
   }
 
   /**
-   * @brief 写端口回调（TX）
-   *        Write port callback (TX)
-   *
-   * @details
-   * - 允许在一次调用内对同一个 op 触发多次 Transfer（每次预写后检查是否可立即发送）
-   *   Allows multiple Transfer kicks for the same op within one call (check-send after
-   * each prefill)
-   * - 仅当启动该 op 最后一段 Transfer 后返回非 PENDING
-   *   Return non-PENDING only after the last segment Transfer of the op is kicked
-   * - 预写仅执行 Take + SetActiveLength，不调用 Finish
-   *   Prefill performs Take + SetActiveLength only; Finish is not called here
-   *
-   * @param port  写端口 / Write port
-   * @param in_isr 是否在 ISR 上下文 / In ISR context
-   * @return 错误码 / Error code
+   * @brief 推进发送队列 / Advance the transmit queue
+   * @param port 写端口 / Write port
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
    */
-  static ErrorCode WriteFun(WritePort& port, bool in_isr)
+  static void WriteFun(WritePort& port, bool in_isr)
   {
-    UNUSED(in_isr);
-
     auto* cdc = LibXR::ContainerOf(&port, &CDCUart::write_port_cdc_);
-
-    /**
-     * @note
-     * 不在 IN ISR；否则由 IN ISR 处理。
-     * Not in IN ISR; otherwise handled by IN ISR.
-     */
-    if (cdc->in_write_isr_.IsSet())
+    if (!cdc->in_write_isr_.IsSet())
     {
-      return ErrorCode::PENDING;
-    }
-
-    auto ep = cdc->GetDataInEndpoint();
-    if (ep == nullptr)
-    {
-      auto drop_ans = cdc->tx_deq_.DropHead(nullptr);
-      if (drop_ans != ErrorCode::OK)
-      {
-        return drop_ans;
-      }
-      return ErrorCode::FAILED;
-    }
-
-    if (!cdc->Inited())
-    {
-      auto drop_ans = cdc->tx_deq_.DropHead(nullptr);
-      if (drop_ans != ErrorCode::OK)
-      {
-        return drop_ans;
-      }
-
-      return ErrorCode::INIT_ERR;  // 非 PENDING -> 同步上报失败 / Non-PENDING reports
-                                   // synchronous failure upstream
-    }
-
-    /**
-     * @note
-     * 入口条件：ActiveLength==0 。
-     * Entry condition: ActiveLength==0.
-     */
-    if (ep->GetActiveLength() != 0)
-    {
-      return ErrorCode::PENDING;
-    }
-
-    /**
-     * @note
-     * 若出现新数据，则取消 ZLP。
-     * Cancel pending ZLP if new data becomes available.
-     */
-    if (cdc->tx_deq_.HasOp())
-    {
-      cdc->need_write_zlp_ = false;
-    }
-
-    /**
-     * @brief 当前 ActiveLength 槽对应数据段的完成态
-     *        Completion state associated with the current ActiveLength slot
-     */
-    ErrorCode slot_ec = ErrorCode::PENDING;
-
-    // 预写第一段 / Prefill first segment
-    {
-      auto buffer = ep->GetBuffer();
-      std::size_t len = 0;
-
-      slot_ec =
-          cdc->tx_deq_.Take(reinterpret_cast<uint8_t*>(buffer.addr_), buffer.size_, len);
-      if (slot_ec == ErrorCode::EMPTY || len == 0)
-      {
-        return ErrorCode::PENDING;
-      }
-      if (slot_ec != ErrorCode::OK && slot_ec != ErrorCode::PENDING)
-      {
-        return slot_ec;
-      }
-
-      ep->SetActiveLength(len);
-    }
-
-    std::atomic_signal_fence(std::memory_order_seq_cst);
-
-    // 循环：可立即发送则发送；发送后预写下一段并继续检查 / Loop: send if possible; then
-    // prefill next segment
-    while (true)
-    {
-      const std::size_t TO_SEND = ep->GetActiveLength();
-
-      /**
-       * @note
-       * 不可发送条件 / Not-sendable conditions:
-       * - 端点非 IDLE / Endpoint not IDLE
-       * - ActiveLength==0（槽已被清零或未发布）/ ActiveLength==0 (slot cleared or not
-       * published)
-       * - 当前时刻无可处理 op（避免预写段在并发路径被消费后继续推进）/ No op available at
-       * this moment
-       */
-      if (ep->GetState() != Endpoint::State::IDLE || TO_SEND == 0 ||
-          !cdc->tx_deq_.HasOp())
-      {
-        return ErrorCode::PENDING;
-      }
-
-      std::atomic_signal_fence(std::memory_order_seq_cst);
-
-      // 启动一次 Transfer / Kick one Transfer
-      ep->SetActiveLength(0);
-      auto ans = ep->Transfer(TO_SEND);
-      ASSERT(ans == ErrorCode::OK);
-
-      /**
-       * @note
-       * 若本次启动的是该 op 最后一段：启动后 pop，并返回 OK 触发 finish。
-       * If this kicked segment is the last of the op: pop after kick and return OK to
-       * trigger finish.
-       */
-      if (slot_ec == ErrorCode::OK && cdc->tx_deq_.HeadCompleted())
-      {
-        auto pop_ok = cdc->tx_deq_.PopCompleted(nullptr);
-        ASSERT(pop_ok == ErrorCode::OK);
-
-        // ZLP 判定。
-        // ZLP decision.
-        const std::size_t MPS = ep->MaxPacketSize();
-        if (MPS > 0 && (TO_SEND % MPS) == 0 && ep->GetActiveLength() == 0 &&
-            !cdc->tx_deq_.HasOp())
-        {
-          cdc->need_write_zlp_ = true;
-        }
-
-        return ErrorCode::OK;  // 非 PENDING -> 上层完成一次 / Non-PENDING triggers one
-                               // upstream finish
-      }
-
-      // 预写下一段。
-      // Prefill the next segment.
-      if (!cdc->tx_deq_.HasOp())
-      {
-        return ErrorCode::PENDING;
-      }
-
-      auto buffer = ep->GetBuffer();
-      std::size_t len2 = 0;
-
-      slot_ec =
-          cdc->tx_deq_.Take(reinterpret_cast<uint8_t*>(buffer.addr_), buffer.size_, len2);
-      if (slot_ec == ErrorCode::EMPTY || len2 == 0)
-      {
-        return ErrorCode::PENDING;
-      }
-      if (slot_ec != ErrorCode::OK && slot_ec != ErrorCode::PENDING)
-      {
-        return slot_ec;
-      }
-
-      ep->SetActiveLength(len2);
-      // 下一轮继续检查是否可立即发送。
-      // The next iteration checks whether sending can continue immediately.
+      cdc->ProgressTx(in_isr);
     }
   }
 
-  static ErrorCode ReadFun(ReadPort&, bool) { return ErrorCode::PENDING; }
-
   /**
-   * @brief OUT 完成回调（RX）
-   *        OUT complete callback (RX)
-   *
-   * @param in_isr 是否在 ISR 上下文 / In ISR context
-   * @param data   OUT 接收数据 / Received OUT data
+   * @brief 将 OUT 数据放入接收队列 / Enqueue completed OUT data
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
+   * @param data 收到的端点数据 / Received endpoint data
    */
   void OnDataOutComplete(bool in_isr, ConstRawData& data) override
   {
-    if (data.size_ > 0)
+    if (data.size_ != 0U)
     {
-      auto push_ans = read_port_cdc_.queue_data_->PushBatch(
-          reinterpret_cast<const uint8_t*>(data.addr_), data.size_);
-      if (push_ans == ErrorCode::OK)
-      {
-        read_port_cdc_.ProcessPendingReads(in_isr);
-      }
-      else
+      auto queue = read_port_cdc_.GetReadQueue(in_isr);
+      if (queue.EmptySize() < data.size_)
       {
         read_port_cdc_.recv_pause_ = true;
         read_port_cdc_.pending_data_ = data;
+        queue.Publish();
         return;
       }
-    }
 
+      const auto ans =
+          queue.PushBatch(static_cast<const uint8_t*>(data.addr_), data.size_);
+      ASSERT(ans == ErrorCode::OK);
+      queue.Publish();
+    }
     (void)TryRearmOut(in_isr);
   }
 
   /**
-   * @brief IN 完成回调（TX）
-   *        IN complete callback (TX)
-   *
-   * @param in_isr 是否在 ISR 上下文 / In ISR context
-   * @param data   IN 数据（未使用）/ IN data (unused)
+   * @brief 在 IN 完成后续发数据或零长度包 / Send more data or a ZLP after IN completion
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
+   * @param data 已发送的端点数据，本实现不使用 / Sent endpoint data, unused here
    */
   void OnDataInComplete(bool in_isr, ConstRawData& data) override
   {
     UNUSED(data);
-
     Flag::ScopedRestore isr_flag(in_write_isr_);
-
-    auto ep = GetDataInEndpoint();
-    if (ep == nullptr)
+    auto* ep = GetDataInEndpoint();
+    if (ep == nullptr || !Inited())
     {
       return;
     }
 
-    if (!Inited())
-    {
-      tx_deq_.Reset();
-      write_port_cdc_.FailAndClearAll(ErrorCode::INIT_ERR, in_isr);
-      return;
-    }
-
-    // ZLP：仅在此刻跨-op 无数据时发送。
-    // Send the ZLP only when there is no data left across ops at this moment.
     if (need_write_zlp_)
     {
-      if (ep->GetActiveLength() == 0 && !tx_deq_.HasOp())
+      if (ep->GetActiveLength() == 0U && write_port_cdc_.Size() == 0U)
       {
-        auto z = ep->TransferZLP();
-        ASSERT(z == ErrorCode::OK);
+        const auto ans = ep->TransferZLP();
+        ASSERT(ans == ErrorCode::OK);
         need_write_zlp_ = false;
         return;
       }
       need_write_zlp_ = false;
     }
-
-    // ActiveLength==0 时不读取队列。
-    // Do not read queues when ActiveLength==0.
-    const std::size_t PENDING_LEN = ep->GetActiveLength();
-    if (PENDING_LEN == 0)
-    {
-      return;
-    }
-
-    // 1) 续发：本 ISR 仅启动一次 Transfer。
-    // 1) Continue: kick only one Transfer in this ISR.
-    ep->SetActiveLength(0);
-    auto ans = ep->Transfer(PENDING_LEN);
-    ASSERT(ans == ErrorCode::OK);
-
-    // 2) 若为 head op 最后一段：启动后 pop + Finish 一次。
-    // 2) If this is the last segment of the head op, pop + Finish once after kick-off.
-    if (tx_deq_.HeadCompleted())
-    {
-      WriteInfoBlock completed{};
-      auto pop_ok = tx_deq_.PopCompleted(&completed);
-      ASSERT(pop_ok == ErrorCode::OK);
-      write_port_cdc_.Finish(in_isr, ErrorCode::OK, completed);
-    }
-
-    // 3) 预写：仅在已启动 Transfer 后允许读取队列。
-    // 3) Prefill: queue reads are allowed only after a Transfer has been kicked.
-    bool primed = false;
-    if (tx_deq_.HasOp())
-    {
-      auto buffer = ep->GetBuffer();
-      std::size_t len2 = 0;
-
-      auto ec2 =
-          tx_deq_.Take(reinterpret_cast<uint8_t*>(buffer.addr_), buffer.size_, len2);
-      if ((ec2 == ErrorCode::OK || ec2 == ErrorCode::PENDING) && len2 > 0)
-      {
-        ep->SetActiveLength(len2);
-        primed = true;
-      }
-    }
-
-    // 4) ZLP 判定 / ZLP decision
-    const std::size_t MPS = ep->MaxPacketSize();
-    if (!primed && PENDING_LEN > 0 && MPS > 0 && (PENDING_LEN % MPS) == 0 &&
-        ep->GetActiveLength() == 0 && !tx_deq_.HasOp())
-    {
-      need_write_zlp_ = true;
-    }
+    ProgressTx(in_isr);
   }
 
  private:
-  CDCUartReadPort read_port_cdc_;    ///< CDC RX 读端口 / CDC RX read port
-  LibXR::WritePort write_port_cdc_;  ///< CDC TX 写端口 / CDC TX write port
-
-  LibXR::CDCUartTxOpDequeueHelper tx_deq_;  ///< TX 出队辅助器 / TX dequeue helper
-
-  Flag::Plain in_write_isr_;  ///< 写 ISR 保护标志 / Write ISR guard flag
-
-  bool need_write_zlp_{false};  ///< ZLP 需求标志 / ZLP required flag
-};
-
-inline void CDCUartReadPort::OnRxDequeue(bool in_isr)
-{
-  if (!recv_pause_)
+  /**
+   * @brief 启动已填充的 IN 缓冲区 / Start the filled IN buffer
+   * @param ep 数据 IN 端点 / Data IN endpoint
+   */
+  void StartTxBuffer(Endpoint& ep)
   {
-    return;
+    const size_t LENGTH = ep.GetActiveLength();
+    ASSERT(LENGTH != 0U);
+    ep.SetActiveLength(0U);
+    const auto ans = ep.Transfer(LENGTH);
+    ASSERT(ans == ErrorCode::OK);
+    const size_t MPS = ep.MaxPacketSize();
+    need_write_zlp_ = MPS != 0U && LENGTH % MPS == 0U;
   }
 
-  // pending_data_ 回填 / Push pending_data_ back into queue
-  if (pending_data_.size_ > 0)
+  /**
+   * @brief 将队首数据复制到 IN 缓冲区 / Copy the front request into the IN buffer
+   * @param ep 数据 IN 端点 / Data IN endpoint
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
+   * @note 完成回调前先发布缓冲区长度和传输状态。
+   *       Publish buffer length and transfer state before the completion callback.
+   */
+  void FillTxBuffer(Endpoint& ep, bool in_isr)
   {
-    if (queue_data_->EmptySize() >= pending_data_.size_)
-    {
-      auto ans = queue_data_->PushBatch(
-          reinterpret_cast<const uint8_t*>(pending_data_.addr_), pending_data_.size_);
-      if (ans == ErrorCode::OK)
-      {
-        pending_data_ = {nullptr, 0};
-        ProcessPendingReads(in_isr);
-      }
-      else
-      {
-        return;
-      }
-    }
-    else
+    auto queue = write_port_cdc_.GetWriteQueue(in_isr);
+    if (queue.Empty())
     {
       return;
     }
+
+    const auto buffer = ep.GetBuffer();
+    ASSERT(buffer.addr_ != nullptr && buffer.size_ != 0U);
+    const size_t LENGTH =
+        queue.PopWithWriter(buffer.size_,
+                            [buffer](const uint8_t* first, size_t first_size,
+                                     const uint8_t* second, size_t second_size) -> size_t
+                            {
+                              auto* dst = static_cast<uint8_t*>(buffer.addr_);
+                              if (first_size != 0U)
+                              {
+                                std::memcpy(dst, first, first_size);
+                              }
+                              if (second_size != 0U)
+                              {
+                                std::memcpy(dst + first_size, second, second_size);
+                              }
+                              return first_size + second_size;
+                            });
+    ASSERT(LENGTH != 0U && LENGTH <= UINT16_MAX);
+    ep.SetActiveLength(static_cast<uint16_t>(LENGTH));
+    need_write_zlp_ = false;
+    if (ep.GetState() == Endpoint::State::IDLE)
+    {
+      StartTxBuffer(ep);
+    }
   }
 
-  // 尝试恢复 rearm / Try to rearm OUT
-  (void)owner_.TryRearmOut(in_isr);
+  /**
+   * @brief 续发已填充的数据并预填下一缓冲区 / Send prepared data and prefill the next
+   * buffer
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
+   */
+  void ProgressTx(bool in_isr)
+  {
+    auto* ep = GetDataInEndpoint();
+    if (ep == nullptr || !Inited() || ep->GetState() != Endpoint::State::IDLE)
+    {
+      return;
+    }
+
+    if (ep->GetActiveLength() != 0U)
+    {
+      StartTxBuffer(*ep);
+    }
+    else
+    {
+      FillTxBuffer(*ep, in_isr);
+    }
+
+    if (ep->GetState() == Endpoint::State::BUSY && ep->UseDoubleBuffer() &&
+        ep->GetActiveLength() == 0U)
+    {
+      FillTxBuffer(*ep, in_isr);
+    }
+  }
+
+  CDCUartReadPort read_port_cdc_;    ///< CDC 接收端口 / CDC receive port
+  LibXR::WritePort write_port_cdc_;  ///< CDC 发送端口 / CDC transmit port
+  Flag::Plain
+      in_write_isr_;  ///< IN 完成回调执行标志 / IN completion callback active flag
+  bool need_write_zlp_ = false;  ///< 待发送零长度包 / Pending zero-length packet
+};
+
+inline void CDCUartReadPort::OnReadQueueSpaceAvailable(bool in_isr)
+{
+  if (recv_pause_)
+  {
+    (void)owner_.TryRearmOut(in_isr);
+  }
 }
 
 }  // namespace LibXR::USB


### PR DESCRIPTION
USB CDC still references the removed RW callbacks and private queues after the frontend migration. This change moves RX production to ReadQueue, TX consumption and completion to short WriteQueue scopes, and CDCToUart's capacity check to the public API.

Only two headers change. Endpoint buffer length and transfer state are set before each write scope completes; pending reads use explicit publication and the read-space hook. The old dequeue helper and manual Finish/FailAndClearAll calls are removed.

This is the previously agreed interface-alignment slice. USB TX serialization, reset/reconfiguration, late completions, and endpoint-buffer lifetime remain unresolved follow-up work; this PR does not establish concurrent or hardware USB correctness.

Validation: Linux Debug full runner and task-local serial endpoint/bridge checks pass with development assertions enabled. The serial checks cover split requests, FIFO/ring wrap, completion after stable buffer state, unavailable/stalled pause, ZLP waiting, RX backpressure, and bidirectional CDCToUart pumping. ESP32-S3 with ESP-IDF 5.5.2 compiles, links the real USB device/endpoint and CDCToUart paths, and generates a firmware image. No hardware flashing or USB runtime test was performed. Verification fixtures stay outside the repository.

## Sourcery 总结

使 USB CDC 队列访问和传输处理与已迁移的读写队列接口保持一致。

改进：
- 使 USB CDC 的接收和发送处理与公开的读写队列作用域接口保持一致。
- 使用作用域队列操作和端点传输推进，替换 CDC 专用的队列出队及手动完成处理。
- 使用公开的 UART 写端口容量 API 对 `CDCToUart` 进行验证。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使 USB CDC 队列访问和传输处理与公开的读写队列接口保持一致。

Bug 修复：
- 使 USB CDC 的接收和发送处理与已迁移的公开读写队列接口保持一致。

增强功能：
- 使用作用域队列操作和端点传输推进机制，替换 CDC 特有的发送出队处理和手动完成处理。
- 使用公开的 UART 写端口容量 API 进行 CDCToUart 验证。
- 更新接收端背压恢复机制，使用显式队列发布和读空间可用性钩子。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align USB CDC queue access and transfer handling with the public read/write queue interfaces.

Bug Fixes:
- Align USB CDC receive and transmit processing with the migrated public read/write queue interfaces.

Enhancements:
- Replace CDC-specific transmit dequeuing and manual completion handling with scoped queue operations and endpoint transfer progression.
- Use the public UART write-port capacity API for CDCToUart validation.
- Update receive backpressure recovery to use explicit queue publication and the read-space availability hook.

</details>

</details>