### PR TITLE
fix(stm32): support H5 Flash programming

### DIFF
--- a/driver/st/stm32_flash.cpp
+++ b/driver/st/stm32_flash.cpp
@@ -1,5 +1,7 @@
 #include "stm32_flash.hpp"
 
+#ifdef HAL_FLASH_MODULE_ENABLED
+
 using namespace LibXR;
 
 STM32Flash::STM32Flash(const FlashSector* sectors, size_t sector_count,
@@ -63,7 +65,13 @@ ErrorCode STM32Flash::Erase(size_t offset, size_t size)
     SetBanks(erase_init, sector.address);
 #elif defined(FLASH_TYPEERASE_SECTORS)  // STM32F4/F7/H7... series
     erase_init.TypeErase = FLASH_TYPEERASE_SECTORS;
+#if defined(FLASH_SECTOR_TOTAL)
     erase_init.Sector = static_cast<uint32_t>(i) % FLASH_SECTOR_TOTAL;
+#elif defined(FLASH_SECTOR_NB)
+    erase_init.Sector = static_cast<uint32_t>(i) % FLASH_SECTOR_NB;
+#else
+#error "No supported Flash sector count defined"
+#endif
     erase_init.NbSectors = 1;
 #if defined(FLASH_BANK_1)
     erase_init.Banks = STM32FlashBankOf(sector.address);
@@ -138,10 +146,9 @@ ErrorCode STM32Flash::Write(size_t offset, ConstRawData data)
   const uint8_t* src = reinterpret_cast<const uint8_t*>(data.addr_);
   size_t written = 0;
 
-#if defined(STM32H7) || defined(STM32H5)
-  alignas(LibXR::HW_CACHE_LINE_SIZE) uint32_t flash_word_buffer[8] = {
-      0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu,
-      0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu};
+#if defined(FLASH_TYPEPROGRAM_FLASHWORD) || defined(FLASH_TYPEPROGRAM_QUADWORD)
+  alignas(LibXR::HW_CACHE_LINE_SIZE)
+      uint32_t flash_word_buffer[DetermineMinWriteSize() / sizeof(uint32_t)];
   while (written < data.size_)
   {
     size_t chunk_size = LibXR::min<size_t>(MinWriteSize(), data.size_ - written);
@@ -218,3 +225,5 @@ bool STM32Flash::IsInRange(uint32_t addr, size_t size) const
   const uint32_t END = addr + size;
   return (addr >= BEGIN) && (END <= LIMIT) && (END >= addr);  // 最后一项防溢出
 }
+
+#endif

--- a/driver/st/stm32_flash.hpp
+++ b/driver/st/stm32_flash.hpp
@@ -9,6 +9,8 @@
 #include "libxr_type.hpp"
 #include "main.h"
 
+#ifdef HAL_FLASH_MODULE_ENABLED
+
 namespace LibXR
 {
 
@@ -146,6 +148,8 @@ class STM32Flash : public Flash
     return FLASH_TYPEPROGRAM_DOUBLEWORD;
 #elif defined(FLASH_TYPEPROGRAM_FLASHWORD)
     return FLASH_TYPEPROGRAM_FLASHWORD;
+#elif defined(FLASH_TYPEPROGRAM_QUADWORD)
+    return FLASH_TYPEPROGRAM_QUADWORD;
 #else
 #error "No supported FLASH_TYPEPROGRAM_xxx defined"
 #endif
@@ -163,6 +167,8 @@ class STM32Flash : public Flash
     return 8;
 #elif defined(FLASH_TYPEPROGRAM_FLASHWORD)
     return FLASH_NB_32BITWORD_IN_FLASHWORD * 4;
+#elif defined(FLASH_TYPEPROGRAM_QUADWORD)
+    return 16;
 #else
 #error "No supported FLASH_TYPEPROGRAM_xxx defined"
 #endif
@@ -172,3 +178,5 @@ class STM32Flash : public Flash
 };
 
 }  // namespace LibXR
+
+#endif


### PR DESCRIPTION
Add STM32H5 Flash compatibility by selecting QUADWORD programming with a 16-byte unit, accepting FLASH_SECTOR_NB for bank-local sector indices, and sizing the existing staging buffer to the selected programming unit. Compile the driver only when the HAL Flash module is enabled.

Preserve existing FF tail padding, equal-data skipping, synchronous HAL calls and error returns. No constructor, cache-policy or general Flash lifecycle redesign.

Validation: real H503/H563 objects and combined-driver relocatable links pass, including Flash-disabled compilation; F401/H743 real-header checks and combined G0 firmware link pass. Actual-source process-memory/HAL-seam tests cover two-unit writes, FF tail, bank/sector selection, equal-data skip, bounds and failure relocking. No hardware Flash writes. One commit/two files; fixtures stay outside the repository.

## Sourcery 摘要

扩展 STM32 Flash 驱动以兼容 STM32H5，同时保留现有的擦除和写入语义。

新功能：
- 添加 STM32H5 Flash 编程支持，使用 QUADWORD 写入和 16 字节编程单元。

错误修复：
- 在提供 FLASH_SECTOR_NB 的 STM32 系列上支持按 Bank 进行本地扇区编号。
- 在禁用 HAL Flash 模块时，避免编译 STM32 Flash 驱动。

改进：
- 根据所选编程单元调整 Flash 暂存缓冲区大小，同时保留现有的写入行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the STM32 Flash driver for STM32H5 compatibility while retaining existing erase and write semantics.

New Features:
- Add STM32H5 Flash programming support with QUADWORD writes and 16-byte programming units.

Bug Fixes:
- Support bank-local sector numbering on STM32 families that expose FLASH_SECTOR_NB.
- Prevent the STM32 Flash driver from compiling when the HAL Flash module is disabled.

Enhancements:
- Size Flash staging buffers according to the selected programming unit while preserving existing write behavior.

</details>