### PR TITLE
fix(linux): wake a waiter on every semaphore post

### DIFF
--- a/system/linux/semaphore.cpp
+++ b/system/linux/semaphore.cpp
@@ -42,11 +42,8 @@ Semaphore::~Semaphore() { delete semaphore_handle_; }
 
 void Semaphore::Post()
 {
-  const uint32_t prev = semaphore_handle_->count.fetch_add(1, std::memory_order_release);
-  if (prev == 0)
-  {
-    (void)FutexWake(&semaphore_handle_->count, 1);
-  }
+  (void)semaphore_handle_->count.fetch_add(1, std::memory_order_release);
+  (void)FutexWake(&semaphore_handle_->count, 1);
 }
 
 ErrorCode Semaphore::Wait(uint32_t timeout)


### PR DESCRIPTION
Two threads already blocked in Semaphore::Wait can remain blocked after two Post calls: the second Post sees a nonzero count and skips FUTEX_WAKE before the first waiter consumes its token.

Wake one waiter after every count increment. This preserves counting and wait semantics without adding waiter state or changing the API. Only system/linux/semaphore.cpp changes.

Validation: the controlled two-parked-waiter/two-post regression fails on the original implementation and passes on this candidate. Linux Debug builds and the complete existing runner passes on the final run. The initial full run failed broadcast_full_64k_smoke; the unchanged dev control also failed that benchmark. A diagnostic control run and the candidate confirmation run pass; that intermittent benchmark failure remains unexplained and was not patched here. Probe and logs remain task-local.

## Sourcery 总结

错误修复：
- 每次 `post` 后唤醒一个信号量等待者，以便通过连续的 `post` 释放多个处于阻塞状态的 Linux 等待者。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 每次 post 后唤醒一个 Linux 信号量等待者，以便连续的 post 操作可以释放多个被阻塞的等待者。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Wake one Linux semaphore waiter after every post so consecutive posts can release multiple blocked waiters.

</details>

</details>