### PR TITLE
fix(esp): declare continuous ADC initialization for the fallback path

### DIFF
--- a/driver/esp/esp_adc.hpp
+++ b/driver/esp/esp_adc.hpp
@@ -72,13 +72,13 @@ class ESP32ADC
   void ConfigureAnalogPad(adc_channel_t channel) const;
   bool InitCalibration();
   bool InitOneshot();
+  ContinuousInitResult InitContinuous(uint32_t freq, size_t dma_buf_size);
   float RawToVoltage(uint8_t idx, uint16_t raw) const;
 
 #if SOC_ADC_DIG_CTRL_SUPPORTED && SOC_ADC_DMA_SUPPORTED
   static bool IsDigiUnitSupported(adc_unit_t unit);
   static adc_digi_output_format_t ResolveContinuousFormat();
   void DrainContinuousFrames(uint32_t timeout_ms);
-  ContinuousInitResult InitContinuous(uint32_t freq, size_t dma_buf_size);
 #endif
 
   Channel* channels_ = nullptr;


### PR DESCRIPTION
The ADC constructor calls InitContinuous unconditionally, and the implementation already supplies an UNSUPPORTED fallback when continuous DMA is unavailable. Its declaration was incorrectly hidden inside the DMA capability guard.

Move only that declaration outside the guard. Continuous-only headers, helpers and fields remain conditional, and runtime backend selection is unchanged.

Validation: with real ESP-IDF5.5.2 C2 flags, the original header fails both constructor and fallback-definition compilation on InitContinuous; the candidate compiles both source files and a consumer. The S3 DMA-capable branch also compiles, and a complete S3 ADC firmware links. C2 validation is focused compilation, not a full C2 firmware or hardware ADC test. Fixtures remain task-local.

## Sourcery 总结

错误修复：
- 通过使连续初始化声明对回退实现可用，修复在不支持连续 DMA 的平台上 ESP32 ADC 的编译问题。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

错误修复：
- 通过使连续初始化声明对回退实现可用，修复不支持连续 DMA 的平台上的 ESP32 ADC 编译问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix ESP32 ADC compilation on platforms without continuous DMA support by making the continuous initialization declaration available to the fallback implementation.

</details>

</details>