### PR TITLE
fix(stm32): complete Cortex-M0 atomic fallbacks

### DIFF
--- a/driver/st/stm32_atomic_shim.c
+++ b/driver/st/stm32_atomic_shim.c
@@ -3,24 +3,52 @@
 #if defined(STM32F0) || defined(STM32G0) || defined(STM32L0)
 
 /**
+ * @brief 保存中断状态并进入原子操作 / Save interrupt state and enter an atomic operation.
+ * @return 进入前的 PRIMASK / PRIMASK before entry.
+ */
+static inline uint32_t AtomicEnter(void)
+{
+  const uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+  __DMB();
+  return primask;
+}
+
+/**
+ * @brief 完成原子操作并恢复中断状态 / Finish an atomic operation and restore interrupts.
+ * @param primask 进入前的 PRIMASK / PRIMASK saved on entry.
+ */
+static inline void AtomicExit(uint32_t primask)
+{
+  __DMB();
+  __set_PRIMASK(primask);
+}
+
+/* GCC 定长运行时接口有五个参数，使用独立名称避开六参数内建声明。
+ * Name the five-argument runtime helper separately from the six-argument builtin. */
+__attribute__((weak, used)) _Bool libxr_atomic_compare_exchange_4(
+    volatile void* ptr, void* expected, unsigned int desired, int success_memorder,
+    int failure_memorder) __asm__("__atomic_compare_exchange_4");
+
+/**
  * @brief  模拟实现 __atomic_compare_exchange_4 函数 / Simulate the
  * __atomic_compare_exchange_4 function
  * @param  ptr 指向原子变量的指针 / Pointer to the atomic variable
  * @param  expected 预期值的指针，如果比较失败会更新为实际值 / Pointer to the expected
  * value, updated with actual value if comparison fails
  * @param  desired 需要交换的新值 / The new value to be stored if the comparison succeeds
- * @param  weak 忽略参数，保留以兼容 / Ignored parameter, kept for compatibility
  * @param  success_memorder 成功时的内存顺序标志（忽略） / Memory order on success
  * (ignored)
  * @param  failure_memorder 失败时的内存顺序标志（忽略） / Memory order on failure
  * (ignored)
  * @retval 返回 1 表示成功，0 表示失败 / Returns 1 on success, 0 on failure
  */
-__attribute__((weak, used)) _Bool
-__atomic_compare_exchange_4(volatile void* ptr, void* expected, unsigned int desired,
-                            _Bool weak, int success_memorder, int failure_memorder)
+__attribute__((weak, used)) _Bool libxr_atomic_compare_exchange_4(volatile void* ptr,
+                                                                  void* expected,
+                                                                  unsigned int desired,
+                                                                  int success_memorder,
+                                                                  int failure_memorder)
 {
-  UNUSED(weak);
   UNUSED(success_memorder);
   UNUSED(failure_memorder);
 
@@ -28,7 +56,7 @@ __atomic_compare_exchange_4(volatile void* ptr, void* expected, unsigned int des
   unsigned int expected_val = *(unsigned int*)expected;
   int result;
 
-  __disable_irq();
+  const uint32_t primask = AtomicEnter();
   if (*addr == expected_val)
   {
     *addr = desired;
@@ -39,7 +67,7 @@ __atomic_compare_exchange_4(volatile void* ptr, void* expected, unsigned int des
     *(unsigned int*)expected = *addr;
     result = 0;
   }
-  __enable_irq();
+  AtomicExit(primask);
   return result;
 }
 
@@ -56,9 +84,9 @@ __attribute__((weak, used)) void __atomic_store_4(volatile void* ptr, unsigned i
   UNUSED(memorder);
 
   volatile unsigned int* addr = (volatile unsigned int*)ptr;
-  __disable_irq();
+  const uint32_t primask = AtomicEnter();
   *addr = val;
-  __enable_irq();
+  AtomicExit(primask);
 }
 
 /**
@@ -74,9 +102,9 @@ __attribute__((weak, used)) unsigned int __atomic_load_4(const volatile void* pt
 
   volatile unsigned int* addr = (volatile unsigned int*)ptr;
   unsigned int val;
-  __disable_irq();
+  const uint32_t primask = AtomicEnter();
   val = *addr;
-  __enable_irq();
+  AtomicExit(primask);
   return val;
 }
 
@@ -95,10 +123,10 @@ __attribute__((weak, used)) unsigned int __atomic_exchange_4(volatile void* ptr,
 
   volatile unsigned int* addr = (volatile unsigned int*)ptr;
   unsigned int old_val;
-  __disable_irq();
+  const uint32_t primask = AtomicEnter();
   old_val = *addr;
   *addr = val;
-  __enable_irq();
+  AtomicExit(primask);
   return old_val;
 }
 
@@ -117,10 +145,10 @@ __attribute__((weak, used)) unsigned int __atomic_fetch_add_4(volatile void* ptr
 
   volatile unsigned int* addr = (volatile unsigned int*)ptr;
   unsigned int old_val;
-  __disable_irq();
+  const uint32_t primask = AtomicEnter();
   old_val = *addr;
   *addr = old_val + val;
-  __enable_irq();
+  AtomicExit(primask);
   return old_val;
 }
 
@@ -139,75 +167,31 @@ __attribute__((weak, used)) unsigned int __atomic_fetch_sub_4(volatile void* ptr
 
   volatile unsigned int* addr = (volatile unsigned int*)ptr;
   unsigned int old_val;
-  __disable_irq();
+  const uint32_t primask = AtomicEnter();
   old_val = *addr;
   *addr = old_val - val;
-  __enable_irq();
+  AtomicExit(primask);
   return old_val;
 }
 
 /**
- * @brief  模拟实现 __atomic_exchange_1 函数 / Simulate the __atomic_exchange_1 function
- * @param  ptr 指向原子变量（1字节大小）的指针 / Pointer to the 1-byte atomic variable
- * @param  val 需要存储的新值 / The new value to be stored
- * @param  memorder 内存顺序标志（忽略） / Memory order (ignored)
- * @retval 交换前的旧值 / Returns the old value before exchange
+ * @brief 原子置位并返回原值 / Atomically set bits and return the previous value.
+ * @param ptr 目标字地址 / Target word address.
+ * @param val 待置位的掩码 / Bits to set.
+ * @param memorder 内存顺序，本实现统一使用屏障 / Memory order; barriers are always used.
+ * @return 更新前的值 / Value before the update.
  */
-__attribute__((weak, used)) unsigned char __atomic_exchange_1(volatile void* ptr,
-                                                              unsigned char val,
-                                                              int memorder)
+__attribute__((weak, used)) unsigned int __atomic_fetch_or_4(volatile void* ptr,
+                                                             unsigned int val,
+                                                             int memorder)
 {
   UNUSED(memorder);
-
-  volatile unsigned char* addr = (volatile unsigned char*)ptr;
-  unsigned char old_val;
-  __disable_irq();
-  old_val = *addr;
-  *addr = val;
-  __enable_irq();
+  volatile unsigned int* addr = (volatile unsigned int*)ptr;
+  const uint32_t primask = AtomicEnter();
+  const unsigned int old_val = *addr;
+  *addr = old_val | val;
+  AtomicExit(primask);
   return old_val;
 }
-
-/**
- * @brief  模拟实现 __atomic_store_1 函数 / Simulate the __atomic_store_1 function
- * @param  ptr 指向原子变量（1字节大小）的指针 / Pointer to the 1-byte atomic variable
- * @param  val 需要存储的新值 / The new value to be stored
- * @param  memorder 内存顺序标志（忽略） / Memory order (ignored)
- * @retval 无返回值 / None
- */
-__attribute__((weak, used)) void __atomic_store_1(volatile void* ptr, unsigned char val,
-                                                  int memorder)
-{
-  UNUSED(memorder);
-
-  volatile unsigned char* addr = (volatile unsigned char*)ptr;
-  __disable_irq();
-  *addr = val;
-  __enable_irq();
-}
-
-/**
- * @brief  模拟实现 __atomic_test_and_set 函数 / Simulate the __atomic_test_and_set
- * function
- * @param  ptr 指向原子标志位的指针 / Pointer to the atomic flag variable
- * @param  memorder 内存顺序标志（忽略） / Memory order (ignored)
- * @retval 返回之前的值 / Returns the previous value (0 or 1)
- */
-#if !defined(__clang__)
-__attribute__((weak, used)) _Bool __atomic_test_and_set(volatile void* ptr, int memorder)
-{
-  UNUSED(memorder);
-
-  volatile unsigned char* addr = (volatile unsigned char*)ptr;
-  _Bool old_val;
-
-  __disable_irq();
-  old_val = *addr;
-  *addr = 1;  // 设置为1
-  __enable_irq();
-
-  return old_val;
-}
-#endif
 
 #endif

--- a/driver/st/stm32_uart.hpp
+++ b/driver/st/stm32_uart.hpp
@@ -193,7 +193,7 @@ class STM32UART : public UART
 
  private:
   /// 待应用配置的发布阶段 / Pending configuration publication phase.
-  enum class ConfigState : uint8_t
+  enum class ConfigState : uint32_t
   {
     EMPTY = 0U,
     RESERVED = 1U,


### PR DESCRIPTION
STM32F0/G0/L0 cannot link the migrated RW path because the fallback lacks word fetch-or. Existing fallback operations also unconditionally enable interrupts on return, breaking callers that entered with PRIMASK set.

Preserve PRIMASK across word operations with memory barriers, add __atomic_fetch_or_4, and align word CAS with the five-argument sized runtime ABI. Change STM32UART's private ConfigState from uint8_t to uint32_t so it uses the existing word CAS contract. Remove the unused byte fallback functions. Only the STM32 atomic shim and UART header change; configuration transitions and public RW behavior are unchanged.

Validation: the original ARMv6-M fetch-or link probe and masked-entry IRQ probe fail as expected. The revised candidate passes word-operation/IRQ checks for both entry mask states and F0/G0/L0 vendor-header compilation. Full STM32G0B1 UART firmware with a polling operation links successfully, has no undefined symbols, and contains no byte atomic runtime symbols. The C++ polling load/store probe compiles to byte instructions and barriers without a fallback. Both submitted files match the validated source; clang-format21.1.8 and diff checks pass.

The earlier candidate completed a Linux Debug full build/runner; the subsequent revision only changes STM32 source, so affected target checks were rerun. No MCU flashing or hardware execution. Probes and BSP fixtures remain outside the repository.

## Sourcery 摘要

完善 STM32 Cortex-M0 原子操作回退实现，同时保留中断状态和字操作兼容性。

新功能：
- 为 STM32F0/G0/L0 目标添加 Cortex-M0 字大小的原子 fetch-or 回退实现。

错误修复：
- 在 STM32 字原子操作期间保留调用方的中断屏蔽状态。
- 使字比较交换回退实现与迁移后的读写路径所使用的运行时 ABI 保持一致。
- 使用字大小的 UART 配置状态，使其与可用的原子比较交换契约匹配。

增强：
- 移除已过时的字节大小原子回退实现。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

完善 STM32 Cortex-M0 原子操作回退实现，同时保留中断状态和字长操作兼容性。

新功能：
- 为 STM32F0/G0/L0 Cortex-M0 目标添加字长原子 fetch-or 回退实现。

错误修复：
- 在 STM32 字长原子操作期间保留调用方的中断屏蔽状态。
- 使字长比较交换回退支持与迁移后的读/写路径所使用的运行时 ABI 保持一致。

增强功能：
- 使用字长 UART 配置状态，以匹配可用的原子比较交换契约。
- 移除已过时的字节大小原子操作回退实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Complete STM32 Cortex-M0 atomic fallbacks while preserving interrupt state and word-operation compatibility.

New Features:
- Add a word-sized atomic fetch-or fallback for STM32F0/G0/L0 Cortex-M0 targets.

Bug Fixes:
- Preserve the caller's interrupt mask state across STM32 word-sized atomic operations.
- Align word-sized compare-exchange fallback support with the runtime ABI used by the migrated read/write path.

Enhancements:
- Use a word-sized UART configuration state to match the available atomic compare-exchange contract.
- Remove obsolete byte-sized atomic fallback implementations.

</details>

</details>