### PR TITLE
fix(stm32): enable USB DRD device branches

### DIFF
--- a/driver/st/stm32_usb.hpp
+++ b/driver/st/stm32_usb.hpp
@@ -15,7 +15,7 @@
  */
 typedef enum : uint8_t
 {
-#if (defined(USB_BASE))
+#if defined(USB_BASE) || defined(USB_DRD_FS)
   STM32_USB_FS_DEV,
 #endif
 #if (defined(USB_OTG_FS))

--- a/driver/st/stm32_usb_dev.cpp
+++ b/driver/st/stm32_usb_dev.cpp
@@ -264,7 +264,7 @@ ErrorCode STM32USBDeviceOtgHS::SetAddress(uint8_t address,
 
 #endif
 
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
 STM32USBDeviceDevFs::STM32USBDeviceDevFs(
     PCD_HandleTypeDef* hpcd, const std::initializer_list<EPConfig> EP_CFGS,
     USB::DeviceDescriptor::PacketSize0 packet_size, uint16_t vid, uint16_t pid,

--- a/driver/st/stm32_usb_dev.hpp
+++ b/driver/st/stm32_usb_dev.hpp
@@ -143,7 +143,7 @@ class STM32USBDeviceOtgHS : public STM32USBDevice
 };
 #endif
 
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
 
 #if defined(PMA_END_ADDR)
 #define LIBXR_STM32_USB_PMA_SIZE PMA_END_ADDR

--- a/driver/st/stm32_usb_ep.cpp
+++ b/driver/st/stm32_usb_ep.cpp
@@ -42,7 +42,7 @@ STM32Endpoint::STM32Endpoint(EPNumber ep_num, stm32_usb_dev_id_t id,
 }
 #endif
 
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
 STM32Endpoint::STM32Endpoint(EPNumber ep_num, stm32_usb_dev_id_t id,
                              PCD_HandleTypeDef* hpcd, Direction dir,
                              size_t hw_buffer_offset, size_t hw_buffer_size,
@@ -135,7 +135,7 @@ void STM32Endpoint::Configure(const Config& cfg)
   }
 #endif
 
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
   if (packet_size_limit > hw_buffer_size_)
   {
     packet_size_limit = hw_buffer_size_;
@@ -225,7 +225,7 @@ ErrorCode STM32Endpoint::Transfer(size_t size)
   }
 #endif
 
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
   if (is_in)
   {
     ep->xfer_fill_db = 0U;
@@ -334,7 +334,7 @@ static STM32Endpoint* GetEndpoint(PCD_HandleTypeDef* hpcd, uint8_t epnum, bool i
     return STM32Endpoint::map_otg_fs_[epnum & 0x7F][static_cast<uint8_t>(is_in)];
   }
 #endif
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
   if (id == STM32_USB_FS_DEV)
   {
     return STM32Endpoint::map_fs_[epnum & 0x7F][static_cast<uint8_t>(is_in)];

--- a/driver/st/stm32_usb_ep.hpp
+++ b/driver/st/stm32_usb_ep.hpp
@@ -21,7 +21,7 @@ class STM32Endpoint : public USB::Endpoint
   STM32Endpoint(EPNumber ep_num, stm32_usb_dev_id_t id, PCD_HandleTypeDef* hpcd,
                 Direction dir, size_t fifo_size, LibXR::RawData buffer);
 #endif
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
   STM32Endpoint(EPNumber ep_num, stm32_usb_dev_id_t id, PCD_HandleTypeDef* hpcd,
                 Direction dir, size_t hw_buffer_offset, size_t hw_buffer_size,
                 LibXR::RawData buffer);
@@ -43,7 +43,7 @@ class STM32Endpoint : public USB::Endpoint
 #if defined(USB_OTG_FS) || defined(USB_OTG_HS)
   size_t fifo_size_ = 0;
 #endif
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
   size_t hw_buffer_size_ = 0;
 #endif
   stm32_usb_dev_id_t id_;
@@ -71,7 +71,7 @@ class STM32Endpoint : public USB::Endpoint
   static inline STM32Endpoint* map_otg_fs_[EP_OTG_FS_MAX_SIZE][2] = {};
 #endif
 
-#if defined(USB_BASE)
+#if defined(USB_BASE) || defined(USB_DRD_FS)
   static constexpr uint8_t EP_OTG_FS_MAX_SIZE = 8;
   static inline STM32Endpoint* map_fs_[EP_OTG_FS_MAX_SIZE][2] = {};
 #endif


### PR DESCRIPTION
Enable the existing STM32 USB device/PMA paths when CMSIS exposes USB_DRD_FS instead of USB_BASE. This restores the device ID, DevFs class, endpoint storage/transfer branches and callback lookup for DRD targets.

No endpoint algorithm or CDC ownership/lifecycle change. The existing H5 PMA sizing remains in use.

Validation: H503/H563 real-HAL device/endpoint/consumer objects and relocatable links pass, with concrete DevFs class and 2048-byte PMA assertions. F401/H743 OTG paths still compile. Combined G0 firmware links the endpoint transfer path. No new USB enumeration or hardware acceptance claim. One commit/five files; ten conditional-expression changes.

## Sourcery 摘要

恢复对 CMSIS USB_DRD_FS 目标的 STM32 USB 设备支持。

错误修复：
- 为公开 USB_DRD_FS 而非 USB_BASE 的目标启用 STM32 USB 设备、PMA 端点、传输和回调路径。

测试：
- 验证 STM32 DRD 设备和端点路径、PMA 大小、可重定位链接，以及与现有 OTG 和 G0 配置的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore STM32 USB device support for CMSIS USB_DRD_FS targets.

Bug Fixes:
- Enable STM32 USB device, PMA endpoint, transfer, and callback paths for targets that expose USB_DRD_FS instead of USB_BASE.

Tests:
- Validate STM32 DRD device and endpoint paths, PMA sizing, relocatable links, and compatibility with existing OTG and G0 configurations.

</details>