### PR TITLE
fix(stm32): enable bus monitoring for internal FDCAN loopback

### DIFF
--- a/driver/st/stm32_canfd.cpp
+++ b/driver/st/stm32_canfd.cpp
@@ -351,9 +351,10 @@ ErrorCode STM32CANFD::SetConfig(const FDCAN::Configuration& cfg)
 #endif
 
 #ifdef FDCAN_CCCR_MON
-  if (cfg.mode.listen_only)
+  if (cfg.mode.loopback || cfg.mode.listen_only)
   {
-    // 总线监控（只听）
+    // 内部回环和只听模式都需要总线监控。
+    // Internal loopback and listen-only mode both require bus monitoring.
     SET_BIT(can->CCCR, FDCAN_CCCR_MON);
   }
   else


### PR DESCRIPTION
SetConfig enables TEST/LBCK for internal loopback but clears MON unless listen_only is also set. This disagrees with the STM32 HAL internal-loopback setup.

Set MON when either loopback or listen_only is requested. Normal and listen-only modes retain their existing behavior. One source file changes.

Validation: the exact mode-setting block, using real G0 register definitions, fails the internal-loopback case on the original and passes all four loopback/listen-only combinations on the candidate. Unrelated mode bits remain intact. Real G0 firmware compiles and links the complete SetConfig path. No physical CAN loopback test or flashing; probes remain task-local.

## Sourcery 总结

错误修复：
- 为 STM32 FDCAN 内部回环模式启用总线监控，以确保回环配置正常工作。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 为 STM32 FDCAN 内部回环模式启用总线监控，使其配置能够正常运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Enable bus monitoring for STM32 FDCAN internal loopback mode so its configuration operates correctly.

</details>

</details>