### PR TITLE
fix(freertos): allocate storage for zero-size new

### DIFF
--- a/system/freertos/libxr_system.cpp
+++ b/system/freertos/libxr_system.cpp
@@ -42,7 +42,7 @@ void* operator new(std::size_t size)
 {
   if (size == 0)
   {
-    return pvPortMalloc(size);
+    size = sizeof(std::size_t);
   }
 
 #ifdef LIBXR_DEBUG_BUILD


### PR DESCRIPTION
A CDC configuration with no BOS capabilities allocates a zero-length capability pointer array. The non-ESP FreeRTOS new[] forwards to operator new, which previously called pvPortMalloc(0). heap_4 returns null and can invoke the malloc-failed hook before LibXR checks the result.

Normalize a zero request to sizeof(std::size_t), then use the normal allocation and failure-check path. Array new inherits the fix. Positive-size requests, deletion, aligned allocation and BOS capability counts are unchanged. Only system/freertos/libxr_system.cpp changes.

Validation: a host probe runs the unchanged FreeRTOS heap_4 V10.3.1 with scheduler seams and an enabled failure hook, using the exact allocation-overload block and real BosManager header. Original zero scalar/array and zero-capability BOS cases trigger the hook; the candidate returns non-null and triggers no hook. Positive allocation, aligned zero allocation and heap recovery after delete pass. A real STM32F401 FreeRTOS UART/BOS firmware compiles and links the replacement new/new[] overloads. No flashing or hardware runtime test was performed. Fixtures stay outside the repository.

## Sourcery 总结

错误修复：
- 通过将零大小的 FreeRTOS 分配规范化为非零分配大小，防止其返回 null 或调用 malloc-failed 钩子。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 通过将零大小的 FreeRTOS 分配规范化为有效的分配大小，防止其返回 null 或触发 malloc-failed 钩子。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent zero-size FreeRTOS allocations from returning null or triggering the malloc-failed hook by normalizing them to a valid allocation size.

</details>

</details>