### PR TITLE
refactor(ch32): derive time from free-running SysTick

### DIFF
--- a/driver/ch/ch32_timebase.cpp
+++ b/driver/ch/ch32_timebase.cpp
@@ -3,46 +3,70 @@
 
 using namespace LibXR;
 
+namespace
+{
+constexpr uint32_t SYSTICK_ENABLE = 1U << 0U;
+constexpr uint32_t SYSTICK_CLOCK_HCLK = 1U << 2U;
+constexpr uint32_t SYSTICK_AUTO_RELOAD = 1U << 3U;
+constexpr uint32_t SYSTICK_COUNT_DOWN = 1U << 4U;
+constexpr uint64_t MICROSECONDS_PER_SECOND = 1000000ULL;
+constexpr uint64_t MILLISECONDS_PER_SECOND = 1000ULL;
+
+uint32_t timebase_clock_hz = 0U;
+
+uint64_t ReadSysTickCounter()
+{
+  auto* count_words = reinterpret_cast<volatile uint32_t*>(&SysTick->CNT);
+  uint32_t high_before;
+  uint32_t low;
+  uint32_t high_after;
+
+  // 低位回绕时重新读取，避免拼接出不一致的计数值。
+  // Retry across a low-word rollover to obtain a coherent counter value.
+  do
+  {
+    high_before = count_words[1];
+    low = count_words[0];
+    high_after = count_words[1];
+  } while (high_before != high_after);
+
+  return (static_cast<uint64_t>(high_after) << 32U) | low;
+}
+
+uint64_t CyclesToUnits(uint64_t cycles, uint64_t units_per_second)
+{
+  // 分开换算整秒和余数，避免直接乘法溢出。
+  // Convert whole seconds and remaining cycles separately to avoid overflow.
+  const uint64_t seconds = cycles / timebase_clock_hz;
+  const uint64_t remaining_cycles = cycles % timebase_clock_hz;
+  return seconds * units_per_second +
+         remaining_cycles * units_per_second / timebase_clock_hz;
+}
+}  // namespace
+
 CH32Timebase::CH32Timebase()
 {
-  ConfigureWrapRange(static_cast<uint64_t>(UINT32_MAX) * 1000ULL + 999ULL, UINT32_MAX);
+  const uint32_t control = SysTick->CTLR;
+  ASSERT((control & (SYSTICK_ENABLE | SYSTICK_CLOCK_HCLK)) ==
+             (SYSTICK_ENABLE | SYSTICK_CLOCK_HCLK) &&
+         (control & (SYSTICK_AUTO_RELOAD | SYSTICK_COUNT_DOWN)) == 0U &&
+         SystemCoreClock >= MICROSECONDS_PER_SECOND);
+
+  timebase_clock_hz = SystemCoreClock;
+  ConfigureWrapRange(CyclesToUnits(UINT64_MAX, MICROSECONDS_PER_SECOND), UINT32_MAX);
   SetReady();
 }
 
 MicrosecondTimestamp Timebase::GetMicroseconds()
 {
-  do
-  {
-    uint32_t tick_old = CH32Timebase::sys_tick_ms_;
-    uint32_t cnt_old = SysTick->CNT;
-    uint32_t tick_new = CH32Timebase::sys_tick_ms_;
-    uint32_t cnt_new = SysTick->CNT;
-
-    auto tick_diff = tick_new - tick_old;
-    uint32_t tick_cmp = SysTick->CMP + 1;
-    switch (tick_diff)
-    {
-      case 0:
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000 +
-                                    static_cast<uint64_t>(cnt_old) * 1000 / tick_cmp);
-      case 1:
-        /* 中断发生在两次读取之间 / Interrupt happened between two reads */
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000 +
-                                    static_cast<uint64_t>(cnt_new) * 1000 / tick_cmp);
-      default:
-        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more
-         * than 1ms, an error case */
-        continue;
-    }
-  } while (true);
+  return MicrosecondTimestamp(
+      CyclesToUnits(ReadSysTickCounter(), MICROSECONDS_PER_SECOND));
 }
 
-MillisecondTimestamp Timebase::GetMilliseconds() { return CH32Timebase::sys_tick_ms_; }
-
-void CH32Timebase::OnSysTickInterrupt() { sys_tick_ms_++; }
-
-void CH32Timebase::Sync(uint32_t ticks) { sys_tick_ms_ = ticks; }
-
-extern "C" void libxr_systick_handler(void) { CH32Timebase::OnSysTickInterrupt(); }
+MillisecondTimestamp Timebase::GetMilliseconds()
+{
+  return MillisecondTimestamp(static_cast<uint32_t>(
+      CyclesToUnits(ReadSysTickCounter(), MILLISECONDS_PER_SECOND)));
+}
 
 // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,performance-no-int-to-ptr)

--- a/driver/ch/ch32_timebase.hpp
+++ b/driver/ch/ch32_timebase.hpp
@@ -4,13 +4,22 @@
 
 #include DEF2STR(LIBXR_CH32_CONFIG_FILE)
 
-extern uint32_t SystemCoreClock;
-
 namespace LibXR
 {
 
 /**
- * @brief CH32 时间基准实现 / CH32 timebase implementation
+ * @brief CH32 硬件计数器时间基准 / CH32 hardware-counter timebase
+ *
+ * @note BSP 必须预先将 SysTick 配置为 HCLK 驱动的 64 位自由运行向上计数器。
+ *       使用期间不得停止、清零计数器或改变 HCLK；HCLK 不低于 1 MHz。
+ *       The BSP must configure SysTick as a 64-bit, HCLK-driven, free-running
+ *       up-counter before initialization. The counter must not be stopped or reset,
+ *       and HCLK must remain unchanged and at least 1 MHz during use.
+ * @note 微秒和毫秒均由硬件计数值换算，不依赖 SysTick 中断的软件计数。
+ *       初始化完成后可在任务或中断中读取，比较值和 tick 中断由 BSP 管理。
+ *       Microseconds and milliseconds are derived from the hardware counter without
+ *       a software interrupt count. Reads are allowed from tasks or interrupts after
+ *       initialization; the BSP manages compare deadlines and tick interrupts.
  */
 class CH32Timebase : public Timebase
 {
@@ -18,29 +27,11 @@ class CH32Timebase : public Timebase
   /**
    * @brief 构造函数 / Constructor
    *
-   * 配置 CH32 SysTick 时间基的回绕范围，并标记时间基已就绪。
-   * Configures the CH32 SysTick wrap range and marks the timebase ready.
+   * 缓存计数器时钟频率，配置时间戳回绕范围并标记时间基就绪。
+   * Cache the counter clock frequency, configure timestamp wrap ranges, and mark
+   * the timebase ready.
    */
   CH32Timebase();
-
-  /**
-   * @brief SysTick 中断入口辅助函数。
-   *        Helper called from the SysTick interrupt path.
-   */
-  static inline void OnSysTickInterrupt();
-
-  /**
-   * @brief 同步毫秒计数器。
-   *        Synchronize the millisecond counter.
-   * @param ticks 新的毫秒计数值。New millisecond tick value.
-   */
-  void Sync(uint32_t ticks);
-
-  /**
-   * @brief SysTick 毫秒计数器。
-   *        SysTick millisecond counter.
-   */
-  static inline volatile uint32_t sys_tick_ms_ = 0;
 };
 
 }  // namespace LibXR


### PR DESCRIPTION
CH32 time reads currently combine a software millisecond count with a periodically reloaded SysTick counter. Move the LibXR timebase to the selected 64-bit free-running counter model: read CNT high/low/high, retry across a low-word rollover, and derive both microseconds and milliseconds from HCLK without relying on tick interrupt service.

Remove the software epoch, Sync(), OnSysTickInterrupt() and libxr_systick_handler. Cache the configured counter frequency; split whole-second/remainder conversion to avoid multiplication overflow. Set the microsecond wrap bound from the maximum hardware counter value; milliseconds retain uint32 output.

This requires the BSP to start an HCLK-driven, upward, non-reloading SysTick before initialization and keep the counter/clock unchanged. Existing periodic BSPs and callers of the removed hooks need migration. BSP changes and merges are outside this PR. No IRQ priority changes, register writes, mode switch or compatibility branch.

Validation: untouched source passes 225 task-local checks at O0/O2 against an independent 128-bit conversion reference, including low-word boundaries, millisecond wrap, maximum counter values, read-only register behavior and configuration assertions. A separately instrumented three-load MMIO seam passes five interleaving cases; removing the retry fails the same cases. Real CH32V307 vendor BSP bba76c2 with matching free-running configuration compiles/links 103/103 using WCH GCC 15.2.0; both getters are linked, no undefined symbols, and disassembly confirms high/low/high loads plus retry. Existing RWX linker warning remains. Formatting and diff checks pass. No product test scaffolding or BSP files, no flashing/hardware execution claim.

## Sourcery 摘要

将 CH32 基于软件的时基替换为通过已验证的自由运行 SysTick 计数器进行时间戳转换。

新功能：
- 直接从由 HCLK 驱动的自由运行 64 位 SysTick 计数器派生 CH32 的微秒和毫秒时间戳。

错误修复：
- 确保在低位字回绕期间能够一致地读取 64 位计数器，并防止转换溢出。

改进：
- 移除软件毫秒纪元和 SysTick 中断同步钩子。
- 缓存已配置的计数器频率，并为硬件计数器模型配置时间戳回绕范围。
- 在时基初始化期间验证所需的 SysTick 模式和最低时钟频率。

文档：
- 记录用于配置和保留自由运行 SysTick 计数器的 BSP 要求。

杂项：
- 移除已废弃的 CH32 SysTick 软件计数器和中断处理程序接口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the CH32 software-backed timebase with timestamp conversion from a validated free-running SysTick counter.

New Features:
- Derive CH32 microsecond and millisecond timestamps directly from a free-running 64-bit HCLK-driven SysTick counter.

Bug Fixes:
- Ensure coherent 64-bit counter reads across low-word rollover and prevent conversion overflow.

Enhancements:
- Remove the software millisecond epoch and SysTick interrupt synchronization hooks.
- Cache the configured counter frequency and configure timestamp wrap ranges for the hardware counter model.
- Validate the required SysTick mode and minimum clock frequency during timebase initialization.

Documentation:
- Document the BSP requirements for configuring and preserving the free-running SysTick counter.

Chores:
- Remove the obsolete CH32 SysTick software counter and interrupt handler interfaces.

</details>