### PR TITLE
fix(stm32): account for pending timebase rollover

### DIFF
--- a/driver/st/stm32_timebase.cpp
+++ b/driver/st/stm32_timebase.cpp
@@ -16,24 +16,33 @@ MicrosecondTimestamp GetSysTickMicroseconds()
 {
   do
   {
-    uint32_t tick_old = HAL_GetTick();
-    uint32_t cnt_old = SysTick->VAL;
-    uint32_t tick_new = HAL_GetTick();
-    uint32_t cnt_new = SysTick->VAL;
-
-    const auto time_diff = tick_new - tick_old;
-    const uint32_t tick_load = SysTick->LOAD + 1U;
-    switch (time_diff)
+    const uint32_t tick_before = HAL_GetTick();
+    const uint32_t counter_before = SysTick->VAL;
+    // 读取挂起位，不通过 CTRL 读取并清除 COUNTFLAG。
+    // Read the pending bit without reading and clearing COUNTFLAG through CTRL.
+    const bool pending = (SCB->ICSR & SCB_ICSR_PENDSTSET_Msk) != 0U;
+    const uint32_t counter_after = SysTick->VAL;
+    const uint32_t tick_after = HAL_GetTick();
+    if (tick_before != tick_after)
     {
-      case 0:
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000ULL + 1000ULL -
-                                    static_cast<uint64_t>(cnt_old) * 1000ULL / tick_load);
-      case 1:
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000ULL + 1000ULL -
-                                    static_cast<uint64_t>(cnt_new) * 1000ULL / tick_load);
-      default:
-        continue;
+      continue;
     }
+
+    const bool crossed_zero =
+        counter_before != 0U && (counter_after == 0U || counter_after > counter_before);
+    uint32_t logical_tick = tick_after + static_cast<uint32_t>(pending || crossed_zero);
+    const uint64_t period_counts = static_cast<uint64_t>(SysTick->LOAD) + 1U;
+    uint64_t fraction = 0U;
+    if (counter_after != 0U)
+    {
+      fraction = 1000U - static_cast<uint64_t>(counter_after) * 1000U / period_counts;
+      if (fraction == 1000U)
+      {
+        ++logical_tick;
+        fraction = 0U;
+      }
+    }
+    return MicrosecondTimestamp(static_cast<uint64_t>(logical_tick) * 1000U + fraction);
   } while (true);
 }
 
@@ -44,26 +53,23 @@ MicrosecondTimestamp GetTimerMicroseconds(TIM_HandleTypeDef* htim)
 
   do
   {
-    uint32_t tick_old = HAL_GetTick();
-    uint32_t cnt_old = __HAL_TIM_GET_COUNTER(htim);
-    uint32_t tick_new = HAL_GetTick();
-    uint32_t cnt_new = __HAL_TIM_GET_COUNTER(htim);
-
-    const uint32_t autoreload = __HAL_TIM_GET_AUTORELOAD(htim) + 1U;
-    const uint32_t delta_ms = tick_new - tick_old;
-    switch (delta_ms)
+    const uint32_t tick_before = HAL_GetTick();
+    const uint32_t counter_before = __HAL_TIM_GET_COUNTER(htim);
+    const bool pending = __HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE) != 0U;
+    const uint32_t counter_after = __HAL_TIM_GET_COUNTER(htim);
+    const uint32_t tick_after = HAL_GetTick();
+    if (tick_before != tick_after)
     {
-      case 0:
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000ULL +
-                                    static_cast<uint64_t>(cnt_old) * 1000ULL /
-                                        autoreload);
-      case 1:
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000ULL +
-                                    static_cast<uint64_t>(cnt_new) * 1000ULL /
-                                        autoreload);
-      default:
-        continue;
+      continue;
     }
+
+    const bool period_elapsed = pending || counter_after < counter_before;
+    const uint32_t logical_tick = tick_after + static_cast<uint32_t>(period_elapsed);
+    const uint64_t period_counts =
+        static_cast<uint64_t>(__HAL_TIM_GET_AUTORELOAD(htim)) + 1U;
+    const uint64_t fraction =
+        static_cast<uint64_t>(counter_after) * 1000U / period_counts;
+    return MicrosecondTimestamp(static_cast<uint64_t>(logical_tick) * 1000U + fraction);
   } while (true);
 }
 

--- a/driver/st/stm32_timebase.hpp
+++ b/driver/st/stm32_timebase.hpp
@@ -7,6 +7,17 @@ namespace LibXR
 {
 /**
  * @brief STM32 SysTick 时间基准实现 / STM32 SysTick-based timebase implementation
+ *
+ * @note SysTick 必须持续按 1 ms 周期运行，每次中断使 HAL tick 加 1，使用期间不可重配。
+ *       读取方不能抢占 SysTick 中断，也不能在 SysTick、NMI 或 fault handler 中读取。
+ *       中断处理延迟必须短于 1 ms；时钟和优先级由 BSP 配置。
+ *       SysTick must run continuously with a 1 ms period and advance HAL tick by one
+ *       per interrupt, without reconfiguration. Readers must not preempt SysTick or
+ *       run in its handler, NMI, or fault handlers. Interrupt service latency must stay
+ *       below 1 ms; the BSP configures the clock and priorities.
+ * @note 微秒读取补偿尚未处理的回绕；毫秒读取仍直接返回 HAL tick，可能暂时落后。
+ *       Microsecond reads compensate a pending rollover; millisecond reads return the
+ *       raw HAL tick and may temporarily lag.
  */
 class STM32Timebase : public Timebase
 {
@@ -24,6 +35,17 @@ class STM32Timebase : public Timebase
 
 /**
  * @brief STM32 硬件定时器时间基准实现 / STM32 timer-based timebase implementation
+ *
+ * @note timer 必须是 HAL tick 的 1 ms 向上计数源，持续运行，每次更新使 HAL tick 加 1。
+ *       读取方不能抢占该更新中断，也不能在该 handler、NMI 或 fault handler 中读取。
+ *       更新中断处理延迟必须短于 1 ms；计数器配置和优先级由 BSP 保持不变。
+ *       The timer must be the continuously running 1 ms HAL tick up-counter, advancing
+ *       HAL tick by one per update. Readers must not preempt its update interrupt or
+ *       run in that handler, NMI, or fault handlers. Update service latency must stay
+ *       below 1 ms; the BSP keeps the counter configuration and priorities unchanged.
+ * @note 微秒读取补偿尚未处理的回绕；毫秒读取仍直接返回 HAL tick，可能暂时落后。
+ *       Microsecond reads compensate a pending rollover; millisecond reads return the
+ *       raw HAL tick and may temporarily lag.
  */
 class STM32TimerTimebase : public Timebase
 {


### PR DESCRIPTION
STM32 microsecond sampling can move backward after the hardware counter rolls over but before the HAL tick interrupt updates the millisecond count. SysTick zero/reload boundaries can also add an extra millisecond.

Sample the pending flag between counter reads, retry if the HAL epoch changes, and compensate one pending/crossed period. Normalize SysTick zero and rounding into the existing timestamp wrap range. Keep the calculation inside the existing private functions; no new helper header or persistent state.

GetMilliseconds still returns HAL_GetTick directly and may temporarily lag compensated microseconds. The documented BSP contract requires a continuous 1 ms HAL timebase, readers that cannot preempt its interrupt, and interrupt service latency below one period. Clock/NVIC configuration, constructors, public API and wrap ranges are unchanged.

Validation: task-local controlled-register tests compile the actual original and candidate source at O0/O2, with TIM enabled and disabled. The original reproduces pending-rollover and zero-boundary failures; the candidate passes normal/pending/crossing/zero/reload/epoch-retry/rounding/wrap cases, monotonic sequences and raw millisecond behavior. No test scaffolding enters the repository. A real STM32G0B1 Debug firmware compiles and links both SysTick and TIM sampling paths with no undefined symbols. No flashing or new hardware runtime claim.

## Sourcery 摘要

使 STM32 微秒采样能够补偿待处理的时基溢出，同时保持 HAL 毫秒行为和现有 API 不变。

错误修复：
- 防止在 HAL tick 中断得到处理之前硬件时基发生溢出时，STM32 微秒时间戳向后跳变。
- 处理 SysTick 零值/重载边界以及定时器溢出取整问题，同时不改变原始毫秒读数。

增强功能：
- 记录可靠进行溢出补偿所需的时基连续性、中断延迟和读取器抢占要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make STM32 microsecond sampling compensate pending timebase rollovers while preserving HAL millisecond behavior and existing APIs.

Bug Fixes:
- Prevent STM32 microsecond timestamps from moving backward when the hardware timebase rolls over before the HAL tick interrupt is serviced.
- Handle SysTick zero/reload boundaries and timer rollover rounding without altering raw millisecond readings.

Enhancements:
- Document the timebase continuity, interrupt-latency, and reader-preemption requirements for reliable rollover compensation.

</details>