### PR TITLE
fix(stm32): dispatch rising and falling EXTI callbacks

### DIFF
--- a/driver/st/stm32_gpio.cpp
+++ b/driver/st/stm32_gpio.cpp
@@ -37,13 +37,28 @@ ErrorCode STM32GPIO::DisableInterrupt()
   return ErrorCode::OK;
 }
 
-extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+static void STM32_GPIO_EXTI_Dispatch(uint16_t pin)
 {
-  const uint8_t LINE = STM32_GPIO_PinToLine(GPIO_Pin);
+  const uint8_t LINE = STM32_GPIO_PinToLine(pin);
   if (auto* gpio = STM32GPIO::map[LINE])
   {
     gpio->callback_.Run(true);
   }
+}
+
+extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+  STM32_GPIO_EXTI_Dispatch(GPIO_Pin);
+}
+
+extern "C" void HAL_GPIO_EXTI_Rising_Callback(uint16_t GPIO_Pin)
+{
+  STM32_GPIO_EXTI_Dispatch(GPIO_Pin);
+}
+
+extern "C" void HAL_GPIO_EXTI_Falling_Callback(uint16_t GPIO_Pin)
+{
+  STM32_GPIO_EXTI_Dispatch(GPIO_Pin);
 }
 
 #endif


### PR DESCRIPTION
STM32 HAL variants such as G0 call separate rising/falling EXTI callbacks, while LibXR only implemented the unified callback. GPIO users therefore missed those edge notifications.

Route all three HAL callback names through the same existing pin map and ISR-context callback dispatch. Registration and GPIO configuration stay unchanged. One source file changes.

Validation: a task-local host dispatch probe compiles the actual driver with real G0 headers and HAL seams. The original receives only the unified callback; the candidate receives all three, preserves the ISR flag, and ignores unmapped pins. A real G0 firmware links all three callback symbols. No physical interrupt test or flashing; fixtures remain outside the repository.

## Sourcery 摘要

将所有受支持的 STM32 EXTI 回调变体分发给已注册的 GPIO 处理程序。

错误修复：
- 确保 STM32 GPIO 用户除了接收统一的 EXTI 回调外，还能接收 EXTI 上升沿和下降沿通知。

增强功能：
- 通过现有的引脚映射和 ISR 上下文分发路径，统一处理 STM32 EXTI 回调。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将所有受支持的 STM32 EXTI 回调变体分发给已注册的 GPIO 处理程序。

错误修复：
- 确保 STM32 GPIO 用户能够收到统一、上升沿和下降沿 EXTI 回调的通知。

增强功能：
- 通过现有的引脚映射和 ISR 上下文回调路径，集中处理受支持的 STM32 EXTI 回调分发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Dispatch all supported STM32 EXTI callback variants to the registered GPIO handlers.

Bug Fixes:
- Ensure STM32 GPIO users receive notifications for unified, rising-edge, and falling-edge EXTI callbacks.

Enhancements:
- Centralize supported STM32 EXTI callback dispatch through the existing pin mapping and ISR-context callback path.

</details>

</details>