### PR TITLE
feat(stm32): integrate H5 GPDMA UART with RW ports

### DIFF
--- a/driver/st/stm32_uart.cpp
+++ b/driver/st/stm32_uart.cpp
@@ -242,13 +242,40 @@ void STM32UART::HandleTxService(uint32_t events, bool in_isr)
 
   if (abort_pending_)
   {
+#if defined(LIBXR_STM32_UART_GPDMA)
+    // HAL 自有的 RX 中止通过错误回调通知，因此按硬件状态判断是否全部停止。
+    // HAL-owned RX aborts notify through the error callback; check actual stop state.
+    if (!gpdma_adapter_.AllStopsComplete())
+    {
+      return;
+    }
+    events |= TX_EVENT_ABORT;
+    REQUIRE_FROM_CALLBACK(HAL_UART_Abort(uart_handle_) == HAL_OK, in_isr);
+    if (uart_handle_->hdmatx != nullptr)
+    {
+      STM32GpdmaUartAdapter::FinalizeStopped(uart_handle_->hdmatx, in_isr);
+    }
+    if (uart_handle_->hdmarx != nullptr)
+    {
+      STM32GpdmaUartAdapter::FinalizeStopped(uart_handle_->hdmarx, in_isr);
+    }
+    HandleTxDone(in_isr);
+    if (config_state_.load(std::memory_order_acquire) == ConfigState::PUBLISHED)
+    {
+      ApplyConfig(pending_config_, in_isr);
+      config_state_.store(ConfigState::EMPTY, std::memory_order_release);
+    }
+#else
     if ((events & TX_EVENT_ABORT) == 0U)
     {
       return;
     }
+#endif
     last_rx_pos_ = 0U;
     SetRxDMA(in_isr);
+#if !defined(LIBXR_STM32_UART_GPDMA)
     HandleTxDone(in_isr);
+#endif
     abort_pending_ = false;
   }
   else if ((events & TX_EVENT_ERROR) != 0U)
@@ -256,7 +283,7 @@ void STM32UART::HandleTxService(uint32_t events, bool in_isr)
     // 中止可能同步完成，调用 HAL 前先记录等待状态。
     // Record the wait before calling HAL, which may complete the abort synchronously.
     abort_pending_ = true;
-    REQUIRE_FROM_CALLBACK(HAL_UART_Abort_IT(uart_handle_) == HAL_OK, in_isr);
+    BeginAbort(in_isr);
     return;
   }
   else if ((events & TX_EVENT_DONE) != 0U)
@@ -264,6 +291,12 @@ void STM32UART::HandleTxService(uint32_t events, bool in_isr)
     HandleTxDone(in_isr);
   }
 
+#if defined(LIBXR_STM32_UART_GPDMA)
+  if ((events & TX_EVENT_START_RX) != 0U)
+  {
+    SetRxDMA(in_isr);
+  }
+#endif
   if ((events & TX_EVENT_RX_WORK) != 0U)
   {
     HandleRxData(in_isr);
@@ -370,6 +403,10 @@ STM32UART::STM32UART(UART_HandleTypeDef* uart_handle, RawData dma_buff_rx,
       dma_buff_tx_(dma_buff_tx),
       uart_handle_(uart_handle),
       id_(stm32_uart_get_id(uart_handle_->Instance))
+#if defined(LIBXR_STM32_UART_GPDMA)
+      ,
+      gpdma_adapter_(uart_handle)
+#endif
 {
   ASSERT(id_ != STM32_UART_ID_ERROR);
 
@@ -379,10 +416,18 @@ STM32UART::STM32UART(UART_HandleTypeDef* uart_handle, RawData dma_buff_rx,
   {
     REQUIRE(tx_queue_size > 0U);
     ASSERT(uart_handle_->hdmatx != NULL);
+#if defined(LIBXR_STM32_UART_GPDMA)
+    ASSERT(uart_handle_->hdmatx->Mode == DMA_NORMAL);
+#endif
     _write_port = WriteFun;
   }
 
+#if defined(LIBXR_STM32_UART_GPDMA)
+  tx_service_.Invoke(TX_EVENT_START_RX, false, [this](uint32_t events, bool in_isr)
+                     { HandleTxService(events, in_isr); });
+#else
   SetRxDMA(false);
+#endif
 }
 
 ErrorCode STM32UART::SetConfig(UART::Configuration config, bool in_isr)
@@ -464,7 +509,18 @@ void STM32UART::ApplyConfig(UART::Configuration config, bool in_isr)
       return;
   }
 
+#if defined(LIBXR_STM32_UART_GPDMA)
+  // 通道已停止，直接配置寄存器，避免在中断中等待 HAL tick。
+  // Channels are stopped; configure registers without waiting for HAL ticks in an ISR.
+  __HAL_UART_DISABLE(uart_handle_);
+  REQUIRE_FROM_CALLBACK(UART_SetConfig(uart_handle_) == HAL_OK, in_isr);
+  CLEAR_BIT(uart_handle_->Instance->CR2, USART_CR2_LINEN | USART_CR2_CLKEN);
+  CLEAR_BIT(uart_handle_->Instance->CR3,
+            USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN);
+  __HAL_UART_ENABLE(uart_handle_);
+#else
   REQUIRE_FROM_CALLBACK(HAL_UART_Init(uart_handle_) == HAL_OK, in_isr);
+#endif
 }
 
 void STM32UART::TryApplyConfig(bool in_isr)
@@ -479,10 +535,15 @@ void STM32UART::TryApplyConfig(bool in_isr)
     return;
   }
 
+#if defined(LIBXR_STM32_UART_GPDMA)
+  abort_pending_ = true;
+  BeginAbort(in_isr);
+#else
   ApplyConfig(pending_config_, in_isr);
   last_rx_pos_ = 0U;
   SetRxDMA(in_isr);
   config_state_.store(ConfigState::EMPTY, std::memory_order_release);
+#endif
 }
 
 void STM32UART::SetRxDMA(bool in_isr)
@@ -491,6 +552,12 @@ void STM32UART::SetRxDMA(bool in_isr)
   {
     ASSERT(uart_handle_->hdmarx != NULL);
 
+#if defined(LIBXR_STM32_UART_GPDMA)
+    REQUIRE_FROM_CALLBACK(
+        gpdma_adapter_.StartLinkedListDmaRx(static_cast<uint8_t*>(dma_buff_rx_.addr_),
+                                            dma_buff_rx_.size_, in_isr) == HAL_OK,
+        in_isr);
+#else
     uart_handle_->hdmarx->Init.Mode = DMA_CIRCULAR;
     REQUIRE_FROM_CALLBACK(HAL_DMA_Init(uart_handle_->hdmarx) == HAL_OK, in_isr);
 
@@ -499,6 +566,7 @@ void STM32UART::SetRxDMA(bool in_isr)
                                      reinterpret_cast<uint8_t*>(dma_buff_rx_.addr_),
                                      dma_buff_rx_.size_) == HAL_OK,
         in_isr);
+#endif
   }
 }
 
@@ -513,9 +581,17 @@ void STM32UART::HandleRxData(bool in_isr)
   auto* const rx_buf = static_cast<uint8_t*>(dma_buff_rx_.addr_);
   REQUIRE_FROM_CALLBACK(rx_buf != nullptr, in_isr);
 
+#if defined(LIBXR_STM32_UART_GPDMA)
+  const uintptr_t destination =
+      reinterpret_cast<uintptr_t>(gpdma_adapter_.GetLinkedListDmaRxProducer());
+  const uintptr_t begin = reinterpret_cast<uintptr_t>(rx_buf);
+  REQUIRE_FROM_CALLBACK(destination >= begin && destination - begin <= dma_size, in_isr);
+  const size_t curr_pos = destination - begin;
+#else
   const size_t remaining = __HAL_DMA_GET_COUNTER(uart_handle_->hdmarx);
   REQUIRE_FROM_CALLBACK(remaining <= dma_size, in_isr);
   const size_t curr_pos = remaining == 0U ? dma_size : dma_size - remaining;
+#endif
   const size_t last_pos = last_rx_pos_;
   REQUIRE_FROM_CALLBACK(last_pos < dma_size, in_isr);
 
@@ -620,6 +696,43 @@ extern "C" void HAL_UART_AbortCpltCallback(UART_HandleTypeDef* huart)
     uart->AbortCompleteIRQHandler();
   }
 }
+
+void STM32UART::BeginAbort(bool in_isr)
+{
+#if defined(LIBXR_STM32_UART_GPDMA)
+  gpdma_adapter_.CloseTxTerminalSource();
+  if (uart_handle_->hdmatx != nullptr)
+  {
+    REQUIRE_FROM_CALLBACK(
+        gpdma_adapter_.LaunchStop(uart_handle_->hdmatx, DmaAbortCallback, in_isr),
+        in_isr);
+  }
+  if (uart_handle_->hdmarx != nullptr)
+  {
+    REQUIRE_FROM_CALLBACK(
+        gpdma_adapter_.LaunchStop(uart_handle_->hdmarx, DmaAbortCallback, in_isr),
+        in_isr);
+  }
+  if (gpdma_adapter_.AllStopsComplete())
+  {
+    tx_service_.Publish(TX_EVENT_ABORT);
+  }
+#else
+  REQUIRE_FROM_CALLBACK(HAL_UART_Abort_IT(uart_handle_) == HAL_OK, in_isr);
+#endif
+}
+
+#if defined(LIBXR_STM32_UART_GPDMA)
+void STM32UART::DmaAbortCallback(DMA_HandleTypeDef* dma_handle)
+{
+  auto* handle = static_cast<UART_HandleTypeDef*>(dma_handle->Parent);
+  const auto id = stm32_uart_get_id(handle->Instance);
+  if (id != STM32_UART_ID_ERROR && map[id] != nullptr)
+  {
+    map[id]->AbortCompleteIRQHandler();
+  }
+}
+#endif
 
 void STM32UART::StartTxDma(bool in_isr)
 {

--- a/driver/st/stm32_uart.hpp
+++ b/driver/st/stm32_uart.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "main.h"
+#include "stm32_uart_gpdma.hpp"
 
 #ifdef HAL_UART_MODULE_ENABLED
 
@@ -127,6 +128,11 @@ namespace LibXR
  * @pre 调用遵守 ReadPort/WritePort 约定；DMA 缓冲区满足平台访问和对齐要求，运行期间有效。
  *      Follow the port contracts. DMA buffers must meet platform access/alignment
  *      requirements and remain valid throughout operation.
+ * @pre H5 的 RX 句柄已挂接静止的循环链表，缓冲区长度是 4 的倍数，每段不超过
+ *      65535 字节；TX 使用普通单次 DMA。相关 UART/DMA 中断具有相同抢占优先级。
+ *      On H5, RX starts with a stopped circular seed list. The buffer size is a multiple
+ *      of four, with at most 65535 bytes per node; TX uses normal one-shot DMA.
+ *      Related UART/DMA IRQs share a preemption priority.
  */
 class STM32UART : public UART
 {
@@ -208,6 +214,14 @@ class STM32UART : public UART
   static constexpr uint32_t TX_EVENT_RX_WORK = 1U << 3U;
   static constexpr uint32_t TX_EVENT_ABORT = 1U << 4U;
   static constexpr uint32_t TX_EVENT_ERROR = 1U << 5U;
+#if defined(LIBXR_STM32_UART_GPDMA)
+  static constexpr uint32_t TX_EVENT_START_RX = 1U << 6U;
+  static void DmaAbortCallback(DMA_HandleTypeDef* dma_handle);
+#endif
+
+  /// 启动或接续硬件中止，由串行处理器调用 / Start or join a hardware abort from the
+  /// service.
+  void BeginAbort(bool in_isr);
 
   /// 串行处理收发和配置通知 / Serialize RX, TX, and configuration progress.
   void HandleTxService(uint32_t events, bool in_isr);
@@ -235,6 +249,9 @@ class STM32UART : public UART
   /// 由调用者发布、后端应用的配置 / Caller-published configuration for backend
   /// application.
   UART::Configuration pending_config_{};
+#if defined(LIBXR_STM32_UART_GPDMA)
+  STM32GpdmaUartAdapter gpdma_adapter_;
+#endif
 };
 
 }  // namespace LibXR

--- a/driver/st/stm32_uart_gpdma.cpp
+++ b/driver/st/stm32_uart_gpdma.cpp
@@ -1,0 +1,393 @@
+#include "stm32_uart_gpdma.hpp"
+
+#if defined(LIBXR_STM32_UART_GPDMA) && defined(HAL_UART_MODULE_ENABLED)
+
+#include "libxr_assert.hpp"
+#include "stm32_dcache.hpp"
+
+namespace LibXR
+{
+namespace
+{
+
+IRQn_Type GetGpdmaIrq(DMA_Channel_TypeDef* instance)
+{
+#define LIBXR_GPDMA_IRQ_CASE(DMA, CHANNEL) \
+  if (instance == DMA##_Channel##CHANNEL)  \
+  {                                        \
+    return DMA##_Channel##CHANNEL##_IRQn;  \
+  }
+
+// 按首通道宏判断通道组是否存在；IRQn 是枚举，不能用 defined 检查。
+// Detect channel groups by their first channel macro; IRQn names are enum values.
+#if defined(GPDMA1_Channel0)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 0)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 1)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 2)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 3)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 4)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 5)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 6)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 7)
+#endif
+#if defined(GPDMA1_Channel8)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 8)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 9)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 10)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 11)
+#endif
+#if defined(GPDMA1_Channel12)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 12)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 13)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 14)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA1, 15)
+#endif
+#if defined(GPDMA2_Channel0)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 0)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 1)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 2)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 3)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 4)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 5)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 6)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 7)
+#endif
+#if defined(GPDMA2_Channel8)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 8)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 9)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 10)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 11)
+#endif
+#if defined(GPDMA2_Channel12)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 12)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 13)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 14)
+  LIBXR_GPDMA_IRQ_CASE(GPDMA2, 15)
+#endif
+
+#undef LIBXR_GPDMA_IRQ_CASE
+
+  ASSERT(false);
+  return NonMaskableInt_IRQn;
+}
+
+class GpdmaNvicMaskGuard
+{
+ public:
+  explicit GpdmaNvicMaskGuard(DMA_HandleTypeDef* dma_handle)
+      : irq_(GetGpdmaIrq(dma_handle->Instance)),
+        valid_(static_cast<int32_t>(irq_) >= 0),
+        was_enabled_(valid_ && (NVIC_GetEnableIRQ(irq_) != 0U))
+  {
+    if (!valid_)
+    {
+      return;
+    }
+
+    if (was_enabled_)
+    {
+      NVIC_DisableIRQ(irq_);
+      __DSB();
+      __ISB();
+    }
+  }
+
+  ~GpdmaNvicMaskGuard()
+  {
+    if (valid_ && was_enabled_)
+    {
+      NVIC_EnableIRQ(irq_);
+      __DSB();
+      __ISB();
+    }
+  }
+
+  GpdmaNvicMaskGuard(const GpdmaNvicMaskGuard&) = delete;
+  GpdmaNvicMaskGuard& operator=(const GpdmaNvicMaskGuard&) = delete;
+
+  [[nodiscard]] bool Valid() const { return valid_; }
+  [[nodiscard]] bool WasEnabled() const { return was_enabled_; }
+
+ private:
+  IRQn_Type irq_;
+  bool valid_;
+  bool was_enabled_;
+};
+
+}  // namespace
+
+STM32GpdmaUartAdapter::STM32GpdmaUartAdapter(UART_HandleTypeDef* uart_handle)
+{
+  REQUIRE(uart_handle != nullptr);
+  REQUIRE((uart_handle->hdmatx == nullptr) ||
+          (IS_GPDMA_INSTANCE(uart_handle->hdmatx->Instance) != 0U));
+  REQUIRE((uart_handle->hdmarx == nullptr) ||
+          (IS_GPDMA_INSTANCE(uart_handle->hdmarx->Instance) != 0U));
+  state_.uart_handle_ = uart_handle;
+}
+
+HAL_StatusTypeDef STM32GpdmaUartAdapter::StartLinkedListDmaRx(uint8_t* buffer,
+                                                              size_t total_size,
+                                                              bool in_isr)
+{
+  DMA_HandleTypeDef* const dma_handle = state_.uart_handle_->hdmarx;
+  REQUIRE_FROM_CALLBACK(dma_handle != nullptr, in_isr);
+  REQUIRE_FROM_CALLBACK(buffer != nullptr, in_isr);
+  REQUIRE_FROM_CALLBACK(total_size >= RX_NODE_COUNT, in_isr);
+  REQUIRE_FROM_CALLBACK((total_size % RX_NODE_COUNT) == 0U, in_isr);
+  REQUIRE_FROM_CALLBACK((total_size / RX_NODE_COUNT) <= UINT16_MAX, in_isr);
+  REQUIRE_FROM_CALLBACK(IS_DMA_BLOCK_SIZE(total_size / RX_NODE_COUNT) != 0U, in_isr);
+  ASSERT_FROM_CALLBACK(dma_handle->Parent == state_.uart_handle_ &&
+                           IS_GPDMA_INSTANCE(dma_handle->Instance) != 0U,
+                       in_isr);
+  ASSERT_FROM_CALLBACK(
+      dma_handle->InitLinkedList.LinkStepMode == DMA_LSM_FULL_EXECUTION &&
+          dma_handle->InitLinkedList.LinkedListMode == DMA_LINKEDLIST_CIRCULAR &&
+          dma_handle->Mode == DMA_LINKEDLIST_CIRCULAR,
+      in_isr);
+
+  if (!state_.rx_queue_built_)
+  {
+    BuildRxQueue(buffer, total_size, in_isr);
+  }
+  else
+  {
+    REQUIRE_FROM_CALLBACK(buffer == state_.rx_buffer_, in_isr);
+    REQUIRE_FROM_CALLBACK(total_size == state_.rx_total_size_, in_isr);
+    REQUIRE_FROM_CALLBACK(dma_handle->LinkedListQueue == &state_.rx_queue_, in_isr);
+  }
+
+  REQUIRE_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
+  FinalizeStopped(dma_handle, in_isr);
+  // 启动前将描述符与接收缓冲区同步到 DMA 可见的存储。
+  // Make descriptors and RX storage visible to DMA before starting the channel.
+  STM32_CleanDCacheByAddr(&state_, sizeof(state_));
+  STM32_CleanDCacheByAddr(buffer, total_size);
+  STM32_InvalidateDCacheByAddr(buffer, total_size);
+
+  return HAL_UARTEx_ReceiveToIdle_DMA(state_.uart_handle_, buffer,
+                                      static_cast<uint16_t>(state_.rx_node_size_));
+}
+
+uint8_t* STM32GpdmaUartAdapter::GetLinkedListDmaRxProducer() const
+{
+  ASSERT(state_.uart_handle_->hdmarx != nullptr);
+  const uintptr_t destination = state_.uart_handle_->hdmarx->Instance->CDAR;
+  return reinterpret_cast<uint8_t*>(destination);
+}
+
+void STM32GpdmaUartAdapter::CloseTxTerminalSource() const
+{
+  ATOMIC_CLEAR_BIT(state_.uart_handle_->Instance->CR1, USART_CR1_TCIE);
+  const volatile uint32_t cr1 = state_.uart_handle_->Instance->CR1;
+  UNUSED(cr1);
+  __DSB();
+}
+
+bool STM32GpdmaUartAdapter::LaunchStop(DMA_HandleTypeDef* dma_handle,
+                                       AbortCallback callback, bool in_isr)
+{
+  ASSERT(dma_handle != nullptr);
+  ASSERT(dma_handle->Parent == state_.uart_handle_);
+  ASSERT(callback != nullptr);
+
+  const auto abort_is_joinable = [&]()
+  {
+    if (dma_handle->XferAbortCallback == callback)
+    {
+      return true;
+    }
+
+    // 保留 HAL 因线路错误安装的 RX 中止回调，它会向同一处理器报告错误。
+    // Preserve HAL's RX line-error abort callback, which notifies the same service.
+    return (dma_handle == state_.uart_handle_->hdmarx) &&
+           (state_.uart_handle_->ErrorCode != HAL_UART_ERROR_NONE) &&
+           (dma_handle->XferAbortCallback != nullptr);
+  };
+
+  if (StopComplete(dma_handle))
+  {
+    return true;
+  }
+
+  GpdmaNvicMaskGuard irq_guard(dma_handle);
+  REQUIRE_FROM_CALLBACK(irq_guard.Valid() && irq_guard.WasEnabled(), in_isr);
+  if (!irq_guard.Valid() || !irq_guard.WasEnabled())
+  {
+    return false;
+  }
+
+  // 屏蔽该 DMA 中断后重新检查，覆盖首次检查后已完成的中止。
+  // Recheck after masking the DMA IRQ in case it completed after the first check.
+  if (StopComplete(dma_handle))
+  {
+    return true;
+  }
+  if (dma_handle->State == HAL_DMA_STATE_ABORT)
+  {
+    const bool joined = abort_is_joinable();
+    REQUIRE_FROM_CALLBACK(joined, in_isr);
+    return joined;
+  }
+  if (dma_handle->State == HAL_DMA_STATE_READY && IsStopped(dma_handle) &&
+      dma_handle->Lock == HAL_LOCKED)
+  {
+    // HAL IRQ 已停止通道，尚未解锁并回调；由该回调继续推进。
+    // The HAL IRQ has stopped the channel but has not unlocked or notified yet.
+    return true;
+  }
+  if (dma_handle->State != HAL_DMA_STATE_BUSY)
+  {
+    return false;
+  }
+
+  AbortCallback const previous_callback = dma_handle->XferAbortCallback;
+  const HAL_StatusTypeDef result = HAL_DMA_Abort_IT(dma_handle);
+  if (result == HAL_OK)
+  {
+    // DMA 中断仍被屏蔽；只有 HAL 未替换回调时才安装本后端回调。
+    // With the DMA IRQ masked, install our callback only if HAL did not replace it.
+    if (dma_handle->XferAbortCallback == previous_callback)
+    {
+      dma_handle->XferAbortCallback = callback;
+      return true;
+    }
+
+    const bool joined = abort_is_joinable();
+    REQUIRE_FROM_CALLBACK(joined, in_isr);
+    return joined;
+  }
+
+  return ((dma_handle->State == HAL_DMA_STATE_ABORT) && abort_is_joinable()) ||
+         StopComplete(dma_handle);
+}
+
+bool STM32GpdmaUartAdapter::StopComplete(DMA_HandleTypeDef* dma_handle)
+{
+  if ((dma_handle == nullptr) || !IsStopped(dma_handle) ||
+      (dma_handle->State != HAL_DMA_STATE_READY) || (dma_handle->Lock != HAL_UNLOCKED))
+  {
+    return false;
+  }
+  if ((dma_handle->Mode & DMA_LINKEDLIST) == DMA_LINKEDLIST)
+  {
+    return (dma_handle->LinkedListQueue != nullptr) &&
+           (dma_handle->LinkedListQueue->State == HAL_DMA_QUEUE_STATE_READY);
+  }
+  return true;
+}
+
+bool STM32GpdmaUartAdapter::AllStopsComplete() const
+{
+  return ((state_.uart_handle_->hdmatx == nullptr) ||
+          StopComplete(state_.uart_handle_->hdmatx)) &&
+         ((state_.uart_handle_->hdmarx == nullptr) ||
+          StopComplete(state_.uart_handle_->hdmarx));
+}
+
+void STM32GpdmaUartAdapter::FinalizeStopped(DMA_HandleTypeDef* dma_handle, bool in_isr)
+{
+  REQUIRE_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
+  REQUIRE_FROM_CALLBACK(dma_handle->Lock == HAL_UNLOCKED, in_isr);
+  if (!StopComplete(dma_handle))
+  {
+    return;
+  }
+
+  DisableInterrupts(dma_handle);
+  if ((dma_handle->Mode & DMA_LINKEDLIST) == DMA_LINKEDLIST)
+  {
+    // 错误中断可能保留 CBR1；清零后下次启动才能从链表头装载。
+    // Error IRQs may leave CBR1 set; clear it so the next start reloads the list head.
+    dma_handle->Instance->CBR1 = 0U;
+  }
+  const volatile uint32_t ccr = dma_handle->Instance->CCR;
+  UNUSED(ccr);
+  __DSB();
+  ClearFlags(dma_handle);
+  __DSB();
+}
+
+bool STM32GpdmaUartAdapter::IsStopped(DMA_HandleTypeDef* dma_handle)
+{
+  const uint32_t ccr = dma_handle->Instance->CCR;
+  return (ccr & DMA_CCR_EN) == 0U;
+}
+
+void STM32GpdmaUartAdapter::DisableInterrupts(DMA_HandleTypeDef* dma_handle)
+{
+  __HAL_DMA_DISABLE_IT(dma_handle, DMA_IT_TC | DMA_IT_HT | DMA_IT_DTE | DMA_IT_ULE |
+                                       DMA_IT_USE | DMA_IT_SUSP | DMA_IT_TO);
+}
+
+void STM32GpdmaUartAdapter::ClearFlags(DMA_HandleTypeDef* dma_handle)
+{
+  __HAL_DMA_CLEAR_FLAG(dma_handle, DMA_FLAG_TC | DMA_FLAG_HT | DMA_FLAG_DTE |
+                                       DMA_FLAG_ULE | DMA_FLAG_USE | DMA_FLAG_SUSP |
+                                       DMA_FLAG_TO);
+}
+
+void STM32GpdmaUartAdapter::BuildRxQueue(uint8_t* buffer, size_t total_size, bool in_isr)
+{
+  DMA_HandleTypeDef* const dma_handle = state_.uart_handle_->hdmarx;
+  REQUIRE_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
+  REQUIRE_FROM_CALLBACK(dma_handle->LinkedListQueue != nullptr, in_isr);
+  REQUIRE_FROM_CALLBACK(dma_handle->LinkedListQueue->Head != nullptr, in_isr);
+
+  DMA_NodeConfTypeDef node_config{};
+  REQUIRE_FROM_CALLBACK(HAL_DMAEx_List_GetNodeConfig(
+                            &node_config, dma_handle->LinkedListQueue->Head) == HAL_OK,
+                        in_isr);
+
+  // 保留 BSP 的请求与端口等属性，明确设置字节接收环的布局。
+  // Preserve BSP request and port attributes while defining the byte RX ring layout.
+  node_config.NodeType = DMA_GPDMA_LINEAR_NODE;
+  node_config.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+  node_config.Init.Direction = DMA_PERIPH_TO_MEMORY;
+  node_config.Init.SrcInc = DMA_SINC_FIXED;
+  node_config.Init.DestInc = DMA_DINC_INCREMENTED;
+  node_config.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+  node_config.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+  node_config.Init.SrcBurstLength = 1U;
+  node_config.Init.DestBurstLength = 1U;
+  node_config.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+  node_config.Init.Mode = DMA_NORMAL;
+  node_config.DataHandlingConfig.DataExchange = DMA_EXCHANGE_NONE;
+  node_config.DataHandlingConfig.DataAlignment = DMA_DATA_RIGHTALIGN_ZEROPADDED;
+  node_config.TriggerConfig.TriggerMode = DMA_TRIGM_BLOCK_TRANSFER;
+  node_config.TriggerConfig.TriggerPolarity = DMA_TRIG_POLARITY_MASKED;
+  node_config.TriggerConfig.TriggerSelection = 0U;
+  node_config.RepeatBlockConfig = {};
+
+  const size_t node_size = total_size / RX_NODE_COUNT;
+  node_config.SrcAddress = static_cast<uint32_t>(
+      reinterpret_cast<uintptr_t>(&state_.uart_handle_->Instance->RDR));
+  node_config.DataSize = static_cast<uint32_t>(node_size);
+
+  for (size_t i = 0U; i < RX_NODE_COUNT; ++i)
+  {
+    node_config.DstAddress =
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&buffer[i * node_size]));
+    REQUIRE_FROM_CALLBACK(
+        HAL_DMAEx_List_BuildNode(&node_config, &state_.nodes_[i]) == HAL_OK, in_isr);
+    REQUIRE_FROM_CALLBACK(
+        HAL_DMAEx_List_InsertNode_Tail(&state_.rx_queue_, &state_.nodes_[i]) == HAL_OK,
+        in_isr);
+  }
+
+  REQUIRE_FROM_CALLBACK(HAL_DMAEx_List_SetCircularMode(&state_.rx_queue_) == HAL_OK,
+                        in_isr);
+  REQUIRE_FROM_CALLBACK(HAL_DMAEx_List_UnLinkQ(dma_handle) == HAL_OK, in_isr);
+  REQUIRE_FROM_CALLBACK(HAL_DMAEx_List_LinkQ(dma_handle, &state_.rx_queue_) == HAL_OK,
+                        in_isr);
+  REQUIRE_FROM_CALLBACK(dma_handle->LinkedListQueue == &state_.rx_queue_, in_isr);
+
+  state_.rx_buffer_ = buffer;
+  state_.rx_total_size_ = total_size;
+  state_.rx_node_size_ = node_size;
+  state_.rx_queue_built_ = true;
+}
+
+}  // namespace LibXR
+
+#endif

--- a/driver/st/stm32_uart_gpdma.hpp
+++ b/driver/st/stm32_uart_gpdma.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "main.h"
+
+#if defined(STM32H5)
+#define LIBXR_STM32_UART_GPDMA 1
+#endif
+
+#if defined(LIBXR_STM32_UART_GPDMA) && defined(HAL_UART_MODULE_ENABLED)
+
+#if !defined(HAL_DMA_MODULE_ENABLED) || !defined(DMA_LINKEDLIST_CIRCULAR) || \
+    !defined(DMA_GPDMA_LINEAR_NODE) || !defined(IS_GPDMA_INSTANCE)
+#error "STM32H5 UART requires the HAL GPDMA linked-list API"
+#endif
+
+#if (defined(STM32H503xx) || defined(STM32H523xx) || defined(STM32H533xx) || \
+     defined(STM32H543xx) || defined(STM32H553xx) || defined(STM32H562xx) || \
+     defined(STM32H563xx) || defined(STM32H573xx)) &&                        \
+    !defined(USART_DMAREQUESTS_SW_WA)
+#error "STM32H5 UART requires the HAL USART DMA-request workaround"
+#endif
+
+namespace LibXR
+{
+/**
+ * @brief STM32 GPDMA 串口适配器 / STM32 GPDMA UART adapter
+ *
+ * 持有四个线性接收节点与循环链表，数据缓冲区由调用者提供。
+ * Owns four linear RX nodes and their circular list; the caller supplies the payload.
+ * @pre UART、DMA 句柄及缓冲区在传输期间有效且由本后端独占；相关 UART/DMA
+ *      中断具有相同抢占优先级，运行中的 DMA 中断必须使能。
+ *      UART/DMA handles and buffers remain valid and exclusively owned by this backend.
+ *      Related UART/DMA IRQs share a preemption priority; active DMA IRQs must be
+ * enabled.
+ */
+class STM32GpdmaUartAdapter
+{
+ public:
+  static constexpr size_t RX_NODE_COUNT = 4U;
+  using AbortCallback = void (*)(DMA_HandleTypeDef*);
+
+  /// 绑定已初始化的 UART 句柄 / Bind an initialized UART handle.
+  explicit STM32GpdmaUartAdapter(UART_HandleTypeDef* uart_handle);
+
+  /// 构建或复用四节点循环链表并启动 RX / Build or reuse the four-node ring and start RX.
+  HAL_StatusTypeDef StartLinkedListDmaRx(uint8_t* buffer, size_t total_size, bool in_isr);
+  /// 读取一次当前 DMA 写入地址 / Read the current DMA destination address once.
+  [[nodiscard]] uint8_t* GetLinkedListDmaRxProducer() const;
+  /// 关闭 TX 完成中断，保留 DMA 请求位 / Disable TX completion IRQ, retaining DMA
+  /// requests.
+  void CloseTxTerminalSource() const;
+  /// 启动异步中止或接续已有中止 / Start an asynchronous abort or join an existing abort.
+  [[nodiscard]] bool LaunchStop(DMA_HandleTypeDef* dma_handle, AbortCallback callback,
+                                bool in_isr);
+  /// 检查通道及 HAL 链表均已停止 / Check that the channel and HAL list have stopped.
+  [[nodiscard]] static bool StopComplete(DMA_HandleTypeDef* dma_handle);
+  /// 检查所有已配置的 DMA 通道均已停止 / Check all configured DMA channels have stopped.
+  [[nodiscard]] bool AllStopsComplete() const;
+  /// 在停止状态清除旧标志和链表计数 / Clear stale flags and list count while stopped.
+  static void FinalizeStopped(DMA_HandleTypeDef* dma_handle, bool in_isr);
+
+ private:
+  // 节点保持在同一 64 KiB 链表地址窗口内。
+  // Keep all nodes within one 64 KiB linked-list address window.
+  struct alignas(256) StateBlock
+  {
+    DMA_NodeTypeDef nodes_[RX_NODE_COUNT];
+    DMA_QListTypeDef rx_queue_{};
+    UART_HandleTypeDef* uart_handle_ = nullptr;
+    uint8_t* rx_buffer_ = nullptr;
+    size_t rx_total_size_ = 0U;
+    size_t rx_node_size_ = 0U;
+    bool rx_queue_built_ = false;
+  };
+  static_assert(offsetof(StateBlock, nodes_) == 0U);
+  static_assert(sizeof(StateBlock) == 256U);
+
+  [[nodiscard]] static bool IsStopped(DMA_HandleTypeDef* dma_handle);
+  static void DisableInterrupts(DMA_HandleTypeDef* dma_handle);
+  static void ClearFlags(DMA_HandleTypeDef* dma_handle);
+  void BuildRxQueue(uint8_t* buffer, size_t total_size, bool in_isr);
+  StateBlock state_{};
+};
+static_assert(sizeof(STM32GpdmaUartAdapter) == 256U);
+}  // namespace LibXR
+#endif


### PR DESCRIPTION
STM32H5 UART cannot use the traditional DMA_CIRCULAR path. Integrate the previously reviewed four-node GPDMA RX adapter with the current ReadPort/WritePort and serialized STM32 backend.

The adapter owns a 256-byte aligned descriptor block, splits caller RX storage into four contiguous nodes and samples CDAR for progress. TX remains normal one-shot DMA with the current stable-half completion semantics. Configuration waits for TX/line completion, stops RX asynchronously, applies framing without HAL tick polling, and resumes retained work. Error recovery uses the #272 abort gate, joins HAL-owned RX aborts, waits for both channels and HAL unlock, then retires the active half without replay. Keep USART DMA-request workaround bits and reset stale linked-list counts only while stopped.

H5 requires initialized exclusive UART/DMA handles, a stopped circular seed RX list, DMA-accessible storage and related UART/DMA IRQs at the same preemption priority. No BSP edits or runtime mode switch. Other STM32 families retain their traditional path; no U5/U3/N6 support claim.

Validation: real H503/H563 HAL/CMSIS with ARM GNU14.2 compiles the UART, adapter and consumer, and relocatably links each three-object group. Adapter size/alignment are checked on target. These are object-level checks, not a complete H5 firmware link. Eight full-driver/current-RW controlled HAL-seam cases pass, including RX wrap, staged TX/config callback reentry, startup callback serialization, two-channel abort, HAL-owned completion and exactly-once write completion. Negative variants detect missing error re-drive, early reset and skipped HAL unlock. The traditional G0 full firmware build/link and four #272 HAL-function regressions pass. Formatting/source identity checks pass. No new hardware execution; historical H503 hardware evidence is provenance only.

Four production files, one commit. Test fixtures and audit reports stay outside the repository. H5 ADC, Flash, USB DRD and PWM gaps remain separate.

## Sourcery 总结

在保留其他 STM32 系列现有行为的同时，将 STM32H5 UART 与支持 GPDMA 链表接收功能集成。

新功能：
- 使用四节点 GPDMA 循环 RX 适配器，为 STM32H5 添加 UART 支持，并与现有的 ReadPort/WritePort 后端集成。

错误修复：
- 通过协调两个 DMA 通道以及 HAL 管理的中止完成流程，改进 STM32H5 的中止和配置恢复机制，然后重新启动接收。

增强功能：
- 为非 H5 STM32 目标保留传统 DMA 路径，同时为 H5 链表接收添加生产者位置跟踪和停止状态清理。

文档：
- 记录 STM32H5 UART 句柄、缓冲区、DMA 模式、链表以及中断优先级要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate STM32H5 UARTs with GPDMA linked-list reception while preserving existing behavior on other STM32 families.

New Features:
- Add STM32H5 UART support using a four-node GPDMA circular RX adapter integrated with the existing ReadPort/WritePort backend.

Bug Fixes:
- Improve STM32H5 abort and configuration recovery by coordinating both DMA channels and HAL-owned abort completion before restarting reception.

Enhancements:
- Preserve the traditional DMA path for non-H5 STM32 targets while adding producer-position tracking and stopped-state cleanup for H5 linked-list reception.

Documentation:
- Document STM32H5 UART handle, buffer, DMA mode, linked-list, and interrupt-priority requirements.

</details>