### PR TITLE
fix(esp): infer alignment policy from the active core configuration

### DIFF
--- a/cmake/esp32.cmake
+++ b/cmake/esp32.cmake
@@ -3,6 +3,19 @@ set(LIBXR_SYSTEM freertos)
 set(LIBXR_DRIVER esp)
 set(LIBXR_STATIC_BUILD ON)
 
+# Preserve an existing policy; otherwise follow the active ESP-IDF core configuration.
+if(NOT DEFINED LIBXR_SINGLE_CORE)
+  if(NOT DEFINED CONFIG_SOC_CPU_CORES_NUM)
+    message(FATAL_ERROR "ESP-IDF did not publish CONFIG_SOC_CPU_CORES_NUM")
+  endif()
+
+  if(CONFIG_SOC_CPU_CORES_NUM GREATER 1 AND NOT CONFIG_FREERTOS_UNICORE)
+    set(LIBXR_SINGLE_CORE OFF)
+  else()
+    set(LIBXR_SINGLE_CORE ON)
+  endif()
+endif()
+
 if(NOT TARGET xr)
   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. ${CMAKE_BINARY_DIR}/libxr_build)
 endif()


### PR DESCRIPTION
The ESP-IDF integration inherited the generic single-core alignment default even on a dual-core ESP32-S3. Infer LIBXR_SINGLE_CORE from the SDK core count and FreeRTOS unicore configuration before creating xr.

Existing normal/cache values remain authoritative, including explicit ON and OFF. Core metadata is required only when inference is needed. Only cmake/esp32.cmake changes.

Validation: actual ESP-IDF5.5.2 configurations and compiled consumers show the original dual-core default ON, then candidate dual-core OFF, S3 unicore ON, C2 single-core ON, and explicit ON/OFF overrides preserved. A full dual-core S3 firmware builds and links. The fixture supplies the flat FreeRTOSConfig include used by previous SDK probes; no new build scaffolding enters the repository. cmake-format0.6.13 passes the repository configuration. No hardware/performance claim.

## Sourcery 总结

根据当前核心配置推断 ESP-IDF 对齐策略，同时保留显式覆盖设置。

错误修复：
- 使 ESP-IDF 单核策略与当前 SDK 核心数量和 FreeRTOS unicore 配置保持一致。

增强功能：
- 仅在需要推断策略时要求 ESP-IDF 核心元数据，同时保留现有的显式对齐设置。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

根据当前激活的核心配置推断 ESP-IDF 对齐策略，同时保留显式覆盖设置。

错误修复：
- 使 ESP-IDF 单核心策略与当前 SDK 核心数量和 FreeRTOS unicore 配置保持一致。

增强功能：
- 保留显式的 `LIBXR_SINGLE_CORE` 覆盖设置，仅在需要推断策略时要求核心元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Infer the ESP-IDF alignment policy from the active core configuration while preserving explicit overrides.

Bug Fixes:
- Align the ESP-IDF single-core policy with the active SDK core count and FreeRTOS unicore configuration.

Enhancements:
- Preserve explicit LIBXR_SINGLE_CORE overrides while requiring core metadata only when policy inference is needed.

</details>

</details>