### PR TITLE
feat(stm32): support H5 ADC circular GPDMA sampling

### DIFF
--- a/driver/st/stm32_adc.cpp
+++ b/driver/st/stm32_adc.cpp
@@ -79,10 +79,18 @@ STM32ADC::STM32ADC(ADC_HandleTypeDef* hadc, RawData dma_buff,
     /* DMA must be in circular mode */
     AssertContinuousConvModeEnabled<H>(hadc_);
     AssertDMAContReqEnabled<H>(hadc_);
+#if !defined(LIBXR_STM32_ADC_GPDMA)
     AssertDMACircular<H>(hadc_);
+#endif
     AssertNbrOfConvEq<H>(hadc_, NUM_CHANNELS);
+#if defined(LIBXR_STM32_ADC_GPDMA)
+    REQUIRE(gpdma_adapter_.Start(hadc_, reinterpret_cast<uint32_t*>(dma_buffer_.addr_),
+                                 NUM_CHANNELS * filter_size_,
+                                 dma_buffer_.size_) == HAL_OK);
+#else
     HAL_ADC_Start_DMA(hadc_, reinterpret_cast<uint32_t*>(dma_buffer_.addr_),
                       NUM_CHANNELS * filter_size_);
+#endif
   }
   else
   {
@@ -94,7 +102,18 @@ STM32ADC::STM32ADC(ADC_HandleTypeDef* hadc, RawData dma_buff,
 
 STM32ADC::~STM32ADC()
 {
+#if defined(LIBXR_STM32_ADC_GPDMA)
+  if (use_dma_)
+  {
+    REQUIRE(gpdma_adapter_.Stop(hadc_) == HAL_OK);
+  }
+  else
+  {
+    HAL_ADC_Stop(hadc_);
+  }
+#else
   use_dma_ ? HAL_ADC_Stop_DMA(hadc_) : HAL_ADC_Stop(hadc_);
+#endif
   for (uint8_t i = 0; i < NUM_CHANNELS; ++i)
   {
     delete channels_[i];

--- a/driver/st/stm32_adc.hpp
+++ b/driver/st/stm32_adc.hpp
@@ -13,6 +13,7 @@
 #include "adc.hpp"
 #include "libxr.hpp"
 #include "libxr_def.hpp"
+#include "stm32_adc_gpdma.hpp"
 
 namespace LibXR
 {
@@ -196,7 +197,11 @@ class STM32ADC
       T hadc)
   {
     ASSERT(hadc->DMA_Handle != nullptr);
+#if defined(DMA_CIRCULAR)
     ASSERT(hadc->DMA_Handle->Init.Mode == DMA_CIRCULAR);
+#else
+    ASSERT(false);
+#endif
   }
 
   template <typename T>
@@ -243,6 +248,9 @@ class STM32ADC
    * @param dma_buff DMA 缓冲区 / DMA buffer
    * @param channels ADC 通道列表 / ADC channel list
    * @param vref 参考电压 / Reference voltage
+   * @note H5 DMA 采样使用半字传输和循环链表，缓冲区、句柄及原链表在对象生命周期内有效。
+   *       H5 DMA sampling uses halfword transfers and a circular list; buffers, handles
+   *       and the original list remain valid for the object's lifetime.
    */
   STM32ADC(ADC_HandleTypeDef* hadc, RawData dma_buff,
            std::initializer_list<uint32_t> channels, float vref);
@@ -278,6 +286,9 @@ class STM32ADC
   float resolution_;
   Channel** channels_;
   float vref_;
+#if defined(LIBXR_STM32_ADC_GPDMA)
+  STM32GpdmaAdcAdapter gpdma_adapter_;
+#endif
 
   float ConvertToVoltage(float adc_value);
 };

--- a/driver/st/stm32_adc_gpdma.cpp
+++ b/driver/st/stm32_adc_gpdma.cpp
@@ -1,0 +1,155 @@
+#include "stm32_adc_gpdma.hpp"
+
+#if defined(LIBXR_STM32_ADC_GPDMA) && defined(HAL_ADC_MODULE_ENABLED)
+
+#include <limits>
+
+#include "libxr_def.hpp"
+#include "stm32_dcache.hpp"
+
+namespace LibXR
+{
+
+HAL_StatusTypeDef STM32GpdmaAdcAdapter::Start(ADC_HandleTypeDef* adc_handle,
+                                              uint32_t* buffer, uint32_t sample_count,
+                                              size_t buffer_size)
+{
+  REQUIRE(adc_handle != nullptr);
+  REQUIRE(adc_handle->DMA_Handle != nullptr);
+  REQUIRE(buffer != nullptr);
+  REQUIRE(sample_count > 0U);
+  REQUIRE(sample_count <= std::numeric_limits<size_t>::max() / sizeof(uint16_t));
+  REQUIRE(buffer_size >= static_cast<size_t>(sample_count) * sizeof(uint16_t));
+  DMA_HandleTypeDef* const dma_handle = adc_handle->DMA_Handle;
+  REQUIRE(dma_handle->Parent == adc_handle);
+  REQUIRE(IS_GPDMA_INSTANCE(dma_handle->Instance) != 0U);
+  REQUIRE(dma_handle->Mode == DMA_LINKEDLIST_CIRCULAR);
+  REQUIRE(dma_handle->InitLinkedList.LinkedListMode == DMA_LINKEDLIST_CIRCULAR);
+  REQUIRE(dma_handle->InitLinkedList.LinkStepMode == DMA_LSM_FULL_EXECUTION);
+  REQUIRE((dma_handle->Instance->CCR & DMA_CCR_LSM) == DMA_LSM_FULL_EXECUTION);
+
+  if (state_.original_queue == nullptr)
+  {
+    BuildAndAttach(adc_handle, buffer, sample_count, buffer_size);
+  }
+  else
+  {
+    REQUIRE(dma_handle->LinkedListQueue == &state_.queue);
+    REQUIRE(state_.queue.Head == &state_.node);
+    REQUIRE(state_.queue.FirstCircularNode == &state_.node);
+    REQUIRE(state_.queue.NodeNumber == 1U);
+  }
+
+  FinalizeStopped(dma_handle);
+  STM32_CleanDCacheByAddr(&state_, sizeof(state_));
+  STM32_CleanDCacheByAddr(buffer, buffer_size);
+  STM32_InvalidateDCacheByAddr(buffer, buffer_size);
+
+  return HAL_ADC_Start_DMA(adc_handle, buffer, sample_count);
+}
+
+HAL_StatusTypeDef STM32GpdmaAdcAdapter::Stop(ADC_HandleTypeDef* adc_handle)
+{
+  REQUIRE(adc_handle != nullptr);
+  REQUIRE(adc_handle->DMA_Handle != nullptr);
+  DMA_HandleTypeDef* const dma_handle = adc_handle->DMA_Handle;
+  REQUIRE(dma_handle->Parent == adc_handle);
+
+  const HAL_StatusTypeDef stop_status = HAL_ADC_Stop_DMA(adc_handle);
+  if (stop_status != HAL_OK)
+  {
+    return stop_status;
+  }
+
+  if (state_.original_queue == nullptr)
+  {
+    return HAL_OK;
+  }
+
+  FinalizeStopped(dma_handle);
+  REQUIRE(dma_handle->LinkedListQueue == &state_.queue);
+  REQUIRE(state_.queue.State == HAL_DMA_QUEUE_STATE_READY);
+  DMA_QListTypeDef* const original_queue = state_.original_queue;
+  REQUIRE(HAL_DMAEx_List_UnLinkQ(dma_handle) == HAL_OK);
+  REQUIRE(HAL_DMAEx_List_LinkQ(dma_handle, original_queue) == HAL_OK);
+  REQUIRE(dma_handle->LinkedListQueue == original_queue);
+  state_.original_queue = nullptr;
+  return HAL_OK;
+}
+
+void STM32GpdmaAdcAdapter::FinalizeStopped(DMA_HandleTypeDef* dma_handle)
+{
+  REQUIRE(dma_handle->State == HAL_DMA_STATE_READY);
+  REQUIRE(dma_handle->Lock == HAL_UNLOCKED);
+  REQUIRE((dma_handle->Instance->CCR & DMA_CCR_EN) == 0U);
+  REQUIRE(dma_handle->LinkedListQueue != nullptr);
+  REQUIRE(dma_handle->LinkedListQueue->State == HAL_DMA_QUEUE_STATE_READY);
+
+  // 错误中断可能保留块计数，清零后下次启动才会装载链表头。
+  // Error IRQs may retain the block count; clear it so the next start loads the list
+  // head.
+  __HAL_DMA_DISABLE_IT(dma_handle, DMA_IT_TC | DMA_IT_HT | DMA_IT_DTE | DMA_IT_ULE |
+                                       DMA_IT_USE | DMA_IT_SUSP | DMA_IT_TO);
+  dma_handle->Instance->CBR1 = 0U;
+  __HAL_DMA_CLEAR_FLAG(dma_handle, DMA_FLAG_TC | DMA_FLAG_HT | DMA_FLAG_DTE |
+                                       DMA_FLAG_ULE | DMA_FLAG_USE | DMA_FLAG_SUSP |
+                                       DMA_FLAG_TO);
+  __DSB();
+}
+
+void STM32GpdmaAdcAdapter::BuildAndAttach(ADC_HandleTypeDef* adc_handle, uint32_t* buffer,
+                                          uint32_t sample_count, size_t buffer_size)
+{
+  DMA_HandleTypeDef* const dma_handle = adc_handle->DMA_Handle;
+  REQUIRE(dma_handle->State == HAL_DMA_STATE_READY);
+  REQUIRE((dma_handle->Instance->CCR & DMA_CCR_EN) == 0U);
+  REQUIRE(dma_handle->LinkedListQueue != nullptr);
+  REQUIRE(dma_handle->LinkedListQueue->Head != nullptr);
+  REQUIRE(dma_handle->LinkedListQueue->FirstCircularNode != nullptr);
+  REQUIRE(dma_handle->LinkedListQueue->State == HAL_DMA_QUEUE_STATE_READY);
+
+  DMA_NodeConfTypeDef node_config{};
+  REQUIRE(HAL_DMAEx_List_GetNodeConfig(&node_config, dma_handle->LinkedListQueue->Head) ==
+          HAL_OK);
+  REQUIRE(node_config.Init.Direction == DMA_PERIPH_TO_MEMORY);
+  REQUIRE(node_config.Init.SrcInc == DMA_SINC_FIXED);
+  REQUIRE(node_config.Init.DestInc == DMA_DINC_INCREMENTED);
+  REQUIRE(node_config.Init.SrcDataWidth == DMA_SRC_DATAWIDTH_HALFWORD);
+  REQUIRE(node_config.Init.DestDataWidth == DMA_DEST_DATAWIDTH_HALFWORD);
+  REQUIRE(node_config.Init.SrcBurstLength == 1U);
+  REQUIRE(node_config.Init.DestBurstLength == 1U);
+  REQUIRE(node_config.Init.BlkHWRequest == DMA_BREQ_SINGLE_BURST);
+  REQUIRE(node_config.Init.Mode == DMA_NORMAL);
+  REQUIRE(node_config.TriggerConfig.TriggerPolarity == DMA_TRIG_POLARITY_MASKED);
+  REQUIRE(node_config.DataHandlingConfig.DataExchange == DMA_EXCHANGE_NONE);
+  REQUIRE(sample_count <= std::numeric_limits<uint32_t>::max() / sizeof(uint16_t));
+
+  const uint32_t transfer_size = sample_count * sizeof(uint16_t);
+  REQUIRE(buffer_size >= transfer_size);
+  REQUIRE(IS_DMA_BLOCK_SIZE(transfer_size) != 0U);
+
+  node_config.NodeType = DMA_GPDMA_LINEAR_NODE;
+  node_config.SrcAddress =
+      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&adc_handle->Instance->DR));
+  node_config.DstAddress = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(buffer));
+  node_config.DataSize = transfer_size;
+
+  REQUIRE(state_.queue.Head == nullptr);
+  REQUIRE(state_.queue.NodeNumber == 0U);
+  REQUIRE(HAL_DMAEx_List_BuildNode(&node_config, &state_.node) == HAL_OK);
+  REQUIRE(HAL_DMAEx_List_InsertNode_Tail(&state_.queue, &state_.node) == HAL_OK);
+  REQUIRE(HAL_DMAEx_List_SetCircularMode(&state_.queue) == HAL_OK);
+  REQUIRE(state_.queue.Head == &state_.node);
+  REQUIRE(state_.queue.FirstCircularNode == &state_.node);
+  REQUIRE(state_.queue.NodeNumber == 1U);
+  REQUIRE(state_.queue.State == HAL_DMA_QUEUE_STATE_READY);
+
+  state_.original_queue = dma_handle->LinkedListQueue;
+  REQUIRE(HAL_DMAEx_List_UnLinkQ(dma_handle) == HAL_OK);
+  REQUIRE(HAL_DMAEx_List_LinkQ(dma_handle, &state_.queue) == HAL_OK);
+  REQUIRE(dma_handle->LinkedListQueue == &state_.queue);
+}
+
+}  // namespace LibXR
+
+#endif

--- a/driver/st/stm32_adc_gpdma.hpp
+++ b/driver/st/stm32_adc_gpdma.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "main.h"
+
+#if defined(STM32H5) && defined(HAL_ADC_MODULE_ENABLED) && defined(HAL_DMA_MODULE_ENABLED)
+#if !defined(DMA_LINKEDLIST_CIRCULAR) || !defined(DMA_GPDMA_LINEAR_NODE)
+#error "STM32H5 ADC requires the HAL GPDMA linked-list API"
+#endif
+#define LIBXR_STM32_ADC_GPDMA 1
+#endif
+
+#if defined(LIBXR_STM32_ADC_GPDMA)
+namespace LibXR
+{
+/**
+ * @brief STM32 ADC 循环采样的 GPDMA 适配器 / GPDMA adapter for circular STM32 ADC
+ * sampling
+ *
+ * 持有一个线性循环节点，采样缓冲区由调用者提供；启动时替换 BSP 链表，停止后恢复。
+ * Owns one linear circular node while borrowing sample storage; replaces the BSP list
+ * on startup and restores it after stopping.
+ * @note 由所属 STM32ADC 在构造时启动、析构时停止，期间独占对应 ADC/DMA 句柄。
+ *       Started by the owning STM32ADC constructor and stopped by its destructor,
+ *       with exclusive ADC/DMA handle ownership throughout that lifetime.
+ */
+class STM32GpdmaAdcAdapter
+{
+ public:
+  STM32GpdmaAdcAdapter() = default;
+
+  /**
+   * @brief 挂接循环链表并启动 ADC DMA / Attach the circular list and start ADC DMA.
+   * @param adc_handle 已关联静止循环链表的 ADC 句柄 / ADC handle with a stopped circular
+   * list.
+   * @param buffer DMA 可访问的半字采样缓冲区 / DMA-accessible halfword sample storage.
+   * @param sample_count 每轮采样数，单位为半字 / Samples per cycle, in halfwords.
+   * @param buffer_size 缓冲区字节数 / Available buffer size in bytes.
+   * @return HAL 启动结果 / HAL startup result.
+   */
+  HAL_StatusTypeDef Start(ADC_HandleTypeDef* adc_handle, uint32_t* buffer,
+                          uint32_t sample_count, size_t buffer_size);
+
+  /**
+   * @brief 停止 ADC DMA 并恢复 BSP 链表 / Stop ADC DMA and restore the BSP list.
+   * @param adc_handle 启动时使用的 ADC 句柄 / ADC handle used at startup.
+   * @return HAL 停止结果；失败时保留私有链表 / HAL stop result; retain the private list
+   * on failure.
+   */
+  HAL_StatusTypeDef Stop(ADC_HandleTypeDef* adc_handle);
+
+ private:
+  // DMA 读取的节点寄存器按 32 字节对齐，避免跨越链表地址窗口。
+  // Align the DMA node registers to 32 bytes to avoid crossing the list address window.
+  struct alignas(32) StateBlock
+  {
+    DMA_NodeTypeDef node{};
+    DMA_QListTypeDef queue{};
+    DMA_QListTypeDef* original_queue = nullptr;
+  };
+  static_assert(offsetof(StateBlock, node) == 0U);
+
+  void BuildAndAttach(ADC_HandleTypeDef* adc_handle, uint32_t* buffer,
+                      uint32_t sample_count, size_t buffer_size);
+  static void FinalizeStopped(DMA_HandleTypeDef* dma_handle);
+  StateBlock state_{};
+};
+}  // namespace LibXR
+#endif


### PR DESCRIPTION
STM32H5 ADC needs linked-list GPDMA instead of the traditional DMA_CIRCULAR path. Restore the reviewed private single-node linear ring for halfword samples, preserving the existing channel filtering and voltage conversion.

Keep the STM32ADC destructor. Stop ADC DMA successfully before detaching the private list and restoring the BSP seed queue, then release channel objects. Clear residual GPDMA block count and flags only at a confirmed stopped boundary: HAL's DMA error path can leave CBR1 set, and HAL_ADC_Stop_DMA skips DMA abort when the handle is already READY. Traditional and polling paths retain their existing behavior and error policy.

Validation: real H503/H563 HAL/CMSIS compile ADC, adapter and consumer objects and relocatably link them; disabled-ADC translation units also compile. Full-source controlled HAL-seam cases cover halfword length, averaging, seed restoration, destruction/reconstruction, polling, start/stop failures, invalid geometry and stale-count recovery. Removing stop or count reset fails the corresponding checks. Real G0 firmware builds/links 96/96, including the ADC constructor/destructor/read path. Format and source-identity checks pass.

Four production files, one commit; no product test scaffolding or BSP changes. No new hardware execution or complete H5 firmware-link claim. Flash, USB DRD and PWM remain separate.

## Sourcery 摘要

支持通过私有 GPDMA 链表实现可靠的 STM32H5 ADC 循环采样，同时保持其他 STM32 目标平台上现有的 ADC 行为不变。

新功能：
- 通过使用半字传输的单节点 GPDMA 链表适配器，新增 STM32H5 ADC 循环采样支持。

错误修复：
- 确保 GPDMA 停止状态会被重置，并在后续 ADC 启动前清除残留的块计数和标志。
- 在 ADC 采样对象停止或销毁时，保存并恢复 BSP GPDMA 队列。

增强功能：
- 在将 GPDMA 生命周期管理集成到 STM32ADC 的同时，保留 ADC 通道过滤、电压转换、轮询行为以及现有的非 H5 DMA 处理逻辑。

文档：
- 记录 H5 GPDMA ADC 采样的生命周期和缓冲区要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support reliable STM32H5 ADC circular sampling with a private GPDMA linked list while preserving existing ADC behavior on other STM32 targets.

New Features:
- Add STM32H5 ADC circular sampling support through a single-node GPDMA linked-list adapter using halfword transfers.

Bug Fixes:
- Ensure stopped GPDMA state is reset and residual block counts and flags are cleared before subsequent ADC starts.
- Preserve and restore the BSP GPDMA queue when the ADC sampling object is stopped or destroyed.

Enhancements:
- Retain ADC channel filtering, voltage conversion, polling behavior, and existing non-H5 DMA handling while integrating GPDMA lifecycle management into STM32ADC.

Documentation:
- Document the lifetime and buffer requirements for H5 GPDMA ADC sampling.

</details>