### PR TITLE
fix(threadx): correct delay conversion and deadline rollover

### DIFF
--- a/system/threadx/libxr_system.hpp
+++ b/system/threadx/libxr_system.hpp
@@ -10,6 +10,23 @@ typedef TX_MUTEX libxr_mutex_handle;
 typedef TX_SEMAPHORE libxr_semaphore_handle;
 typedef TX_THREAD* libxr_thread_handle;
 
+namespace Detail
+{
+/**
+ * @brief 将有限毫秒等待向上换算为 ThreadX tick / Round a finite millisecond wait up to
+ * ticks.
+ * @note 超出范围时取最大有限 tick，避免使用永久等待值。
+ *       Saturate at the largest finite tick count, excluding the forever sentinel.
+ */
+[[nodiscard]] inline ULONG MillisecondsToThreadXTicks(uint32_t milliseconds)
+{
+  const uint64_t ticks =
+      (static_cast<uint64_t>(milliseconds) * TX_TIMER_TICKS_PER_SECOND + 999U) / 1000U;
+  return ticks >= static_cast<uint64_t>(TX_WAIT_FOREVER) ? TX_WAIT_FOREVER - 1U
+                                                         : static_cast<ULONG>(ticks);
+}
+}  // namespace Detail
+
 /**
  * @brief  平台初始化函数
  *         Platform initialization function
@@ -19,10 +36,10 @@ typedef TX_THREAD* libxr_thread_handle;
  *                            Timer task stack depth (default: 512)
  *
  * @details
- * 该函数用于初始化 FreeRTOS 相关资源，如定时器任务。
+ * 该函数用于初始化 ThreadX 相关资源，如定时器任务。
  * 它设置定时器任务的优先级 `timer_pri` 和栈深度 `timer_stack_depth`。
  *
- * This function initializes FreeRTOS-related resources, such as the timer task.
+ * This function initializes ThreadX-related resources, such as the timer task.
  * It sets the timer task priority (`timer_pri`) and stack depth (`timer_stack_depth`).
  */
 void PlatformInit(uint32_t timer_pri = 2,

--- a/system/threadx/semaphore.cpp
+++ b/system/threadx/semaphore.cpp
@@ -1,8 +1,6 @@
 #include "semaphore.hpp"
 
-#include "libxr.hpp"
 #include "libxr_def.hpp"
-#include "timer.hpp"
 #include "tx_api.h"
 
 using namespace LibXR;
@@ -18,17 +16,9 @@ void Semaphore::Post() { tx_semaphore_put(&semaphore_handle_); }
 
 ErrorCode Semaphore::Wait(uint32_t timeout)
 {
-  ULONG tx_timeout;
-
-  if (timeout == 0)
-  {
-    tx_timeout = TX_NO_WAIT;
-  }
-  else
-  {
-    tx_timeout = timeout * TX_TIMER_TICKS_PER_SECOND / 1000;
-    if (tx_timeout == 0) tx_timeout = 1;
-  }
+  const ULONG tx_timeout = timeout == UINT32_MAX
+                               ? TX_WAIT_FOREVER
+                               : Detail::MillisecondsToThreadXTicks(timeout);
 
   UINT status = tx_semaphore_get(&semaphore_handle_, tx_timeout);
 

--- a/system/threadx/thread.cpp
+++ b/system/threadx/thread.cpp
@@ -1,25 +1,25 @@
 #include "thread.hpp"
 
 #include "timebase.hpp"
-#include "timer.hpp"
 #include "tx_api.h"
 
 using namespace LibXR;
 
 void Thread::Sleep(uint32_t milliseconds)
 {
-  tx_thread_sleep(milliseconds * TX_TIMER_TICKS_PER_SECOND / 1000);
+  tx_thread_sleep(Detail::MillisecondsToThreadXTicks(milliseconds));
 }
 
-void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep)
+void Thread::SleepUntil(MillisecondTimestamp& last_wakeup_time, uint32_t time_to_sleep)
 {
-  uint32_t target = last_waskup_time + time_to_sleep;
-  uint32_t now = Timebase::GetMilliseconds();
-  if (target > now)
+  const uint32_t target = static_cast<uint32_t>(last_wakeup_time) + time_to_sleep;
+  const uint32_t now = Timebase::GetMilliseconds();
+  const uint32_t remaining = target - now;
+  if (remaining != 0U && remaining < (UINT32_C(1) << 31U))
   {
-    tx_thread_sleep((target - now) * TX_TIMER_TICKS_PER_SECOND / 1000);
+    Sleep(remaining);
   }
-  last_waskup_time = target;
+  last_wakeup_time = target;
 }
 
 uint32_t Thread::GetTime() { return Timebase::GetMilliseconds(); }

--- a/system/threadx/thread.hpp
+++ b/system/threadx/thread.hpp
@@ -9,8 +9,8 @@
 namespace LibXR
 {
 /**
- * @brief  线程管理类，封装 FreeRTOS 任务创建和调度
- *         Thread management class encapsulating FreeRTOS task creation and scheduling
+ * @brief  线程管理类，封装 ThreadX 任务创建和调度
+ *         Thread management class encapsulating ThreadX task creation and scheduling
  */
 class Thread
 {
@@ -36,9 +36,9 @@ class Thread
   Thread() : thread_handle_(nullptr) {};
 
   /**
-   * @brief  通过 FreeRTOS 线程句柄创建线程对象
-   *         Constructor to create a thread object from a FreeRTOS thread handle
-   * @param  handle FreeRTOS 线程句柄 FreeRTOS thread handle
+   * @brief  通过 ThreadX 线程句柄创建线程对象
+   *         Constructor to create a thread object from a ThreadX thread handle
+   * @param  handle ThreadX 线程句柄 ThreadX thread handle
    */
   Thread(TX_THREAD* handle) : thread_handle_(handle) {};
 
@@ -53,13 +53,13 @@ class Thread
    * @param  priority 线程优先级 Thread priority
    *
    * @details
-   * 该方法基于 FreeRTOS `xTaskCreate()` 创建新线程，执行 `function` 并传递 `arg`
-   * 作为参数。 线程优先级 `priority` 必须符合 FreeRTOS 配置的 `configMAX_PRIORITIES`
+   * 该方法基于 ThreadX `tx_thread_create()` 创建新线程，执行 `function` 并传递 `arg`
+   * 作为参数。 线程优先级 `priority` 必须符合 ThreadX 配置的 `TX_MAX_PRIORITIES`
    * 约束。
    *
-   * This method creates a new thread using FreeRTOS `xTaskCreate()`, executing `function`
-   * with `arg` as the argument. The thread priority `priority` must adhere to FreeRTOS
-   * configuration constraints defined by `configMAX_PRIORITIES`.
+   * This method creates a new thread using ThreadX `tx_thread_create()`, executing
+   * `function` with `arg` as the argument. The thread priority `priority` must adhere to
+   * ThreadX configuration constraints defined by `TX_MAX_PRIORITIES`.
    */
   template <typename ArgType>
   void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
@@ -108,16 +108,24 @@ class Thread
    * @brief  让线程进入休眠状态
    *         Puts the thread to sleep
    * @param  milliseconds 休眠时间（毫秒） Sleep duration in milliseconds
+   * @note 向上取整到 tick，超出单次范围时取 TX_WAIT_FOREVER - 1 个 tick。
+   *       Round up to ticks, saturating at TX_WAIT_FOREVER - 1 ticks.
    */
   static void Sleep(uint32_t milliseconds);
 
   /**
    * @brief  让线程休眠直到指定时间点
    *         Puts the thread to sleep until a specified time
-   * @param  last_waskup_time 上次唤醒时间 Last wake-up time
+   * @param  last_wakeup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
+   * @pre 用 GetTime 初始化计划时间；目标位于当前时间前后 2^31 毫秒以内。
+   *      Initialize the schedule with GetTime. The target must be less than 2^31
+   *      milliseconds before or after now for unambiguous modular ordering.
+   * @note 保留计划唤醒时间；错过期限时不休眠，下一次仍按原周期推进。
+   *       Keep the scheduled wake time; overdue calls do not sleep and retain the
+   * cadence.
    */
-  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_wakeup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程
@@ -126,9 +134,9 @@ class Thread
   static void Yield();
 
   /**
-   * @brief  线程对象转换为 FreeRTOS 线程句柄
-   *         Converts the thread object to a FreeRTOS thread handle
-   * @return FreeRTOS 线程句柄 FreeRTOS thread handle
+   * @brief  线程对象转换为 ThreadX 线程句柄
+   *         Converts the thread object to a ThreadX thread handle
+   * @return ThreadX 线程句柄 ThreadX thread handle
    */
   operator TX_THREAD*() { return thread_handle_; }
 


### PR DESCRIPTION
ThreadX delay conversion multiplies in 32 bits and truncates fractional ticks; SleepUntil also misses deadlines that cross the millisecond counter wrap.

Use one 64-bit, round-up conversion for finite delays, saturating below TX_WAIT_FOREVER. The ThreadX suspend implementation treats that sentinel specially, so finite Sleep must not produce it. Map Semaphore::Wait(UINT32_MAX) to the documented default infinite wait; zero and existing status/abort mappings remain unchanged.

Keep MillisecondTimestamp and the current Timebase clock. Compare deadlines modulo 32 bits, preserve the scheduled anchor when late, and document the half-cycle ordering window. No global scheduler-clock, timer callback-count or thread-priority change.

Validation: actual wrapper-source/API-seam tests at 100/1000/1024/2000 Hz pass 41 checks each; baseline fails 13/8/18/8 respectively. Tests cover overflow, rounding, zero, finite saturation, infinite sentinel, rollover/future/late anchors and return mappings. Real committed STM32F407 ThreadX BSP/kernel compiles and links an active probe thread with the updated Sleep/SleepUntil/Wait and kernel services present, no undefined symbols. Formatting checks pass. No new board runtime or wall-clock delay measurement. Four files/one commit; fixtures outside the repository.

## Sourcery 总结

修复 ThreadX 延迟处理以及支持回绕安全的计划睡眠，同时不改变现有的时间基准或调度器行为。

错误修复：
- 修正 ThreadX 毫秒延迟转换，改用 64 位算术；将有限等待时间向上取整到下一个时钟节拍，并避免生成无限等待哨兵值。
- 按文档规定，将 ThreadX 信号量等待的 `UINT32_MAX` 映射为无限等待，同时保留零值和状态映射。
- 使 `SleepUntil` 能够正确处理 32 位毫秒计数器回绕，并在错过截止时间时保留计划锚点。

增强功能：
- 记录 ThreadX 特有的睡眠行为，以及为实现无歧义模截止时间排序所需的半周期窗口。
- 修正平台和线程 API 文档中过时的 ThreadX/FreeRTOS 术语。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix ThreadX delay handling and rollover-safe scheduled sleeping without changing the existing timebase or scheduler behavior.

Bug Fixes:
- Correct ThreadX millisecond delay conversion to use 64-bit arithmetic, round finite waits up to the next tick, and avoid producing the infinite-wait sentinel.
- Handle ThreadX semaphore waits with the documented infinite-wait mapping for UINT32_MAX while preserving zero and status mappings.
- Make SleepUntil correctly handle 32-bit millisecond counter rollover and preserve scheduled anchors when deadlines are missed.

Enhancements:
- Document ThreadX-specific sleep behavior and the half-cycle window required for unambiguous modular deadline ordering.
- Correct stale ThreadX/FreeRTOS terminology in platform and thread API documentation.

</details>