### PR TITLE
fix(stm32): serialize UART error aborts with TX startup

### DIFF
--- a/driver/st/stm32_uart.cpp
+++ b/driver/st/stm32_uart.cpp
@@ -240,15 +240,27 @@ void STM32UART::HandleTxService(uint32_t events, bool in_isr)
     }
   }
 
-  if ((events & TX_EVENT_DONE) != 0U)
+  if (abort_pending_)
   {
-    HandleTxDone(in_isr);
-  }
-
-  if ((events & TX_EVENT_ABORT) != 0U)
-  {
+    if ((events & TX_EVENT_ABORT) == 0U)
+    {
+      return;
+    }
     last_rx_pos_ = 0U;
     SetRxDMA(in_isr);
+    HandleTxDone(in_isr);
+    abort_pending_ = false;
+  }
+  else if ((events & TX_EVENT_ERROR) != 0U)
+  {
+    // 中止可能同步完成，调用 HAL 前先记录等待状态。
+    // Record the wait before calling HAL, which may complete the abort synchronously.
+    abort_pending_ = true;
+    REQUIRE_FROM_CALLBACK(HAL_UART_Abort_IT(uart_handle_) == HAL_OK, in_isr);
+    return;
+  }
+  else if ((events & TX_EVENT_DONE) != 0U)
+  {
     HandleTxDone(in_isr);
   }
 
@@ -549,6 +561,12 @@ void STM32UART::RxEventIRQHandler()
                      { HandleTxService(events, in_isr); });
 }
 
+void STM32UART::ErrorIRQHandler()
+{
+  tx_service_.Invoke(TX_EVENT_ERROR, true, [this](uint32_t events, bool in_isr)
+                     { HandleTxService(events, in_isr); });
+}
+
 void STM32UART::AbortCompleteIRQHandler()
 {
   tx_service_.Invoke(TX_EVENT_ABORT, true, [this](uint32_t events, bool in_isr)
@@ -582,7 +600,16 @@ extern "C" void HAL_UART_TxCpltCallback(UART_HandleTypeDef* huart)
 
 extern "C" __attribute__((used)) void HAL_UART_ErrorCallback(UART_HandleTypeDef* huart)
 {
-  HAL_UART_Abort_IT(huart);
+  const auto id = stm32_uart_get_id(huart->Instance);
+  if (id == STM32_UART_ID_ERROR)
+  {
+    return;
+  }
+  auto* uart = STM32UART::map[id];
+  if (uart != nullptr)
+  {
+    uart->ErrorIRQHandler();
+  }
 }
 
 extern "C" void HAL_UART_AbortCpltCallback(UART_HandleTypeDef* huart)

--- a/driver/st/stm32_uart.hpp
+++ b/driver/st/stm32_uart.hpp
@@ -165,6 +165,8 @@ class STM32UART : public UART
   void TxCompleteIRQHandler();
   /// 通知接收位置变化 / Notify RX position changes.
   void RxEventIRQHandler();
+  /// 通知错误，由后端处理器启动中止 / Report an error; the service initiates the abort.
+  void ErrorIRQHandler();
   /// 通知 HAL 中止完成，由后端恢复收发 / Notify HAL abort completion for backend
   /// recovery.
   void AbortCompleteIRQHandler();
@@ -205,6 +207,7 @@ class STM32UART : public UART
   static constexpr uint32_t TX_EVENT_CONFIG = 1U << 2U;
   static constexpr uint32_t TX_EVENT_RX_WORK = 1U << 3U;
   static constexpr uint32_t TX_EVENT_ABORT = 1U << 4U;
+  static constexpr uint32_t TX_EVENT_ERROR = 1U << 5U;
 
   /// 串行处理收发和配置通知 / Serialize RX, TX, and configuration progress.
   void HandleTxService(uint32_t events, bool in_isr);
@@ -223,6 +226,10 @@ class STM32UART : public UART
 
   /// 共享的收发与配置处理器 / Shared RX, TX, and configuration service.
   SerializedService tx_service_;
+  /// 中止完成前保留发送半区并暂停硬件操作，仅处理器访问。
+  /// Retain the TX half and defer hardware operations until abort completion;
+  /// service-only.
+  bool abort_pending_ = false;
   /// 配置槽的并发发布状态 / Concurrent configuration slot state.
   std::atomic<ConfigState> config_state_{ConfigState::EMPTY};
   /// 由调用者发布、后端应用的配置 / Caller-published configuration for backend


### PR DESCRIPTION
A UART error IRQ can interrupt HAL_UART_Transmit_DMA after DMA starts but before DMAT is enabled. Calling HAL_UART_Abort_IT directly from that IRQ may report completion without stopping the new TX, allowing the service to release a half still used by hardware.

Publish the error through the existing SerializedService and initiate abort from its handler. Retain the active half and defer TX, RX restart and configuration work until abort completion; coalesce repeated errors while recovery is outstanding. Preserve the existing abort-completion retirement and queued/pending work semantics.

Validation: reproduced the original seven-step TLC counterexample and G0 HAL-function witness (hardware active with released half). The updated finite model passes; disabling the asynchronous wait gate restores a counterexample. Extracted current LibXR handler/start/completion functions plus real G0 HAL start/abort functions and SerializedService pass four controlled cases: synchronous completion, deferred completion with repeated error/write/config/RX/TX-done notifications, write during RX-only abort, and normal TX. A negative variant that keeps serialized abort/completion but removes the wait gate reproduces hardware-active/released-half in the RX-only-abort case. DMA/IRQ scheduling and unrelated backend helpers are test seams, not hardware execution.

Real STM32G0B1 ARM GNU14.2 Debug firmware compiles/links the updated UART, error callback and service with no undefined symbols. Format/diff checks pass. Only two production files; all verification scaffolding stays outside the repository. No hardware acceptance or H5/GPDMA compatibility claim; this is the prerequisite repair for that separate migration.

## Sourcery 摘要

对 STM32 UART 错误中止处理进行序列化，防止硬件在释放传输缓冲区后继续使用该缓冲区。

错误修复：
- 将 UART 错误恢复与传输启动进行序列化，确保 DMA 仍拥有 TX 缓冲区时，错误处理不会释放该缓冲区的一半。
- 在中止完成前延迟 TX、RX 和配置进度，并在中止处于挂起状态时合并恢复通知。

增强功能：
- 通过现有的序列化服务处理 STM32 UART 错误回调，同时保留中止完成和排队任务的行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

对 STM32 UART 错误中止处理进行序列化，防止硬件在恢复期间继续使用已释放的传输缓冲区。

错误修复：
- 将 STM32 UART 错误恢复与传输启动进行序列化，防止 DMA 在 TX 缓冲区释放后继续使用其一半内容。
- 在中止完成前延迟 TX、RX 和配置进度，并在中止处于挂起状态时合并恢复通知。

增强功能：
- 通过现有的序列化服务处理 UART 错误回调，同时保留中止完成和排队工作行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Serialize STM32 UART error abort handling to prevent hardware from retaining released transmission buffers during recovery.

Bug Fixes:
- Serialize STM32 UART error recovery with transmission startup so DMA cannot continue using a TX buffer half after it has been released.
- Defer TX, RX, and configuration progress until abort completion and coalesce recovery notifications while an abort is pending.

Enhancements:
- Route UART error callbacks through the existing serialized service while preserving abort-completion and queued-work behavior.

</details>

</details>