### PR TITLE
refactor: unify assertions and fix shared topic notifications

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,12 +2,23 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
   pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:
+    name: build (${{ matrix.build_type }}, DEV_ASSERT=${{ matrix.dev_assert }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build_type: Debug
+            dev_assert: "ON"
+          - build_type: Release
+            dev_assert: "ON"
+          - build_type: Release
+            dev_assert: "OFF"
 
     runs-on: ubuntu-latest
 
@@ -16,11 +27,13 @@ jobs:
     - name: setup deps
       run: sudo apt-get update && sudo apt-get install -y libwpa-client-dev libnm-dev libudev-dev
     - name: configure
-      run: mkdir build && cd build && cmake -DLIBXR_TEST_BUILD=True ..
+      run: cmake -S . -B build -DLIBXR_TEST_BUILD=ON -DLIBXR_DEV_ASSERT_BUILD=${{ matrix.dev_assert }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
     - name: make
       run: cd build && cmake --build . -j"$(nproc)"
     - name: check
       run: script -q -e -c "./build/test/test" /dev/null
+    - name: assertion modes
+      run: ctest --test-dir build/test --output-on-failure
 
   clang-format:
     needs: build

--- a/driver/ch/ch32_uart.cpp
+++ b/driver/ch/ch32_uart.cpp
@@ -54,7 +54,7 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
   ASSERT(tx_enable || rx_enable);
   if (tx_enable)
   {
-    REQUIRE(tx_queue_size > 0U);
+    ASSERT(tx_queue_size > 0U);
     ASSERT(dma_tx_channel_ != nullptr);
     ASSERT(CH32_UART_TX_DMA_IT_MAP[id] != 0);
   }
@@ -109,9 +109,9 @@ CH32UART::CH32UART(ch32_uart_id_t id, RawData dma_rx, RawData dma_tx,
   RCC_AHBPeriphClockCmd(CH32_UART_RCC_PERIPH_MAP_DMA[id], ENABLE);
 
   // 设置初始串口参数 / Apply initial UART settings.
-  REQUIRE(config.baudrate > 0U);
-  REQUIRE(Ch32DataBitsSupported(config));
-  REQUIRE(Ch32StopBitsSupported(config));
+  ASSERT(config.baudrate > 0U);
+  ASSERT(Ch32DataBitsSupported(config));
+  ASSERT(Ch32StopBitsSupported(config));
   USART_InitTypeDef usart_cfg = {};
   usart_cfg.USART_BaudRate = config.baudrate;
   usart_cfg.USART_StopBits =
@@ -274,7 +274,7 @@ void CH32UART::ApplyConfig(UART::Configuration config)
           config.data_bits == 7U ? USART_WordLength_8b : USART_WordLength_9b;
       break;
     default:
-      REQUIRE(false);
+      DEV_ASSERT(false);
       return;
   }
 
@@ -316,7 +316,7 @@ void CH32UART::HandleTxService(uint32_t events, bool in_isr)
     }
     else
     {
-      REQUIRE_FROM_CALLBACK(state == ConfigState::PUBLISHED, in_isr);
+      DEV_ASSERT_FROM_CALLBACK(state == ConfigState::PUBLISHED, in_isr);
     }
   }
 
@@ -381,7 +381,7 @@ void CH32UART::FillTx(bool in_isr)
           return;
         }
         size = queue.AvailableSize();
-        REQUIRE_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
+        DEV_ASSERT_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
         queue.PopAll(dma_buff_tx_.ActiveBuffer());
         dma_buff_tx_.SetActiveLength(size);
       }
@@ -401,7 +401,7 @@ void CH32UART::FillTx(bool in_isr)
     if (!queue.Empty())
     {
       const size_t size = queue.AvailableSize();
-      REQUIRE_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
+      DEV_ASSERT_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
       queue.PopAll(dma_buff_tx_.PendingBuffer());
       dma_buff_tx_.SetPendingLength(size);
       dma_buff_tx_.EnablePending();
@@ -446,7 +446,7 @@ void CH32UART::TryApplyConfig(bool in_isr)
   if ((uart_mode_ & USART_Mode_Rx) != 0U && dma_buff_rx_.size_ != 0U)
   {
     const size_t remaining = dma_rx_channel_->CNTR;
-    REQUIRE_FROM_CALLBACK(remaining <= dma_buff_rx_.size_, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(remaining <= dma_buff_rx_.size_, in_isr);
     const size_t position =
         remaining == 0U ? dma_buff_rx_.size_ : dma_buff_rx_.size_ - remaining;
     last_rx_pos_ = position == dma_buff_rx_.size_ ? 0U : position;
@@ -459,7 +459,7 @@ void CH32UART::TryApplyConfig(bool in_isr)
 void CH32UART::StartTxDma(bool in_isr)
 {
   const size_t size = dma_buff_tx_.GetActiveLength();
-  REQUIRE_FROM_CALLBACK(size != 0U && size <= dma_buff_tx_.Size(), in_isr);
+  DEV_ASSERT_FROM_CALLBACK(size != 0U && size <= dma_buff_tx_.Size(), in_isr);
 
   DMA_Cmd(dma_tx_channel_, DISABLE);
   dma_tx_channel_->MADDR = reinterpret_cast<uint32_t>(dma_buff_tx_.ActiveBuffer());
@@ -477,10 +477,10 @@ void CH32UART::HandleRxData(bool in_isr)
   }
 
   const size_t remaining = dma_rx_channel_->CNTR;
-  REQUIRE_FROM_CALLBACK(remaining <= dma_size, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(remaining <= dma_size, in_isr);
   const size_t curr_pos = remaining == 0U ? dma_size : dma_size - remaining;
   const size_t last_pos = last_rx_pos_;
-  REQUIRE_FROM_CALLBACK(last_pos < dma_size, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(last_pos < dma_size, in_isr);
 
   if (curr_pos != last_pos)
   {
@@ -495,18 +495,16 @@ void CH32UART::HandleRxData(bool in_isr)
       const size_t first_accepted = std::min(first_size, accepted);
       if (first_accepted != 0U)
       {
-        REQUIRE_FROM_CALLBACK(
-            queue.PushBatch(static_cast<const uint8_t*>(dma_buff_rx_.addr_) + last_pos,
-                            first_accepted) == ErrorCode::OK,
-            in_isr);
+        [[maybe_unused]] const auto push_batch_result = queue.PushBatch(
+            static_cast<const uint8_t*>(dma_buff_rx_.addr_) + last_pos, first_accepted);
+        DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
         accepted -= first_accepted;
       }
       if (accepted != 0U)
       {
-        REQUIRE_FROM_CALLBACK(
-            queue.PushBatch(static_cast<const uint8_t*>(dma_buff_rx_.addr_), accepted) ==
-                ErrorCode::OK,
-            in_isr);
+        [[maybe_unused]] const auto push_batch_result =
+            queue.PushBatch(static_cast<const uint8_t*>(dma_buff_rx_.addr_), accepted);
+        DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
       }
     }
 

--- a/driver/ch/ch32_usb_rcc.hpp
+++ b/driver/ch/ch32_usb_rcc.hpp
@@ -145,7 +145,9 @@ inline void ConfigureUsbHsPhyFromHse()
   // legal combinations stay explicit and auditable.
   UsbHsPllConfig cfg = {};
   const uint32_t hse_hz = static_cast<uint32_t>(HSE_VALUE);
-  ASSERT(TryGetUsbHsPllConfigForHse(hse_hz, cfg));
+  [[maybe_unused]] const auto try_get_usb_hs_pll_config_for_hse_result =
+      TryGetUsbHsPllConfigForHse(hse_hz, cfg);
+  ASSERT(try_get_usb_hs_pll_config_for_hse_result);
 
   RCC_USBHSPLLCLKConfig(RCC_HSBHSPLLCLKSource_HSE);
   RCC_USBHSConfig(cfg.divider_cfg);

--- a/driver/esp/esp_adc.cpp
+++ b/driver/esp/esp_adc.cpp
@@ -126,12 +126,12 @@ ESP32ADC::ESP32ADC(adc_unit_t unit, const adc_channel_t* channels, uint8_t num_c
 
   if (cont_ans == ContinuousInitResult::FAILED)
   {
-    ASSERT(false);
+    REQUIRE(false);
     return;
   }
 
   const bool oneshot_ok = InitOneshot();
-  ASSERT(oneshot_ok);
+  REQUIRE(oneshot_ok);
   if (!oneshot_ok)
   {
     return;
@@ -167,19 +167,19 @@ float ESP32ADC::ReadChannel(uint8_t idx)
       DrainContinuousFrames(0U);
     }
 #endif
-    ASSERT(channel_ready_[idx]);
+    DEV_ASSERT(channel_ready_[idx]);
     return latest_values_[idx];
   }
 
-  ASSERT(backend_ == Backend::ONESHOT);
-  ASSERT(oneshot_inited_ && (oneshot_hal_ != nullptr));
+  DEV_ASSERT(backend_ == Backend::ONESHOT);
+  DEV_ASSERT(oneshot_inited_ && (oneshot_hal_ != nullptr));
   if (!oneshot_inited_ || (oneshot_hal_ == nullptr))
   {
     return 0.f;
   }
 
   const esp_err_t lock_err = adc_lock_try_acquire(unit_);
-  ASSERT(lock_err == ESP_OK);
+
   if (lock_err != ESP_OK)
   {
     return 0.f;
@@ -194,7 +194,7 @@ float ESP32ADC::ReadChannel(uint8_t idx)
 #if SOC_ADC_DIG_CTRL_SUPPORTED && !SOC_ADC_RTC_CTRL_SUPPORTED
   const esp_err_t clk_on =
       esp_clk_tree_enable_src(static_cast<soc_module_clk_t>(oneshot_hal_->clk_src), true);
-  ASSERT(clk_on == ESP_OK);
+
   clk_src_enabled = (clk_on == ESP_OK);
 #else
   clk_src_enabled = true;
@@ -216,7 +216,7 @@ float ESP32ADC::ReadChannel(uint8_t idx)
   {
     const esp_err_t clk_off = esp_clk_tree_enable_src(
         static_cast<soc_module_clk_t>(oneshot_hal_->clk_src), false);
-    ASSERT(clk_off == ESP_OK);
+
     if (clk_off != ESP_OK)
     {
       converted = false;
@@ -227,13 +227,12 @@ float ESP32ADC::ReadChannel(uint8_t idx)
   portEXIT_CRITICAL(&rtc_spinlock);
 
   const esp_err_t unlock_err = adc_lock_release(unit_);
-  ASSERT(unlock_err == ESP_OK);
+
   if (unlock_err != ESP_OK)
   {
     return 0.f;
   }
 
-  ASSERT(converted);
   if (!converted)
   {
     return 0.f;
@@ -323,7 +322,7 @@ float ESP32ADC::RawToVoltage(uint8_t idx, uint16_t raw) const
     int voltage_mv = 0;
     const esp_err_t err =
         adc_cali_raw_to_voltage(cali_handles_[idx], static_cast<int>(raw), &voltage_mv);
-    ASSERT(err == ESP_OK);
+
     if (err == ESP_OK)
     {
       return static_cast<float>(voltage_mv) / 1000.0f;

--- a/driver/esp/esp_adc_continuous.cpp
+++ b/driver/esp/esp_adc_continuous.cpp
@@ -48,7 +48,6 @@ void ESP32ADC::DrainContinuousFrames(uint32_t timeout_ms)
       break;
     }
 
-    ASSERT(read_err == ESP_OK);
     if (read_err != ESP_OK)
     {
       if (read_err == ESP_ERR_INVALID_STATE)
@@ -67,7 +66,7 @@ void ESP32ADC::DrainContinuousFrames(uint32_t timeout_ms)
     const esp_err_t parse_err =
         adc_continuous_parse_data(continuous_handle_, continuous_read_buf_, out_length,
                                   continuous_parsed_buf_, &parsed_count);
-    ASSERT(parse_err == ESP_OK);
+
     if (parse_err != ESP_OK)
     {
       break;

--- a/driver/esp/esp_adc_oneshot.cpp
+++ b/driver/esp/esp_adc_oneshot.cpp
@@ -18,7 +18,7 @@ namespace LibXR
 
 bool ESP32ADC::InitOneshot()
 {
-  ASSERT(oneshot_hal_ == nullptr);
+  DEV_ASSERT(oneshot_hal_ == nullptr);
   if (oneshot_hal_ != nullptr)
   {
     return false;

--- a/driver/esp/esp_cdc_jtag.cpp
+++ b/driver/esp/esp_cdc_jtag.cpp
@@ -37,14 +37,15 @@ ESP32CDCJtag::ESP32CDCJtag(size_t rx_buffer_size, size_t tx_buffer_size,
       _read_port(rx_buffer_size, *this),
       _write_port(tx_queue_size, tx_buffer_size)
 {
-  REQUIRE(rx_buffer_size > 0U);
-  REQUIRE(tx_buffer_size > 0U);
-  REQUIRE(tx_queue_size > 0U);
+  ASSERT(rx_buffer_size > 0U);
+  ASSERT(tx_buffer_size > 0U);
+  ASSERT(tx_queue_size > 0U);
 
   INIT_CRIT_SECTION_LOCK_RUNTIME(&irq_lock_);
 
-  REQUIRE(IsConfigSupported(config));
-  REQUIRE(InitHardware() == ErrorCode::OK);
+  ASSERT(IsConfigSupported(config));
+  [[maybe_unused]] const auto init_hardware_result = InitHardware();
+  REQUIRE(init_hardware_result == ErrorCode::OK);
 
   _write_port = WriteFun;
 }
@@ -120,7 +121,8 @@ void ESP32CDCJtag::ServiceEvents(uint32_t events, bool in_isr)
 void ESP32CDCJtag::PushRxBytes(ReadPort::ReadQueue& queue, const uint8_t* data,
                                size_t size, bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(queue.PushBatch(data, size) == ErrorCode::OK, in_isr);
+  [[maybe_unused]] const auto push_batch_result = queue.PushBatch(data, size);
+  DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
 }
 
 void ESP32CDCJtag::DrainRxToQueue(ReadPort::ReadQueue& queue, bool in_isr)
@@ -141,7 +143,7 @@ void ESP32CDCJtag::DrainRxToQueue(ReadPort::ReadQueue& queue, bool in_isr)
     {
       return;
     }
-    REQUIRE_FROM_CALLBACK(static_cast<size_t>(got) <= read_size, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(static_cast<size_t>(got) <= read_size, in_isr);
     PushRxBytes(queue, rx_tmp, static_cast<size_t>(got), in_isr);
   }
 }
@@ -205,7 +207,7 @@ size_t ESP32CDCJtag::FillTxFifo(WritePort::WriteQueue& queue, bool in_isr)
           const int written =
               usb_serial_jtag_ll_write_txfifo(data, static_cast<uint32_t>(size));
           REQUIRE_FROM_CALLBACK(written >= 0, in_isr);
-          REQUIRE_FROM_CALLBACK(static_cast<size_t>(written) <= size, in_isr);
+          DEV_ASSERT_FROM_CALLBACK(static_cast<size_t>(written) <= size, in_isr);
           return written > 0 ? static_cast<size_t>(written) : 0U;
         };
 

--- a/driver/esp/esp_gpio.cpp
+++ b/driver/esp/esp_gpio.cpp
@@ -7,7 +7,7 @@ void IRAM_ATTR ESP32GPIO::InterruptDispatcher(void* arg)
 {
   auto gpio_num = static_cast<gpio_num_t>(reinterpret_cast<uintptr_t>(arg));
   const bool valid = (gpio_num >= 0) && (gpio_num < GPIO_NUM_MAX);
-  ASSERT(valid);
+  DEV_ASSERT_FROM_CALLBACK(valid, true);
   if (!valid)
   {
     return;

--- a/driver/esp/esp_i2c.cpp
+++ b/driver/esp/esp_i2c.cpp
@@ -151,7 +151,7 @@ ESP32I2C::ESP32I2C(i2c_port_t port_num, int scl_pin, int sda_pin, uint32_t clock
 
   if (InitHardware() != ErrorCode::OK)
   {
-    ASSERT(false);
+    REQUIRE(false);
     return;
   }
 }
@@ -182,7 +182,7 @@ size_t ESP32I2C::MemAddrBytes(MemAddrLength mem_addr_size)
 
 void ESP32I2C::EncodeMemAddr(uint16_t mem_addr, size_t mem_len, uint8_t* out)
 {
-  ASSERT(out != nullptr);
+  DEV_ASSERT(out != nullptr);
   if (mem_len == 2U)
   {
     out[0] = static_cast<uint8_t>((mem_addr >> 8) & 0xFFU);
@@ -257,7 +257,6 @@ ErrorCode ESP32I2C::InitHardware()
   _i2c_hal_init(&hal_, static_cast<int>(port_num_));
   if (hal_.dev == nullptr)
   {
-    ASSERT(false);
     return ErrorCode::INIT_ERR;
   }
 
@@ -268,21 +267,18 @@ ErrorCode ESP32I2C::InitHardware()
   ErrorCode err = ConfigurePins();
   if (err != ErrorCode::OK)
   {
-    ASSERT(false);
     return err;
   }
 
   err = InstallInterrupt();
   if (err != ErrorCode::OK)
   {
-    ASSERT(false);
     return err;
   }
 
   err = ApplyConfig();
   if (err != ErrorCode::OK)
   {
-    ASSERT(false);
     return err;
   }
 
@@ -470,7 +466,7 @@ ErrorCode ESP32I2C::KickAsyncTransaction()
       static_cast<uint8_t>((async_slave_addr_ << 1U) | I2C_MASTER_READ);
   const size_t fifo_len = FIFO_LEN;
   const size_t write_chunk_cap = (fifo_len > 1U) ? (fifo_len - 1U) : 0U;
-  ASSERT(write_chunk_cap > 0U);
+  DEV_ASSERT(write_chunk_cap > 0U);
 
   while (true)
   {
@@ -787,7 +783,7 @@ ErrorCode ESP32I2C::ExecuteTransaction(uint16_t slave_addr, const uint8_t* write
   const uint8_t read_addr = static_cast<uint8_t>((slave_addr << 1U) | I2C_MASTER_READ);
   const size_t fifo_len = FIFO_LEN;
   const size_t write_chunk_cap = (fifo_len > 1U) ? (fifo_len - 1U) : 0U;
-  ASSERT(write_chunk_cap > 0U);
+  DEV_ASSERT(write_chunk_cap > 0U);
 
   int cmd_idx = 0;
 

--- a/driver/esp/esp_pwm.hpp
+++ b/driver/esp/esp_pwm.hpp
@@ -38,7 +38,7 @@ class ESP32PWM : public PWM
     const esp_err_t err = ledc_channel_config(&channel_conf);
     if (err != ESP_OK)
     {
-      ASSERT(false);
+      REQUIRE(false);
     }
   }
 

--- a/driver/esp/esp_spi.cpp
+++ b/driver/esp/esp_spi.cpp
@@ -130,26 +130,26 @@ ESP32SPI::ESP32SPI(spi_host_device_t host, int sclk_pin, int miso_pin, int mosi_
 
   if (InitializeHardware() != ErrorCode::OK)
   {
-    ASSERT(false);
+    REQUIRE(false);
     return;
   }
 
   if (ConfigurePins() != ErrorCode::OK)
   {
-    ASSERT(false);
+    REQUIRE(false);
     return;
   }
 
   if (InstallInterrupt() != ErrorCode::OK)
   {
-    ASSERT(false);
+    REQUIRE(false);
     return;
   }
 
   if (dma_requested_)
   {
     const ErrorCode dma_ans = InitDmaBackend();
-    ASSERT(dma_ans == ErrorCode::OK);
+    REQUIRE(dma_ans == ErrorCode::OK);
     if (dma_ans != ErrorCode::OK)
     {
       return;
@@ -158,7 +158,7 @@ ESP32SPI::ESP32SPI(spi_host_device_t host, int sclk_pin, int miso_pin, int mosi_
 
   if (SetConfig(config) != ErrorCode::OK)
   {
-    ASSERT(false);
+    REQUIRE(false);
     return;
   }
 }

--- a/driver/esp/esp_uart.cpp
+++ b/driver/esp/esp_uart.cpp
@@ -165,7 +165,7 @@ ESP32UART::ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin,
   ASSERT(uart_num_ < SOC_UART_HP_NUM);
   ASSERT(rx_isr_buffer_size_ > 0);
   ASSERT(tx_buffer_size > 0);
-  REQUIRE(tx_queue_size > 0U);
+  ASSERT(tx_queue_size > 0U);
 
   INIT_CRIT_SECTION_LOCK_RUNTIME(&irq_lock_);
 
@@ -175,7 +175,7 @@ ESP32UART::ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin,
 
   if (InitUartHardware() != ErrorCode::OK)
   {
-    ASSERT(false);
+    REQUIRE(false);
     return;
   }
 
@@ -184,7 +184,7 @@ ESP32UART::ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin,
   {
     if (InitDmaBackend() != ErrorCode::OK)
     {
-      ASSERT(false);
+      REQUIRE(false);
       return;
     }
   }
@@ -193,7 +193,7 @@ ESP32UART::ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin,
   {
     if (InstallUartIsr() != ErrorCode::OK)
     {
-      ASSERT(false);
+      REQUIRE(false);
       return;
     }
     ConfigureRxInterruptPath();
@@ -201,7 +201,7 @@ ESP32UART::ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin,
 #else
   if (InstallUartIsr() != ErrorCode::OK)
   {
-    ASSERT(false);
+    REQUIRE(false);
     return;
   }
   ConfigureRxInterruptPath();
@@ -272,8 +272,12 @@ ErrorCode ESP32UART::ApplyConfig(const UART::Configuration& config)
 
   uart_word_length_t word_length = UART_DATA_8_BITS;
   uart_stop_bits_t stop_bits = UART_STOP_BITS_1;
-  REQUIRE(ResolveWordLength(config.data_bits, word_length));
-  REQUIRE(ResolveStopBits(config.stop_bits, stop_bits));
+  [[maybe_unused]] const auto resolve_word_length_result =
+      ResolveWordLength(config.data_bits, word_length);
+  DEV_ASSERT(resolve_word_length_result);
+  [[maybe_unused]] const auto resolve_stop_bits_result =
+      ResolveStopBits(config.stop_bits, stop_bits);
+  DEV_ASSERT(resolve_stop_bits_result);
 
   const uart_sclk_t sclk = UART_SCLK_DEFAULT;
   uart_hal_set_sclk(&uart_hal_, static_cast<soc_module_clk_t>(sclk));
@@ -376,7 +380,8 @@ bool IRAM_ATTR ESP32UART::TryApplyPublishedConfig(bool in_isr)
     StopDmaRx(in_isr);
   }
 #endif
-  REQUIRE_FROM_CALLBACK(ApplyConfig(requested_config_) == ErrorCode::OK, in_isr);
+  [[maybe_unused]] const auto apply_config_result = ApplyConfig(requested_config_);
+  REQUIRE_FROM_CALLBACK(apply_config_result == ErrorCode::OK, in_isr);
   config_ = requested_config_;
   config_state_.store(static_cast<uint8_t>(ConfigState::EMPTY),
                       std::memory_order_release);
@@ -724,7 +729,7 @@ bool IRAM_ATTR ESP32UART::LoadActiveTxFromQueue(bool in_isr)
   }
 
   const size_t size = queue.AvailableSize();
-  REQUIRE_FROM_CALLBACK(size <= tx_dma_buffer_.Size(), in_isr);
+  DEV_ASSERT_FROM_CALLBACK(size <= tx_dma_buffer_.Size(), in_isr);
   queue.PopAll(tx_dma_buffer_.ActiveBuffer());
   tx_dma_buffer_.SetActiveLength(size);
   tx_active_length_ = size;
@@ -755,7 +760,7 @@ bool IRAM_ATTR ESP32UART::LoadPendingTxFromQueue(bool in_isr)
   }
 
   const size_t size = queue.AvailableSize();
-  REQUIRE_FROM_CALLBACK(size <= tx_dma_buffer_.Size(), in_isr);
+  DEV_ASSERT_FROM_CALLBACK(size <= tx_dma_buffer_.Size(), in_isr);
   queue.PopAll(tx_dma_buffer_.PendingBuffer());
   tx_dma_buffer_.SetPendingLength(size);
   tx_dma_buffer_.EnablePending();
@@ -843,7 +848,8 @@ void IRAM_ATTR ESP32UART::PushRxBytes(const uint8_t* data, size_t size, bool in_
     }
 
     const size_t chunk = std::min(free_space, size - offset);
-    REQUIRE_FROM_CALLBACK(queue.PushBatch(data + offset, chunk) == ErrorCode::OK, in_isr);
+    [[maybe_unused]] const auto push_batch_result = queue.PushBatch(data + offset, chunk);
+    DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
 
     offset += chunk;
   }
@@ -870,14 +876,20 @@ void IRAM_ATTR ESP32UART::OnTxTransferDone(bool in_isr, ErrorCode result)
 
     if (tx_dma_buffer_.HasPending())
     {
-      REQUIRE_FROM_CALLBACK(PromotePendingTxToActive(), in_isr);
-      REQUIRE_FROM_CALLBACK(StartAndReportActive(in_isr), in_isr);
+      [[maybe_unused]] const auto promote_pending_tx_to_active_result =
+          PromotePendingTxToActive();
+      DEV_ASSERT_FROM_CALLBACK(promote_pending_tx_to_active_result, in_isr);
+      [[maybe_unused]] const auto start_and_report_active_result =
+          StartAndReportActive(in_isr);
+      REQUIRE_FROM_CALLBACK(start_and_report_active_result, in_isr);
     }
     else if (config_state_.load(std::memory_order_acquire) ==
                  static_cast<uint8_t>(ConfigState::EMPTY) &&
              LoadActiveTxFromQueue(in_isr))
     {
-      REQUIRE_FROM_CALLBACK(StartAndReportActive(in_isr), in_isr);
+      [[maybe_unused]] const auto start_and_report_active_result =
+          StartAndReportActive(in_isr);
+      REQUIRE_FROM_CALLBACK(start_and_report_active_result, in_isr);
     }
 
     if (tx_busy_.IsSet() && !tx_dma_buffer_.HasPending() &&

--- a/driver/esp/esp_uart_dma.cpp
+++ b/driver/esp/esp_uart_dma.cpp
@@ -495,18 +495,18 @@ void IRAM_ATTR ESP32UART::HandleDmaRxDone(gdma_event_data_t* event_data, bool in
   }
 
   auto* first = LinkItemFromHeadAddr(gdma_link_get_head_addr(rx_dma_link_));
-  REQUIRE_FROM_CALLBACK(first != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(first != nullptr, in_isr);
   auto* item = first;
   for (uint32_t i = 0U; i < rx_dma_node_index_; ++i)
   {
-    REQUIRE_FROM_CALLBACK(item != nullptr, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(item != nullptr, in_isr);
     item = item->next;
   }
 
   auto queue = _read_port.GetReadQueue(in_isr);
   for (uint32_t processed = 0U; processed < DMA_RX_NODE_COUNT; ++processed)
   {
-    REQUIRE_FROM_CALLBACK(item != nullptr, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(item != nullptr, in_isr);
     if (item->dw0.owner != GDMA_OWNER_CPU)
     {
       break;
@@ -515,15 +515,16 @@ void IRAM_ATTR ESP32UART::HandleDmaRxDone(gdma_event_data_t* event_data, bool in
     std::atomic_thread_fence(std::memory_order_acquire);
     const size_t received = std::min<size_t>(item->dw0.length, rx_dma_chunk_size_);
 #if SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE || SOC_PSRAM_DMA_CAPABLE
-    REQUIRE_FROM_CALLBACK(CacheSyncDmaBuffer(item->buffer, rx_dma_chunk_size_, false),
-                          in_isr);
+    [[maybe_unused]] const auto cache_sync_dma_buffer_result =
+        CacheSyncDmaBuffer(item->buffer, rx_dma_chunk_size_, false);
+    REQUIRE_FROM_CALLBACK(cache_sync_dma_buffer_result, in_isr);
 #endif
     if (received != 0U && queue.EmptySize() != 0U)
     {
       const size_t fitting = std::min(received, queue.EmptySize());
-      REQUIRE_FROM_CALLBACK(queue.PushBatch(static_cast<const uint8_t*>(item->buffer),
-                                            fitting) == ErrorCode::OK,
-                            in_isr);
+      [[maybe_unused]] const auto push_batch_result =
+          queue.PushBatch(static_cast<const uint8_t*>(item->buffer), fitting);
+      DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
     }
 
     std::atomic_thread_fence(std::memory_order_release);
@@ -536,19 +537,21 @@ void IRAM_ATTR ESP32UART::HandleDmaRxDone(gdma_event_data_t* event_data, bool in
 
 void IRAM_ATTR ESP32UART::StopDmaRx(bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(rx_dma_channel_ != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(gdma_stop(rx_dma_channel_) == ESP_OK, in_isr);
-  REQUIRE_FROM_CALLBACK(gdma_reset(rx_dma_channel_) == ESP_OK, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(rx_dma_channel_ != nullptr, in_isr);
+  [[maybe_unused]] const auto gdma_stop_result = gdma_stop(rx_dma_channel_);
+  REQUIRE_FROM_CALLBACK(gdma_stop_result == ESP_OK, in_isr);
+  [[maybe_unused]] const auto gdma_reset_result = gdma_reset(rx_dma_channel_);
+  REQUIRE_FROM_CALLBACK(gdma_reset_result == ESP_OK, in_isr);
 }
 
 void IRAM_ATTR ESP32UART::ResetDmaRxDescriptors(bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(rx_dma_link_ != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(rx_dma_link_ != nullptr, in_isr);
   auto* item = LinkItemFromHeadAddr(gdma_link_get_head_addr(rx_dma_link_));
-  REQUIRE_FROM_CALLBACK(item != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(item != nullptr, in_isr);
   for (uint32_t i = 0U; i < DMA_RX_NODE_COUNT; ++i)
   {
-    REQUIRE_FROM_CALLBACK(item != nullptr, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(item != nullptr, in_isr);
     item->dw0.size = static_cast<uint32_t>(rx_dma_chunk_size_);
     item->dw0.length = static_cast<uint32_t>(rx_dma_chunk_size_);
     item->dw0.err_eof = 0U;
@@ -563,11 +566,11 @@ void IRAM_ATTR ESP32UART::ResetDmaRxDescriptors(bool in_isr)
 
 void IRAM_ATTR ESP32UART::StartDmaRx(bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(rx_dma_channel_ != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(rx_dma_link_ != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(
-      gdma_start(rx_dma_channel_, gdma_link_get_head_addr(rx_dma_link_)) == ESP_OK,
-      in_isr);
+  DEV_ASSERT_FROM_CALLBACK(rx_dma_channel_ != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(rx_dma_link_ != nullptr, in_isr);
+  [[maybe_unused]] const auto gdma_start_result =
+      gdma_start(rx_dma_channel_, gdma_link_get_head_addr(rx_dma_link_));
+  REQUIRE_FROM_CALLBACK(gdma_start_result == ESP_OK, in_isr);
 }
 
 // RX DMA 恢复会从节点零重新启动整个环。

--- a/driver/esp/esp_uart_fifo.cpp
+++ b/driver/esp/esp_uart_fifo.cpp
@@ -134,14 +134,14 @@ void IRAM_ATTR ESP32UART::DrainRxFifo(bool in_isr)
     const size_t chunk =
         std::min({free_space, rx_isr_buffer_size_,
                   static_cast<size_t>(uart_hal_get_rxfifo_len(&uart_hal_))});
-    REQUIRE_FROM_CALLBACK(chunk != 0U, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(chunk != 0U, in_isr);
     int read_size = static_cast<int>(chunk);
     uart_hal_read_rxfifo(&uart_hal_, rx_isr_buffer_, &read_size);
-    REQUIRE_FROM_CALLBACK(read_size > 0 && static_cast<size_t>(read_size) <= chunk,
-                          in_isr);
-    REQUIRE_FROM_CALLBACK(
-        queue.PushBatch(rx_isr_buffer_, static_cast<size_t>(read_size)) == ErrorCode::OK,
-        in_isr);
+    DEV_ASSERT_FROM_CALLBACK(read_size > 0 && static_cast<size_t>(read_size) <= chunk,
+                             in_isr);
+    [[maybe_unused]] const auto push_batch_result =
+        queue.PushBatch(rx_isr_buffer_, static_cast<size_t>(read_size));
+    DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
   }
 
   queue.Publish();

--- a/driver/esp/esp_usb_dev.cpp
+++ b/driver/esp/esp_usb_dev.cpp
@@ -115,8 +115,10 @@ void ESP32USBDevice::Start(bool)
   }
 
   EnsureRomUsbCleaned();
-  ASSERT(EnsurePhyReady());
-  ASSERT(EnsureInterruptReady());
+  [[maybe_unused]] const auto ensure_phy_ready_result = EnsurePhyReady();
+  REQUIRE(ensure_phy_ready_result);
+  [[maybe_unused]] const auto ensure_interrupt_ready_result = EnsureInterruptReady();
+  REQUIRE(ensure_interrupt_ready_result);
 
   InitializeCore();
   if (IsInited())
@@ -370,8 +372,9 @@ void ESP32USBDevice::ReloadSetupPacketCount()
     dev->doeptsiz0_reg.xfersize = 3U * SETUP_PACKET_BYTES;
     dev->doeptsiz0_reg.pktcnt = 1U;
     dev->doeptsiz0_reg.supcnt = 3U;
-    ASSERT(
-        ESPUSBDetail::CacheSyncDmaBuffer(setup_packet_, SETUP_DMA_BUFFER_BYTES, false));
+    [[maybe_unused]] const auto cache_sync_dma_buffer_result =
+        ESPUSBDetail::CacheSyncDmaBuffer(setup_packet_, SETUP_DMA_BUFFER_BYTES, false);
+    ASSERT(cache_sync_dma_buffer_result);
     dev->doepdma0_reg.dmaaddr =
         static_cast<uint32_t>(reinterpret_cast<uintptr_t>(setup_packet_));
     dev->doepctl0_reg.cnak = 1;

--- a/driver/esp/esp_usb_ep.cpp
+++ b/driver/esp/esp_usb_ep.cpp
@@ -338,7 +338,8 @@ void ESP32USBEndpoint::HandleOutInterrupt(bool in_isr)
   {
     const size_t actual =
         device_.DmaEnabled() ? GetCompletedTransferSize() : transfer_actual_size_;
-    ASSERT(FinishOutTransfer(actual));
+    [[maybe_unused]] const auto finish_out_transfer_result = FinishOutTransfer(actual);
+    ASSERT(finish_out_transfer_result);
     if (ep_num == 0U)
     {
       FinishPendingEp0InStatus(in_isr);
@@ -358,8 +359,10 @@ void ESP32USBEndpoint::HandleOutInterrupt(bool in_isr)
   {
     if (device_.DmaEnabled())
     {
-      ASSERT(ESPUSBDetail::CacheSyncDmaBuffer(
-          device_.setup_packet_, ESP32USBDevice::SETUP_DMA_BUFFER_BYTES, false));
+      [[maybe_unused]] const auto cache_sync_dma_buffer_result =
+          ESPUSBDetail::CacheSyncDmaBuffer(device_.setup_packet_,
+                                           ESP32USBDevice::SETUP_DMA_BUFFER_BYTES, false);
+      ASSERT(cache_sync_dma_buffer_result);
     }
     device_.UpdateSetupState(device_.setup_packet_);
     const auto* setup = reinterpret_cast<const USB::SetupPacket*>(device_.setup_packet_);

--- a/driver/hpm/hpm_i2c.cpp
+++ b/driver/hpm/hpm_i2c.cpp
@@ -585,7 +585,7 @@ HPMI2C::HPMI2C(I2C_Type* i2c, clock_name_t clock, bool auto_board_init,
 
   ASSERT(source_clock_hz_ != 0);
   const ErrorCode ans = SetConfig(config);
-  ASSERT(ans == ErrorCode::OK);
+  REQUIRE(ans == ErrorCode::OK);
 }
 
 ErrorCode HPMI2C::SetAddressMode(AddressMode mode)

--- a/driver/linux/linux_gpio.cpp
+++ b/driver/linux/linux_gpio.cpp
@@ -577,7 +577,6 @@ ErrorCode LinuxGPIO::OpenChip()
   {
     XR_LOG_ERROR("Failed to open GPIO chip: %s (%s)", chip_path_.c_str(),
                  std::strerror(errno));
-    ASSERT(false);
     return ErrorCode::INIT_ERR;
   }
 

--- a/driver/linux/linux_uart.hpp
+++ b/driver/linux/linux_uart.hpp
@@ -110,7 +110,7 @@ class LinuxUART : public UART
         _write_port(tx_queue_size, buffer_size)
   {
     ASSERT(buff_size_ > 0);
-    REQUIRE(tx_queue_size > 0);
+    ASSERT(tx_queue_size > 0);
 
     while (!std::filesystem::exists(dev_path))
     {
@@ -201,8 +201,8 @@ class LinuxUART : public UART
         _read_port(buffer_size, *this),
         _write_port(tx_queue_size, buffer_size)
   {
-    REQUIRE(tx_queue_size > 0);
-    REQUIRE(buff_size_ > 0);
+    ASSERT(tx_queue_size > 0);
+    ASSERT(buff_size_ > 0);
     while (!FindUSBTTYByVidPid(vid, pid, control_interface_name, serial, device_path_))
     {
       XR_LOG_WARN(
@@ -218,7 +218,7 @@ class LinuxUART : public UART
     if (std::filesystem::exists(device_path_) == false)
     {
       XR_LOG_ERROR("Cannot find UART device: %s", device_path_.c_str());
-      ASSERT(false);
+      REQUIRE(false);
       return;
     }
 
@@ -553,7 +553,7 @@ class LinuxUART : public UART
   /// attempt.
   void StartIoOwner(size_t thread_stack_size)
   {
-    REQUIRE(ValidateConfig(config_) == ErrorCode::OK);
+    ASSERT(ValidateConfig(config_) == ErrorCode::OK);
 
     wake_fd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     REQUIRE(wake_fd_ >= 0);
@@ -574,7 +574,7 @@ class LinuxUART : public UART
   /// 发布唤醒通知，已有未处理通知时允许合并 / Signal progress, coalescing pending wakes.
   void NotifyIoOwner()
   {
-    REQUIRE(wake_fd_ >= 0);
+    DEV_ASSERT(wake_fd_ >= 0);
     const uint64_t value = 1U;
     for (;;)
     {
@@ -680,7 +680,7 @@ class LinuxUART : public UART
       if (written > 0)
       {
         const size_t accepted = static_cast<size_t>(written);
-        REQUIRE(accepted <= first_size + second_size);
+        DEV_ASSERT(accepted <= first_size + second_size);
         return accepted;
       }
       if (written == 0)
@@ -769,7 +769,9 @@ class LinuxUART : public UART
       const ssize_t bytes = read(fd, rx_buff_, read_size);
       if (bytes > 0)
       {
-        REQUIRE(queue.PushBatch(rx_buff_, static_cast<size_t>(bytes)) == ErrorCode::OK);
+        [[maybe_unused]] const auto push_batch_result =
+            queue.PushBatch(rx_buff_, static_cast<size_t>(bytes));
+        DEV_ASSERT(push_batch_result == ErrorCode::OK);
         queue.Publish();
         budget -= static_cast<size_t>(bytes);
         continue;

--- a/driver/linux/linux_wifi_client.hpp
+++ b/driver/linux/linux_wifi_client.hpp
@@ -41,7 +41,7 @@ class LinuxWifiClient : public WifiClient
       if (iface.empty())
       {
         XR_LOG_ERROR("Wi-Fi interface not found");
-        ASSERT(false);
+        REQUIRE(false);
       }
       else
       {

--- a/driver/mspm0/mspm0_spi.cpp
+++ b/driver/mspm0/mspm0_spi.cpp
@@ -178,10 +178,10 @@ void MSPM0SPI::StartDmaRxOnly(uint32_t offset, uint32_t count)
 {
   RawData rx = GetRxBuffer();
 
-  ASSERT(offset < rx.size_);
-  ASSERT(count > 0U);
-  ASSERT(count <= RX_ONLY_REPEAT_TX_MAX_FRAMES);
-  ASSERT((offset + count) <= rx.size_);
+  DEV_ASSERT(offset < rx.size_);
+  DEV_ASSERT(count > 0U);
+  DEV_ASSERT(count <= RX_ONLY_REPEAT_TX_MAX_FRAMES);
+  DEV_ASSERT((offset + count) <= rx.size_);
 
   masked_interrupts_for_tx_only_ = 0;
 

--- a/driver/mspm0/mspm0_uart.cpp
+++ b/driver/mspm0/mspm0_uart.cpp
@@ -112,45 +112,45 @@ MSPM0UART::MSPM0UART(Resources res, RawData tx_dma_storage, RawData rx_dma_stora
       rx_dma_storage_(rx_dma_storage),
       tx_half_size_(tx_dma_storage.size_ / 2U)
 {
-  REQUIRE(res_.instance != nullptr);
-  REQUIRE(res_.clock_freq > 0U);
-  REQUIRE(res_.index < MAX_UART_INSTANCES);
-  REQUIRE(res_.index == ResolveIndex(res_.irqn));
-  REQUIRE(instance_map_[res_.index] == nullptr);
-  REQUIRE(tx_dma_storage_.addr_ != nullptr);
-  REQUIRE(tx_dma_storage_.size_ > 1U);
-  REQUIRE((tx_dma_storage_.size_ % 2U) == 0U);
-  REQUIRE((reinterpret_cast<uintptr_t>(tx_dma_storage_.addr_) % alignof(size_t)) == 0U);
-  REQUIRE((tx_dma_storage_.size_ % (2U * alignof(size_t))) == 0U);
-  REQUIRE(tx_half_size_ <= MSPM0_UART_DMA_MAX_TRANSFER_SIZE);
-  REQUIRE(tx_queue_size > 0U);
-  REQUIRE(rx_queue_capacity > 0U);
+  ASSERT(res_.instance != nullptr);
+  ASSERT(res_.clock_freq > 0U);
+  ASSERT(res_.index < MAX_UART_INSTANCES);
+  ASSERT(res_.index == ResolveIndex(res_.irqn));
+  ASSERT(instance_map_[res_.index] == nullptr);
+  ASSERT(tx_dma_storage_.addr_ != nullptr);
+  ASSERT(tx_dma_storage_.size_ > 1U);
+  ASSERT((tx_dma_storage_.size_ % 2U) == 0U);
+  ASSERT((reinterpret_cast<uintptr_t>(tx_dma_storage_.addr_) % alignof(size_t)) == 0U);
+  ASSERT((tx_dma_storage_.size_ % (2U * alignof(size_t))) == 0U);
+  ASSERT(tx_half_size_ <= MSPM0_UART_DMA_MAX_TRANSFER_SIZE);
+  ASSERT(tx_queue_size > 0U);
+  ASSERT(rx_queue_capacity > 0U);
 
   if (res_.rx_mode == RxMode::EXTEND_DMA)
   {
-    REQUIRE(rx_dma_storage_.addr_ != nullptr);
-    REQUIRE(rx_dma_storage_.size_ > 1U);
-    REQUIRE((rx_dma_storage_.size_ % 2U) == 0U);
-    REQUIRE(rx_dma_storage_.size_ <= MSPM0_UART_DMA_MAX_TRANSFER_SIZE);
-    REQUIRE(res_.dma_rx_channel < DMA_SYS_N_DMA_FULL_CHANNEL);
+    ASSERT(rx_dma_storage_.addr_ != nullptr);
+    ASSERT(rx_dma_storage_.size_ > 1U);
+    ASSERT((rx_dma_storage_.size_ % 2U) == 0U);
+    ASSERT(rx_dma_storage_.size_ <= MSPM0_UART_DMA_MAX_TRANSFER_SIZE);
+    ASSERT(res_.dma_rx_channel < DMA_SYS_N_DMA_FULL_CHANNEL);
   }
   else
   {
-    REQUIRE(rx_dma_storage_.addr_ == nullptr);
-    REQUIRE(rx_dma_storage_.size_ == 0U);
-    REQUIRE(!res_.rx_half_interrupt);
-    REQUIRE(res_.dma_rx_channel == INVALID_DMA_CHANNEL);
+    ASSERT(rx_dma_storage_.addr_ == nullptr);
+    ASSERT(rx_dma_storage_.size_ == 0U);
+    ASSERT(!res_.rx_half_interrupt);
+    ASSERT(res_.dma_rx_channel == INVALID_DMA_CHANNEL);
   }
 
-  REQUIRE(res_.dma_tx_channel < MAX_DMA_CHANNELS);
-  REQUIRE(res_.dma_tx_trigger != 0U);
+  ASSERT(res_.dma_tx_channel < MAX_DMA_CHANNELS);
+  ASSERT(res_.dma_tx_trigger != 0U);
   if (res_.rx_mode == RxMode::EXTEND_DMA)
   {
-    REQUIRE(res_.dma_rx_channel < MAX_DMA_CHANNELS);
-    REQUIRE(res_.dma_rx_channel != res_.dma_tx_channel);
-    REQUIRE(res_.dma_rx_trigger != 0U);
-    REQUIRE(res_.dma_rx_trigger != res_.dma_tx_trigger);
-    REQUIRE(!res_.rx_half_interrupt || res_.dma_rx_channel < 8U);
+    ASSERT(res_.dma_rx_channel < MAX_DMA_CHANNELS);
+    ASSERT(res_.dma_rx_channel != res_.dma_tx_channel);
+    ASSERT(res_.dma_rx_trigger != 0U);
+    ASSERT(res_.dma_rx_trigger != res_.dma_tx_trigger);
+    ASSERT(!res_.rx_half_interrupt || res_.dma_rx_channel < 8U);
   }
 
   for (const MSPM0UART* other : instance_map_)
@@ -160,23 +160,23 @@ MSPM0UART::MSPM0UART(Resources res, RawData tx_dma_storage, RawData rx_dma_stora
       continue;
     }
 
-    REQUIRE(res_.dma_tx_channel != other->res_.dma_tx_channel);
+    ASSERT(res_.dma_tx_channel != other->res_.dma_tx_channel);
     if (other->res_.rx_mode == RxMode::EXTEND_DMA)
     {
-      REQUIRE(res_.dma_tx_channel != other->res_.dma_rx_channel);
+      ASSERT(res_.dma_tx_channel != other->res_.dma_rx_channel);
     }
 
     if (res_.rx_mode == RxMode::EXTEND_DMA)
     {
-      REQUIRE(res_.dma_rx_channel != other->res_.dma_tx_channel);
+      ASSERT(res_.dma_rx_channel != other->res_.dma_tx_channel);
       if (other->res_.rx_mode == RxMode::EXTEND_DMA)
       {
-        REQUIRE(res_.dma_rx_channel != other->res_.dma_rx_channel);
+        ASSERT(res_.dma_rx_channel != other->res_.dma_rx_channel);
       }
     }
   }
 
-  REQUIRE(ValidateConfig(config) == ErrorCode::OK);
+  ASSERT(ValidateConfig(config) == ErrorCode::OK);
   _read_port.SetOwner(this);
   _write_port = WriteFun;
 
@@ -220,8 +220,8 @@ ErrorCode MSPM0UART::ValidateConfig(UART::Configuration config) const
 UART::Configuration MSPM0UART::BuildConfigFromSysCfg(UART_Regs* instance,
                                                      uint32_t baudrate)
 {
-  REQUIRE(instance != nullptr);
-  REQUIRE(baudrate > 0U);
+  DEV_ASSERT(instance != nullptr);
+  DEV_ASSERT(baudrate > 0U);
 
   UART::Configuration config = {baudrate, UART::Parity::NO_PARITY, 8U, 1U};
   switch (DL_UART_getWordLength(instance))
@@ -253,7 +253,7 @@ UART::Configuration MSPM0UART::BuildConfigFromSysCfg(UART_Regs* instance,
       config.parity = UART::Parity::ODD;
       break;
     default:
-      REQUIRE(false);
+      DEV_ASSERT(false);
       break;
   }
   config.stop_bits = DL_UART_getStopBits(instance) == DL_UART_STOP_BITS_TWO ? 2U : 1U;
@@ -301,7 +301,7 @@ void MSPM0UART::HandleService(uint32_t events, bool in_isr)
 {
   if ((events & EVENT_CONFIG) != 0U)
   {
-    REQUIRE_FROM_CALLBACK(
+    DEV_ASSERT_FROM_CALLBACK(
         config_state_.load(std::memory_order_acquire) == ConfigState::RESERVED, in_isr);
     config_state_.store(ConfigState::PUBLISHED, std::memory_order_release);
   }
@@ -380,7 +380,7 @@ void MSPM0UART::FillTx(bool in_isr)
       }
 
       size = queue.AvailableSize();
-      REQUIRE_FROM_CALLBACK(size > 0U && size <= tx_half_size_, in_isr);
+      DEV_ASSERT_FROM_CALLBACK(size > 0U && size <= tx_half_size_, in_isr);
       queue.PopAll(TxHalf(free_half));
       tx_half_size_used_[free_half] = size;
     }
@@ -396,7 +396,7 @@ void MSPM0UART::FillTx(bool in_isr)
 
 void MSPM0UART::HandleTxDone(bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(active_half_ >= 0 && active_half_ < 2, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(active_half_ >= 0 && active_half_ < 2, in_isr);
   const uint8_t completed = static_cast<uint8_t>(active_half_);
   tx_half_size_used_[completed] = 0U;
   active_half_ = -1;
@@ -444,7 +444,8 @@ void MSPM0UART::HandleMainRx(bool in_isr)
     }
 
     const uint8_t byte = DL_UART_receiveData(res_.instance);
-    REQUIRE_FROM_CALLBACK(queue.PushBatch(&byte, 1U) == ErrorCode::OK, in_isr);
+    [[maybe_unused]] const auto push_batch_result = queue.PushBatch(&byte, 1U);
+    DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
   }
   queue.Publish();
 }
@@ -452,14 +453,14 @@ void MSPM0UART::HandleMainRx(bool in_isr)
 void MSPM0UART::HandleExtendRx(bool in_isr)
 {
   const size_t capacity = RxCapacity();
-  REQUIRE_FROM_CALLBACK(capacity > 1U, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(capacity > 1U, in_isr);
 
   const uint32_t remaining = DL_DMA_getTransferSize(DMA, res_.dma_rx_channel);
-  REQUIRE_FROM_CALLBACK(remaining <= capacity, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(remaining <= capacity, in_isr);
 
   const size_t position = remaining == 0U ? capacity : capacity - remaining;
   const size_t cursor = rx_dma_cursor_;
-  REQUIRE_FROM_CALLBACK(cursor < capacity, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(cursor < capacity, in_isr);
 
   const size_t first_size = position >= cursor ? position - cursor : capacity - cursor;
   const size_t second_size = position >= cursor ? 0U : position;
@@ -471,16 +472,16 @@ void MSPM0UART::HandleExtendRx(bool in_isr)
   if (first_accepted != 0U)
   {
     auto* source = static_cast<const uint8_t*>(rx_dma_storage_.addr_) + cursor;
-    REQUIRE_FROM_CALLBACK(queue.PushBatch(source, first_accepted) == ErrorCode::OK,
-                          in_isr);
+    [[maybe_unused]] const auto push_batch_result =
+        queue.PushBatch(source, first_accepted);
+    DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
     accepted -= first_accepted;
   }
   if (accepted != 0U)
   {
-    REQUIRE_FROM_CALLBACK(
-        queue.PushBatch(static_cast<const uint8_t*>(rx_dma_storage_.addr_), accepted) ==
-            ErrorCode::OK,
-        in_isr);
+    [[maybe_unused]] const auto push_batch_result =
+        queue.PushBatch(static_cast<const uint8_t*>(rx_dma_storage_.addr_), accepted);
+    DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
   }
 
   // 超出软件容量的尾部作为溢出丢弃，回调前先推进游标。
@@ -580,7 +581,7 @@ void MSPM0UART::OnDmaInterrupt()
 
 void MSPM0UARTReadPort::OnReadQueueSpaceAvailable(bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(owner_ != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(owner_ != nullptr, in_isr);
   owner_->NotifyReadSpace(in_isr);
 }
 
@@ -619,7 +620,7 @@ void MSPM0UART::ConfigureRxDma()
                                               DL_DMA_EARLY_INTERRUPT_THRESHOLD_HALF);
   }
 #else
-  REQUIRE(false);
+  DEV_ASSERT(false);
 #endif
 }
 
@@ -642,7 +643,7 @@ void MSPM0UART::ApplyConfig(UART::Configuration config)
     case 8U:
       break;
     default:
-      REQUIRE(false);
+      DEV_ASSERT(false);
       break;
   }
 
@@ -735,8 +736,8 @@ void MSPM0UART::DiscardRxFifo()
 
 void MSPM0UART::StartTxDma(uint8_t half, size_t size)
 {
-  REQUIRE(half < 2U);
-  REQUIRE(size > 0U && size <= tx_half_size_);
+  DEV_ASSERT(half < 2U);
+  DEV_ASSERT(size > 0U && size <= tx_half_size_);
 
   DL_DMA_disableChannel(DMA, res_.dma_tx_channel);
   DL_DMA_clearInterruptStatus(DMA, DmaCompleteMask(res_.dma_tx_channel));

--- a/driver/st/stm32_adc.cpp
+++ b/driver/st/stm32_adc.cpp
@@ -84,9 +84,10 @@ STM32ADC::STM32ADC(ADC_HandleTypeDef* hadc, RawData dma_buff,
 #endif
     AssertNbrOfConvEq<H>(hadc_, NUM_CHANNELS);
 #if defined(LIBXR_STM32_ADC_GPDMA)
-    REQUIRE(gpdma_adapter_.Start(hadc_, reinterpret_cast<uint32_t*>(dma_buffer_.addr_),
-                                 NUM_CHANNELS * filter_size_,
-                                 dma_buffer_.size_) == HAL_OK);
+    [[maybe_unused]] const auto adc_dma_result =
+        gpdma_adapter_.Start(hadc_, reinterpret_cast<uint32_t*>(dma_buffer_.addr_),
+                             NUM_CHANNELS * filter_size_, dma_buffer_.size_);
+    REQUIRE(adc_dma_result == HAL_OK);
 #else
     HAL_ADC_Start_DMA(hadc_, reinterpret_cast<uint32_t*>(dma_buffer_.addr_),
                       NUM_CHANNELS * filter_size_);
@@ -105,7 +106,8 @@ STM32ADC::~STM32ADC()
 #if defined(LIBXR_STM32_ADC_GPDMA)
   if (use_dma_)
   {
-    REQUIRE(gpdma_adapter_.Stop(hadc_) == HAL_OK);
+    [[maybe_unused]] const auto adc_dma_result = gpdma_adapter_.Stop(hadc_);
+    REQUIRE(adc_dma_result == HAL_OK);
   }
   else
   {

--- a/driver/st/stm32_adc_gpdma.cpp
+++ b/driver/st/stm32_adc_gpdma.cpp
@@ -14,19 +14,19 @@ HAL_StatusTypeDef STM32GpdmaAdcAdapter::Start(ADC_HandleTypeDef* adc_handle,
                                               uint32_t* buffer, uint32_t sample_count,
                                               size_t buffer_size)
 {
-  REQUIRE(adc_handle != nullptr);
-  REQUIRE(adc_handle->DMA_Handle != nullptr);
-  REQUIRE(buffer != nullptr);
-  REQUIRE(sample_count > 0U);
-  REQUIRE(sample_count <= std::numeric_limits<size_t>::max() / sizeof(uint16_t));
-  REQUIRE(buffer_size >= static_cast<size_t>(sample_count) * sizeof(uint16_t));
+  ASSERT(adc_handle != nullptr);
+  ASSERT(adc_handle->DMA_Handle != nullptr);
+  ASSERT(buffer != nullptr);
+  ASSERT(sample_count > 0U);
+  ASSERT(sample_count <= std::numeric_limits<size_t>::max() / sizeof(uint16_t));
+  ASSERT(buffer_size >= static_cast<size_t>(sample_count) * sizeof(uint16_t));
   DMA_HandleTypeDef* const dma_handle = adc_handle->DMA_Handle;
-  REQUIRE(dma_handle->Parent == adc_handle);
-  REQUIRE(IS_GPDMA_INSTANCE(dma_handle->Instance) != 0U);
-  REQUIRE(dma_handle->Mode == DMA_LINKEDLIST_CIRCULAR);
-  REQUIRE(dma_handle->InitLinkedList.LinkedListMode == DMA_LINKEDLIST_CIRCULAR);
-  REQUIRE(dma_handle->InitLinkedList.LinkStepMode == DMA_LSM_FULL_EXECUTION);
-  REQUIRE((dma_handle->Instance->CCR & DMA_CCR_LSM) == DMA_LSM_FULL_EXECUTION);
+  ASSERT(dma_handle->Parent == adc_handle);
+  ASSERT(IS_GPDMA_INSTANCE(dma_handle->Instance) != 0U);
+  ASSERT(dma_handle->Mode == DMA_LINKEDLIST_CIRCULAR);
+  ASSERT(dma_handle->InitLinkedList.LinkedListMode == DMA_LINKEDLIST_CIRCULAR);
+  ASSERT(dma_handle->InitLinkedList.LinkStepMode == DMA_LSM_FULL_EXECUTION);
+  ASSERT((dma_handle->Instance->CCR & DMA_CCR_LSM) == DMA_LSM_FULL_EXECUTION);
 
   if (state_.original_queue == nullptr)
   {
@@ -34,10 +34,10 @@ HAL_StatusTypeDef STM32GpdmaAdcAdapter::Start(ADC_HandleTypeDef* adc_handle,
   }
   else
   {
-    REQUIRE(dma_handle->LinkedListQueue == &state_.queue);
-    REQUIRE(state_.queue.Head == &state_.node);
-    REQUIRE(state_.queue.FirstCircularNode == &state_.node);
-    REQUIRE(state_.queue.NodeNumber == 1U);
+    DEV_ASSERT(dma_handle->LinkedListQueue == &state_.queue);
+    DEV_ASSERT(state_.queue.Head == &state_.node);
+    DEV_ASSERT(state_.queue.FirstCircularNode == &state_.node);
+    DEV_ASSERT(state_.queue.NodeNumber == 1U);
   }
 
   FinalizeStopped(dma_handle);
@@ -50,10 +50,10 @@ HAL_StatusTypeDef STM32GpdmaAdcAdapter::Start(ADC_HandleTypeDef* adc_handle,
 
 HAL_StatusTypeDef STM32GpdmaAdcAdapter::Stop(ADC_HandleTypeDef* adc_handle)
 {
-  REQUIRE(adc_handle != nullptr);
-  REQUIRE(adc_handle->DMA_Handle != nullptr);
+  ASSERT(adc_handle != nullptr);
+  ASSERT(adc_handle->DMA_Handle != nullptr);
   DMA_HandleTypeDef* const dma_handle = adc_handle->DMA_Handle;
-  REQUIRE(dma_handle->Parent == adc_handle);
+  ASSERT(dma_handle->Parent == adc_handle);
 
   const HAL_StatusTypeDef stop_status = HAL_ADC_Stop_DMA(adc_handle);
   if (stop_status != HAL_OK)
@@ -67,23 +67,27 @@ HAL_StatusTypeDef STM32GpdmaAdcAdapter::Stop(ADC_HandleTypeDef* adc_handle)
   }
 
   FinalizeStopped(dma_handle);
-  REQUIRE(dma_handle->LinkedListQueue == &state_.queue);
-  REQUIRE(state_.queue.State == HAL_DMA_QUEUE_STATE_READY);
+  DEV_ASSERT(dma_handle->LinkedListQueue == &state_.queue);
+  DEV_ASSERT(state_.queue.State == HAL_DMA_QUEUE_STATE_READY);
   DMA_QListTypeDef* const original_queue = state_.original_queue;
-  REQUIRE(HAL_DMAEx_List_UnLinkQ(dma_handle) == HAL_OK);
-  REQUIRE(HAL_DMAEx_List_LinkQ(dma_handle, original_queue) == HAL_OK);
-  REQUIRE(dma_handle->LinkedListQueue == original_queue);
+  [[maybe_unused]] const auto dma_ex_list_un_linkq_result =
+      HAL_DMAEx_List_UnLinkQ(dma_handle);
+  DEV_ASSERT(dma_ex_list_un_linkq_result == HAL_OK);
+  [[maybe_unused]] const auto dma_ex_list_linkq_result =
+      HAL_DMAEx_List_LinkQ(dma_handle, original_queue);
+  DEV_ASSERT(dma_ex_list_linkq_result == HAL_OK);
+  DEV_ASSERT(dma_handle->LinkedListQueue == original_queue);
   state_.original_queue = nullptr;
   return HAL_OK;
 }
 
 void STM32GpdmaAdcAdapter::FinalizeStopped(DMA_HandleTypeDef* dma_handle)
 {
-  REQUIRE(dma_handle->State == HAL_DMA_STATE_READY);
-  REQUIRE(dma_handle->Lock == HAL_UNLOCKED);
-  REQUIRE((dma_handle->Instance->CCR & DMA_CCR_EN) == 0U);
-  REQUIRE(dma_handle->LinkedListQueue != nullptr);
-  REQUIRE(dma_handle->LinkedListQueue->State == HAL_DMA_QUEUE_STATE_READY);
+  DEV_ASSERT(dma_handle->State == HAL_DMA_STATE_READY);
+  DEV_ASSERT(dma_handle->Lock == HAL_UNLOCKED);
+  DEV_ASSERT((dma_handle->Instance->CCR & DMA_CCR_EN) == 0U);
+  DEV_ASSERT(dma_handle->LinkedListQueue != nullptr);
+  DEV_ASSERT(dma_handle->LinkedListQueue->State == HAL_DMA_QUEUE_STATE_READY);
 
   // 错误中断可能保留块计数，清零后下次启动才会装载链表头。
   // Error IRQs may retain the block count; clear it so the next start loads the list
@@ -101,32 +105,33 @@ void STM32GpdmaAdcAdapter::BuildAndAttach(ADC_HandleTypeDef* adc_handle, uint32_
                                           uint32_t sample_count, size_t buffer_size)
 {
   DMA_HandleTypeDef* const dma_handle = adc_handle->DMA_Handle;
-  REQUIRE(dma_handle->State == HAL_DMA_STATE_READY);
-  REQUIRE((dma_handle->Instance->CCR & DMA_CCR_EN) == 0U);
-  REQUIRE(dma_handle->LinkedListQueue != nullptr);
-  REQUIRE(dma_handle->LinkedListQueue->Head != nullptr);
-  REQUIRE(dma_handle->LinkedListQueue->FirstCircularNode != nullptr);
-  REQUIRE(dma_handle->LinkedListQueue->State == HAL_DMA_QUEUE_STATE_READY);
+  DEV_ASSERT(dma_handle->State == HAL_DMA_STATE_READY);
+  DEV_ASSERT((dma_handle->Instance->CCR & DMA_CCR_EN) == 0U);
+  ASSERT(dma_handle->LinkedListQueue != nullptr);
+  ASSERT(dma_handle->LinkedListQueue->Head != nullptr);
+  ASSERT(dma_handle->LinkedListQueue->FirstCircularNode != nullptr);
+  DEV_ASSERT(dma_handle->LinkedListQueue->State == HAL_DMA_QUEUE_STATE_READY);
 
   DMA_NodeConfTypeDef node_config{};
-  REQUIRE(HAL_DMAEx_List_GetNodeConfig(&node_config, dma_handle->LinkedListQueue->Head) ==
-          HAL_OK);
-  REQUIRE(node_config.Init.Direction == DMA_PERIPH_TO_MEMORY);
-  REQUIRE(node_config.Init.SrcInc == DMA_SINC_FIXED);
-  REQUIRE(node_config.Init.DestInc == DMA_DINC_INCREMENTED);
-  REQUIRE(node_config.Init.SrcDataWidth == DMA_SRC_DATAWIDTH_HALFWORD);
-  REQUIRE(node_config.Init.DestDataWidth == DMA_DEST_DATAWIDTH_HALFWORD);
-  REQUIRE(node_config.Init.SrcBurstLength == 1U);
-  REQUIRE(node_config.Init.DestBurstLength == 1U);
-  REQUIRE(node_config.Init.BlkHWRequest == DMA_BREQ_SINGLE_BURST);
-  REQUIRE(node_config.Init.Mode == DMA_NORMAL);
-  REQUIRE(node_config.TriggerConfig.TriggerPolarity == DMA_TRIG_POLARITY_MASKED);
-  REQUIRE(node_config.DataHandlingConfig.DataExchange == DMA_EXCHANGE_NONE);
-  REQUIRE(sample_count <= std::numeric_limits<uint32_t>::max() / sizeof(uint16_t));
+  [[maybe_unused]] const auto dma_ex_list_get_node_config_result =
+      HAL_DMAEx_List_GetNodeConfig(&node_config, dma_handle->LinkedListQueue->Head);
+  DEV_ASSERT(dma_ex_list_get_node_config_result == HAL_OK);
+  ASSERT(node_config.Init.Direction == DMA_PERIPH_TO_MEMORY);
+  ASSERT(node_config.Init.SrcInc == DMA_SINC_FIXED);
+  ASSERT(node_config.Init.DestInc == DMA_DINC_INCREMENTED);
+  ASSERT(node_config.Init.SrcDataWidth == DMA_SRC_DATAWIDTH_HALFWORD);
+  ASSERT(node_config.Init.DestDataWidth == DMA_DEST_DATAWIDTH_HALFWORD);
+  ASSERT(node_config.Init.SrcBurstLength == 1U);
+  ASSERT(node_config.Init.DestBurstLength == 1U);
+  ASSERT(node_config.Init.BlkHWRequest == DMA_BREQ_SINGLE_BURST);
+  ASSERT(node_config.Init.Mode == DMA_NORMAL);
+  ASSERT(node_config.TriggerConfig.TriggerPolarity == DMA_TRIG_POLARITY_MASKED);
+  ASSERT(node_config.DataHandlingConfig.DataExchange == DMA_EXCHANGE_NONE);
+  ASSERT(sample_count <= std::numeric_limits<uint32_t>::max() / sizeof(uint16_t));
 
   const uint32_t transfer_size = sample_count * sizeof(uint16_t);
-  REQUIRE(buffer_size >= transfer_size);
-  REQUIRE(IS_DMA_BLOCK_SIZE(transfer_size) != 0U);
+  ASSERT(buffer_size >= transfer_size);
+  ASSERT(IS_DMA_BLOCK_SIZE(transfer_size) != 0U);
 
   node_config.NodeType = DMA_GPDMA_LINEAR_NODE;
   node_config.SrcAddress =
@@ -134,20 +139,30 @@ void STM32GpdmaAdcAdapter::BuildAndAttach(ADC_HandleTypeDef* adc_handle, uint32_
   node_config.DstAddress = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(buffer));
   node_config.DataSize = transfer_size;
 
-  REQUIRE(state_.queue.Head == nullptr);
-  REQUIRE(state_.queue.NodeNumber == 0U);
-  REQUIRE(HAL_DMAEx_List_BuildNode(&node_config, &state_.node) == HAL_OK);
-  REQUIRE(HAL_DMAEx_List_InsertNode_Tail(&state_.queue, &state_.node) == HAL_OK);
-  REQUIRE(HAL_DMAEx_List_SetCircularMode(&state_.queue) == HAL_OK);
-  REQUIRE(state_.queue.Head == &state_.node);
-  REQUIRE(state_.queue.FirstCircularNode == &state_.node);
-  REQUIRE(state_.queue.NodeNumber == 1U);
-  REQUIRE(state_.queue.State == HAL_DMA_QUEUE_STATE_READY);
+  DEV_ASSERT(state_.queue.Head == nullptr);
+  DEV_ASSERT(state_.queue.NodeNumber == 0U);
+  [[maybe_unused]] const auto dma_ex_list_build_node_result =
+      HAL_DMAEx_List_BuildNode(&node_config, &state_.node);
+  DEV_ASSERT(dma_ex_list_build_node_result == HAL_OK);
+  [[maybe_unused]] const auto dma_ex_list_insert_node_tail_result =
+      HAL_DMAEx_List_InsertNode_Tail(&state_.queue, &state_.node);
+  DEV_ASSERT(dma_ex_list_insert_node_tail_result == HAL_OK);
+  [[maybe_unused]] const auto dma_ex_list_set_circular_mode_result =
+      HAL_DMAEx_List_SetCircularMode(&state_.queue);
+  DEV_ASSERT(dma_ex_list_set_circular_mode_result == HAL_OK);
+  DEV_ASSERT(state_.queue.Head == &state_.node);
+  DEV_ASSERT(state_.queue.FirstCircularNode == &state_.node);
+  DEV_ASSERT(state_.queue.NodeNumber == 1U);
+  DEV_ASSERT(state_.queue.State == HAL_DMA_QUEUE_STATE_READY);
 
   state_.original_queue = dma_handle->LinkedListQueue;
-  REQUIRE(HAL_DMAEx_List_UnLinkQ(dma_handle) == HAL_OK);
-  REQUIRE(HAL_DMAEx_List_LinkQ(dma_handle, &state_.queue) == HAL_OK);
-  REQUIRE(dma_handle->LinkedListQueue == &state_.queue);
+  [[maybe_unused]] const auto dma_ex_list_un_linkq_result =
+      HAL_DMAEx_List_UnLinkQ(dma_handle);
+  DEV_ASSERT(dma_ex_list_un_linkq_result == HAL_OK);
+  [[maybe_unused]] const auto dma_ex_list_linkq_result =
+      HAL_DMAEx_List_LinkQ(dma_handle, &state_.queue);
+  DEV_ASSERT(dma_ex_list_linkq_result == HAL_OK);
+  DEV_ASSERT(dma_handle->LinkedListQueue == &state_.queue);
 }
 
 }  // namespace LibXR

--- a/driver/st/stm32_uart.cpp
+++ b/driver/st/stm32_uart.cpp
@@ -236,7 +236,7 @@ void STM32UART::HandleTxService(uint32_t events, bool in_isr)
     }
     else
     {
-      REQUIRE_FROM_CALLBACK(state == ConfigState::PUBLISHED, in_isr);
+      DEV_ASSERT_FROM_CALLBACK(state == ConfigState::PUBLISHED, in_isr);
     }
   }
 
@@ -250,7 +250,8 @@ void STM32UART::HandleTxService(uint32_t events, bool in_isr)
       return;
     }
     events |= TX_EVENT_ABORT;
-    REQUIRE_FROM_CALLBACK(HAL_UART_Abort(uart_handle_) == HAL_OK, in_isr);
+    [[maybe_unused]] const auto uart_abort_result = HAL_UART_Abort(uart_handle_);
+    REQUIRE_FROM_CALLBACK(uart_abort_result == HAL_OK, in_isr);
     if (uart_handle_->hdmatx != nullptr)
     {
       STM32GpdmaUartAdapter::FinalizeStopped(uart_handle_->hdmatx, in_isr);
@@ -354,7 +355,7 @@ void STM32UART::FillTx(bool in_isr)
           return;
         }
         size = queue.AvailableSize();
-        REQUIRE_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
+        DEV_ASSERT_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
         queue.PopAll(dma_buff_tx_.ActiveBuffer());
         dma_buff_tx_.SetActiveLength(size);
       }
@@ -374,7 +375,7 @@ void STM32UART::FillTx(bool in_isr)
     if (!queue.Empty())
     {
       const size_t size = queue.AvailableSize();
-      REQUIRE_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
+      DEV_ASSERT_FROM_CALLBACK(size <= dma_buff_tx_.Size(), in_isr);
       queue.PopAll(dma_buff_tx_.PendingBuffer());
       dma_buff_tx_.SetPendingLength(size);
       dma_buff_tx_.EnablePending();
@@ -414,7 +415,7 @@ STM32UART::STM32UART(UART_HandleTypeDef* uart_handle, RawData dma_buff_rx,
 
   if ((uart_handle->Init.Mode & UART_MODE_TX) == UART_MODE_TX)
   {
-    REQUIRE(tx_queue_size > 0U);
+    ASSERT(tx_queue_size > 0U);
     ASSERT(uart_handle_->hdmatx != NULL);
 #if defined(LIBXR_STM32_UART_GPDMA)
     ASSERT(uart_handle_->hdmatx->Mode == DMA_NORMAL);
@@ -492,7 +493,7 @@ void STM32UART::ApplyConfig(UART::Configuration config, bool in_isr)
           config.data_bits == 7U ? UART_WORDLENGTH_8B : UART_WORDLENGTH_9B;
       break;
     default:
-      REQUIRE_FROM_CALLBACK(false, in_isr);
+      DEV_ASSERT_FROM_CALLBACK(false, in_isr);
       return;
   }
 
@@ -505,7 +506,7 @@ void STM32UART::ApplyConfig(UART::Configuration config, bool in_isr)
       uart_handle_->Init.StopBits = UART_STOPBITS_2;
       break;
     default:
-      REQUIRE_FROM_CALLBACK(false, in_isr);
+      DEV_ASSERT_FROM_CALLBACK(false, in_isr);
       return;
   }
 
@@ -513,13 +514,15 @@ void STM32UART::ApplyConfig(UART::Configuration config, bool in_isr)
   // 通道已停止，直接配置寄存器，避免在中断中等待 HAL tick。
   // Channels are stopped; configure registers without waiting for HAL ticks in an ISR.
   __HAL_UART_DISABLE(uart_handle_);
-  REQUIRE_FROM_CALLBACK(UART_SetConfig(uart_handle_) == HAL_OK, in_isr);
+  [[maybe_unused]] const auto uart_set_config_result = UART_SetConfig(uart_handle_);
+  REQUIRE_FROM_CALLBACK(uart_set_config_result == HAL_OK, in_isr);
   CLEAR_BIT(uart_handle_->Instance->CR2, USART_CR2_LINEN | USART_CR2_CLKEN);
   CLEAR_BIT(uart_handle_->Instance->CR3,
             USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN);
   __HAL_UART_ENABLE(uart_handle_);
 #else
-  REQUIRE_FROM_CALLBACK(HAL_UART_Init(uart_handle_) == HAL_OK, in_isr);
+  [[maybe_unused]] const auto uart_init_result = HAL_UART_Init(uart_handle_);
+  REQUIRE_FROM_CALLBACK(uart_init_result == HAL_OK, in_isr);
 #endif
 }
 
@@ -553,19 +556,20 @@ void STM32UART::SetRxDMA(bool in_isr)
     ASSERT(uart_handle_->hdmarx != NULL);
 
 #if defined(LIBXR_STM32_UART_GPDMA)
-    REQUIRE_FROM_CALLBACK(
+    [[maybe_unused]] const auto start_linked_list_dma_rx_result =
         gpdma_adapter_.StartLinkedListDmaRx(static_cast<uint8_t*>(dma_buff_rx_.addr_),
-                                            dma_buff_rx_.size_, in_isr) == HAL_OK,
-        in_isr);
+                                            dma_buff_rx_.size_, in_isr);
+    REQUIRE_FROM_CALLBACK(start_linked_list_dma_rx_result == HAL_OK, in_isr);
 #else
     uart_handle_->hdmarx->Init.Mode = DMA_CIRCULAR;
-    REQUIRE_FROM_CALLBACK(HAL_DMA_Init(uart_handle_->hdmarx) == HAL_OK, in_isr);
+    [[maybe_unused]] const auto dma_init_result = HAL_DMA_Init(uart_handle_->hdmarx);
+    REQUIRE_FROM_CALLBACK(dma_init_result == HAL_OK, in_isr);
 
-    REQUIRE_FROM_CALLBACK(
+    [[maybe_unused]] const auto uart_ex_receive_to_idle_dma_result =
         HAL_UARTEx_ReceiveToIdle_DMA(uart_handle_,
                                      reinterpret_cast<uint8_t*>(dma_buff_rx_.addr_),
-                                     dma_buff_rx_.size_) == HAL_OK,
-        in_isr);
+                                     dma_buff_rx_.size_);
+    REQUIRE_FROM_CALLBACK(uart_ex_receive_to_idle_dma_result == HAL_OK, in_isr);
 #endif
   }
 }
@@ -579,21 +583,22 @@ void STM32UART::HandleRxData(bool in_isr)
   }
 
   auto* const rx_buf = static_cast<uint8_t*>(dma_buff_rx_.addr_);
-  REQUIRE_FROM_CALLBACK(rx_buf != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(rx_buf != nullptr, in_isr);
 
 #if defined(LIBXR_STM32_UART_GPDMA)
   const uintptr_t destination =
       reinterpret_cast<uintptr_t>(gpdma_adapter_.GetLinkedListDmaRxProducer());
   const uintptr_t begin = reinterpret_cast<uintptr_t>(rx_buf);
-  REQUIRE_FROM_CALLBACK(destination >= begin && destination - begin <= dma_size, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(destination >= begin && destination - begin <= dma_size,
+                           in_isr);
   const size_t curr_pos = destination - begin;
 #else
   const size_t remaining = __HAL_DMA_GET_COUNTER(uart_handle_->hdmarx);
-  REQUIRE_FROM_CALLBACK(remaining <= dma_size, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(remaining <= dma_size, in_isr);
   const size_t curr_pos = remaining == 0U ? dma_size : dma_size - remaining;
 #endif
   const size_t last_pos = last_rx_pos_;
-  REQUIRE_FROM_CALLBACK(last_pos < dma_size, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(last_pos < dma_size, in_isr);
 
   STM32_InvalidateDCacheByAddr(rx_buf, dma_size);
 
@@ -610,13 +615,15 @@ void STM32UART::HandleRxData(bool in_isr)
       const size_t first_accepted = std::min(first_size, accepted);
       if (first_accepted != 0U)
       {
-        REQUIRE_FROM_CALLBACK(
-            queue.PushBatch(rx_buf + last_pos, first_accepted) == ErrorCode::OK, in_isr);
+        [[maybe_unused]] const auto push_batch_result =
+            queue.PushBatch(rx_buf + last_pos, first_accepted);
+        DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
         accepted -= first_accepted;
       }
       if (accepted != 0U)
       {
-        REQUIRE_FROM_CALLBACK(queue.PushBatch(rx_buf, accepted) == ErrorCode::OK, in_isr);
+        [[maybe_unused]] const auto push_batch_result = queue.PushBatch(rx_buf, accepted);
+        DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
       }
     }
 
@@ -703,22 +710,23 @@ void STM32UART::BeginAbort(bool in_isr)
   gpdma_adapter_.CloseTxTerminalSource();
   if (uart_handle_->hdmatx != nullptr)
   {
-    REQUIRE_FROM_CALLBACK(
-        gpdma_adapter_.LaunchStop(uart_handle_->hdmatx, DmaAbortCallback, in_isr),
-        in_isr);
+    [[maybe_unused]] const auto launch_stop_result =
+        gpdma_adapter_.LaunchStop(uart_handle_->hdmatx, DmaAbortCallback, in_isr);
+    REQUIRE_FROM_CALLBACK(launch_stop_result, in_isr);
   }
   if (uart_handle_->hdmarx != nullptr)
   {
-    REQUIRE_FROM_CALLBACK(
-        gpdma_adapter_.LaunchStop(uart_handle_->hdmarx, DmaAbortCallback, in_isr),
-        in_isr);
+    [[maybe_unused]] const auto launch_stop_result =
+        gpdma_adapter_.LaunchStop(uart_handle_->hdmarx, DmaAbortCallback, in_isr);
+    REQUIRE_FROM_CALLBACK(launch_stop_result, in_isr);
   }
   if (gpdma_adapter_.AllStopsComplete())
   {
     tx_service_.Publish(TX_EVENT_ABORT);
   }
 #else
-  REQUIRE_FROM_CALLBACK(HAL_UART_Abort_IT(uart_handle_) == HAL_OK, in_isr);
+  [[maybe_unused]] const auto uart_abort_it_result = HAL_UART_Abort_IT(uart_handle_);
+  REQUIRE_FROM_CALLBACK(uart_abort_it_result == HAL_OK, in_isr);
 #endif
 }
 
@@ -737,7 +745,7 @@ void STM32UART::DmaAbortCallback(DMA_HandleTypeDef* dma_handle)
 void STM32UART::StartTxDma(bool in_isr)
 {
   const size_t size = dma_buff_tx_.GetActiveLength();
-  REQUIRE_FROM_CALLBACK(size != 0U && size <= dma_buff_tx_.Size(), in_isr);
+  DEV_ASSERT_FROM_CALLBACK(size != 0U && size <= dma_buff_tx_.Size(), in_isr);
 
   STM32_CleanDCacheByAddr(dma_buff_tx_.ActiveBuffer(), size);
   tx_busy_.Set();

--- a/driver/st/stm32_uart_gpdma.cpp
+++ b/driver/st/stm32_uart_gpdma.cpp
@@ -118,11 +118,11 @@ class GpdmaNvicMaskGuard
 
 STM32GpdmaUartAdapter::STM32GpdmaUartAdapter(UART_HandleTypeDef* uart_handle)
 {
-  REQUIRE(uart_handle != nullptr);
-  REQUIRE((uart_handle->hdmatx == nullptr) ||
-          (IS_GPDMA_INSTANCE(uart_handle->hdmatx->Instance) != 0U));
-  REQUIRE((uart_handle->hdmarx == nullptr) ||
-          (IS_GPDMA_INSTANCE(uart_handle->hdmarx->Instance) != 0U));
+  ASSERT(uart_handle != nullptr);
+  ASSERT((uart_handle->hdmatx == nullptr) ||
+         (IS_GPDMA_INSTANCE(uart_handle->hdmatx->Instance) != 0U));
+  ASSERT((uart_handle->hdmarx == nullptr) ||
+         (IS_GPDMA_INSTANCE(uart_handle->hdmarx->Instance) != 0U));
   state_.uart_handle_ = uart_handle;
 }
 
@@ -131,12 +131,12 @@ HAL_StatusTypeDef STM32GpdmaUartAdapter::StartLinkedListDmaRx(uint8_t* buffer,
                                                               bool in_isr)
 {
   DMA_HandleTypeDef* const dma_handle = state_.uart_handle_->hdmarx;
-  REQUIRE_FROM_CALLBACK(dma_handle != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(buffer != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(total_size >= RX_NODE_COUNT, in_isr);
-  REQUIRE_FROM_CALLBACK((total_size % RX_NODE_COUNT) == 0U, in_isr);
-  REQUIRE_FROM_CALLBACK((total_size / RX_NODE_COUNT) <= UINT16_MAX, in_isr);
-  REQUIRE_FROM_CALLBACK(IS_DMA_BLOCK_SIZE(total_size / RX_NODE_COUNT) != 0U, in_isr);
+  ASSERT_FROM_CALLBACK(dma_handle != nullptr, in_isr);
+  ASSERT_FROM_CALLBACK(buffer != nullptr, in_isr);
+  ASSERT_FROM_CALLBACK(total_size >= RX_NODE_COUNT, in_isr);
+  ASSERT_FROM_CALLBACK((total_size % RX_NODE_COUNT) == 0U, in_isr);
+  ASSERT_FROM_CALLBACK((total_size / RX_NODE_COUNT) <= UINT16_MAX, in_isr);
+  ASSERT_FROM_CALLBACK(IS_DMA_BLOCK_SIZE(total_size / RX_NODE_COUNT) != 0U, in_isr);
   ASSERT_FROM_CALLBACK(dma_handle->Parent == state_.uart_handle_ &&
                            IS_GPDMA_INSTANCE(dma_handle->Instance) != 0U,
                        in_isr);
@@ -152,12 +152,12 @@ HAL_StatusTypeDef STM32GpdmaUartAdapter::StartLinkedListDmaRx(uint8_t* buffer,
   }
   else
   {
-    REQUIRE_FROM_CALLBACK(buffer == state_.rx_buffer_, in_isr);
-    REQUIRE_FROM_CALLBACK(total_size == state_.rx_total_size_, in_isr);
-    REQUIRE_FROM_CALLBACK(dma_handle->LinkedListQueue == &state_.rx_queue_, in_isr);
+    ASSERT_FROM_CALLBACK(buffer == state_.rx_buffer_, in_isr);
+    ASSERT_FROM_CALLBACK(total_size == state_.rx_total_size_, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(dma_handle->LinkedListQueue == &state_.rx_queue_, in_isr);
   }
 
-  REQUIRE_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
+  DEV_ASSERT_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
   FinalizeStopped(dma_handle, in_isr);
   // 启动前将描述符与接收缓冲区同步到 DMA 可见的存储。
   // Make descriptors and RX storage visible to DMA before starting the channel.
@@ -211,7 +211,7 @@ bool STM32GpdmaUartAdapter::LaunchStop(DMA_HandleTypeDef* dma_handle,
   }
 
   GpdmaNvicMaskGuard irq_guard(dma_handle);
-  REQUIRE_FROM_CALLBACK(irq_guard.Valid() && irq_guard.WasEnabled(), in_isr);
+  ASSERT_FROM_CALLBACK(irq_guard.Valid() && irq_guard.WasEnabled(), in_isr);
   if (!irq_guard.Valid() || !irq_guard.WasEnabled())
   {
     return false;
@@ -226,7 +226,7 @@ bool STM32GpdmaUartAdapter::LaunchStop(DMA_HandleTypeDef* dma_handle,
   if (dma_handle->State == HAL_DMA_STATE_ABORT)
   {
     const bool joined = abort_is_joinable();
-    REQUIRE_FROM_CALLBACK(joined, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(joined, in_isr);
     return joined;
   }
   if (dma_handle->State == HAL_DMA_STATE_READY && IsStopped(dma_handle) &&
@@ -254,7 +254,7 @@ bool STM32GpdmaUartAdapter::LaunchStop(DMA_HandleTypeDef* dma_handle,
     }
 
     const bool joined = abort_is_joinable();
-    REQUIRE_FROM_CALLBACK(joined, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(joined, in_isr);
     return joined;
   }
 
@@ -287,8 +287,8 @@ bool STM32GpdmaUartAdapter::AllStopsComplete() const
 
 void STM32GpdmaUartAdapter::FinalizeStopped(DMA_HandleTypeDef* dma_handle, bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
-  REQUIRE_FROM_CALLBACK(dma_handle->Lock == HAL_UNLOCKED, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
+  DEV_ASSERT_FROM_CALLBACK(dma_handle->Lock == HAL_UNLOCKED, in_isr);
   if (!StopComplete(dma_handle))
   {
     return;
@@ -330,14 +330,14 @@ void STM32GpdmaUartAdapter::ClearFlags(DMA_HandleTypeDef* dma_handle)
 void STM32GpdmaUartAdapter::BuildRxQueue(uint8_t* buffer, size_t total_size, bool in_isr)
 {
   DMA_HandleTypeDef* const dma_handle = state_.uart_handle_->hdmarx;
-  REQUIRE_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
-  REQUIRE_FROM_CALLBACK(dma_handle->LinkedListQueue != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(dma_handle->LinkedListQueue->Head != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(StopComplete(dma_handle), in_isr);
+  ASSERT_FROM_CALLBACK(dma_handle->LinkedListQueue != nullptr, in_isr);
+  ASSERT_FROM_CALLBACK(dma_handle->LinkedListQueue->Head != nullptr, in_isr);
 
   DMA_NodeConfTypeDef node_config{};
-  REQUIRE_FROM_CALLBACK(HAL_DMAEx_List_GetNodeConfig(
-                            &node_config, dma_handle->LinkedListQueue->Head) == HAL_OK,
-                        in_isr);
+  [[maybe_unused]] const auto dma_ex_list_get_node_config_result =
+      HAL_DMAEx_List_GetNodeConfig(&node_config, dma_handle->LinkedListQueue->Head);
+  DEV_ASSERT_FROM_CALLBACK(dma_ex_list_get_node_config_result == HAL_OK, in_isr);
 
   // 保留 BSP 的请求与端口等属性，明确设置字节接收环的布局。
   // Preserve BSP request and port attributes while defining the byte RX ring layout.
@@ -368,19 +368,24 @@ void STM32GpdmaUartAdapter::BuildRxQueue(uint8_t* buffer, size_t total_size, boo
   {
     node_config.DstAddress =
         static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&buffer[i * node_size]));
-    REQUIRE_FROM_CALLBACK(
-        HAL_DMAEx_List_BuildNode(&node_config, &state_.nodes_[i]) == HAL_OK, in_isr);
-    REQUIRE_FROM_CALLBACK(
-        HAL_DMAEx_List_InsertNode_Tail(&state_.rx_queue_, &state_.nodes_[i]) == HAL_OK,
-        in_isr);
+    [[maybe_unused]] const auto dma_ex_list_build_node_result =
+        HAL_DMAEx_List_BuildNode(&node_config, &state_.nodes_[i]);
+    DEV_ASSERT_FROM_CALLBACK(dma_ex_list_build_node_result == HAL_OK, in_isr);
+    [[maybe_unused]] const auto dma_ex_list_insert_node_tail_result =
+        HAL_DMAEx_List_InsertNode_Tail(&state_.rx_queue_, &state_.nodes_[i]);
+    DEV_ASSERT_FROM_CALLBACK(dma_ex_list_insert_node_tail_result == HAL_OK, in_isr);
   }
 
-  REQUIRE_FROM_CALLBACK(HAL_DMAEx_List_SetCircularMode(&state_.rx_queue_) == HAL_OK,
-                        in_isr);
-  REQUIRE_FROM_CALLBACK(HAL_DMAEx_List_UnLinkQ(dma_handle) == HAL_OK, in_isr);
-  REQUIRE_FROM_CALLBACK(HAL_DMAEx_List_LinkQ(dma_handle, &state_.rx_queue_) == HAL_OK,
-                        in_isr);
-  REQUIRE_FROM_CALLBACK(dma_handle->LinkedListQueue == &state_.rx_queue_, in_isr);
+  [[maybe_unused]] const auto dma_ex_list_set_circular_mode_result =
+      HAL_DMAEx_List_SetCircularMode(&state_.rx_queue_);
+  DEV_ASSERT_FROM_CALLBACK(dma_ex_list_set_circular_mode_result == HAL_OK, in_isr);
+  [[maybe_unused]] const auto dma_ex_list_un_linkq_result =
+      HAL_DMAEx_List_UnLinkQ(dma_handle);
+  DEV_ASSERT_FROM_CALLBACK(dma_ex_list_un_linkq_result == HAL_OK, in_isr);
+  [[maybe_unused]] const auto dma_ex_list_linkq_result =
+      HAL_DMAEx_List_LinkQ(dma_handle, &state_.rx_queue_);
+  DEV_ASSERT_FROM_CALLBACK(dma_ex_list_linkq_result == HAL_OK, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(dma_handle->LinkedListQueue == &state_.rx_queue_, in_isr);
 
   state_.rx_buffer_ = buffer;
   state_.rx_total_size_ = total_size;

--- a/src/core/libxr_def.hpp
+++ b/src/core/libxr_def.hpp
@@ -221,8 +221,10 @@ enum class SizeLimitMode : uint8_t
 #endif
 
 /**
- * @brief 面向 LibXR 用户的断言宏
- * @brief Assertion macro for LibXR users
+ * @brief 固定配置和调用前提检查 / Fixed configuration and caller precondition check
+ * @note LIBXR_DEBUG_BUILD 启用失败检查；关闭时仍求值。必要操作应在宏外执行。
+ *       LIBXR_DEBUG_BUILD enables failure checking; otherwise the expression is still
+ *       evaluated. Required operations belong outside the macro.
  * @param arg 要检查的条件 | Condition to check
  */
 #ifdef LIBXR_DEBUG_BUILD
@@ -261,8 +263,10 @@ enum class SizeLimitMode : uint8_t
 #endif
 
 /**
- * @brief 仅供 LibXR 本体开发使用的开发期断言
- * @brief Development-only assertion for LibXR maintainers
+ * @brief 库内部实现的开发期检查 / Development check for library implementation
+ * @note 默认禁用且不求值；仅在定义 LIBXR_DEV_ASSERT_BUILD 时启用。
+ *       Disabled without evaluation unless LIBXR_DEV_ASSERT_BUILD is defined.
+ *       条件不得包含必须执行的操作。 / Conditions must not contain required operations.
  * @param arg 要检查的条件 | Condition to check
  */
 #ifdef LIBXR_DEV_ASSERT_BUILD
@@ -291,18 +295,14 @@ enum class SizeLimitMode : uint8_t
     }                                                  \
   } while (0)
 #else
-#define DEV_ASSERT(arg) (void(arg), (void)0)
-#define DEV_ASSERT_FROM_CALLBACK(arg, in_isr) \
-  do                                          \
-  {                                           \
-    (void)(arg);                              \
-    (void)(in_isr);                           \
-  } while (0)
+#define DEV_ASSERT(arg) ((void)0)
+#define DEV_ASSERT_FROM_CALLBACK(arg, in_isr) ((void)0)
 #endif
 
 /**
- * @brief 与编译开关无关的强约束检查
- * @brief Strong requirement check independent of build switches
+ * @brief 始终生效的致命运行错误检查 / Always-enabled fatal runtime error check
+ * @note 可恢复错误应通过接口返回，不应在此终止。
+ *       Recoverable errors belong to the interface's error-return path.
  * @param arg 要检查的条件 | Condition to check
  */
 #define REQUIRE(arg)                                \

--- a/src/core/libxr_pipe.hpp
+++ b/src/core/libxr_pipe.hpp
@@ -37,7 +37,7 @@ class Pipe
    */
   explicit Pipe(size_t buffer_size) : read_port_(0), write_port_(0, buffer_size)
   {
-    REQUIRE(write_port_.queue_data_ != nullptr);
+    ASSERT(write_port_.queue_data_ != nullptr);
     read_port_.BindQueue(write_port_.queue_data_);
     write_port_ = &WriteFun;
   }

--- a/src/core/print/printf/printf_frontend_binding_field.hpp
+++ b/src/core/print/printf/printf_frontend_binding_field.hpp
@@ -139,11 +139,11 @@ namespace FieldSelection
     case FormatType::TextInline:
     case FormatType::TextRef:
     case FormatType::TextSpace:
-      ASSERT(false);
+      DEV_ASSERT(false);
       return FormatPackKind::U32;
   }
 
-  ASSERT(false);
+  DEV_ASSERT(false);
   return FormatPackKind::U32;
 }
 

--- a/src/core/rw/operation.hpp
+++ b/src/core/rw/operation.hpp
@@ -200,13 +200,11 @@ class AsyncBlockWait
    */
   ErrorCode Wait(uint32_t timeout)
   {
-    ASSERT(sem_ != nullptr);
+    DEV_ASSERT(sem_ != nullptr);
     auto wait_ans = sem_->Wait(timeout);
     if (wait_ans == ErrorCode::OK)
     {
-#ifdef LIBXR_DEBUG_BUILD
-      ASSERT(state_.load(std::memory_order_acquire) == State::CLAIMED);
-#endif
+      DEV_ASSERT(state_.load(std::memory_order_acquire) == State::CLAIMED);
       state_.store(State::IDLE, std::memory_order_release);
       return result_;
     }
@@ -219,8 +217,8 @@ class AsyncBlockWait
       return ErrorCode::TIMEOUT;
     }
 
-    ASSERT(expected == State::CLAIMED || expected == State::DETACHED ||
-           expected == State::IDLE);
+    DEV_ASSERT(expected == State::CLAIMED || expected == State::DETACHED ||
+               expected == State::IDLE);
     if (expected == State::DETACHED)
     {
       state_.store(State::IDLE, std::memory_order_release);
@@ -250,14 +248,15 @@ class AsyncBlockWait
    */
   bool TryPost(bool in_isr, ErrorCode ec)
   {
-    ASSERT(sem_ != nullptr);
+    DEV_ASSERT_FROM_CALLBACK(sem_ != nullptr, in_isr);
 
     State expected = State::PENDING;
     if (!state_.compare_exchange_strong(expected, State::CLAIMED,
                                         std::memory_order_acq_rel,
                                         std::memory_order_acquire))
     {
-      ASSERT(expected == State::DETACHED || expected == State::IDLE);
+      DEV_ASSERT_FROM_CALLBACK(expected == State::DETACHED || expected == State::IDLE,
+                               in_isr);
       if (expected == State::DETACHED)
       {
         expected = State::DETACHED;

--- a/src/core/rw/read_port.cpp
+++ b/src/core/rw/read_port.cpp
@@ -13,7 +13,7 @@ ReadPort::ReadPort(size_t buffer_size)
 
 ReadPort::ReadQueue ReadPort::GetReadQueue(bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(queue_data_ != nullptr, in_isr);
+  ASSERT_FROM_CALLBACK(queue_data_ != nullptr, in_isr);
   return ReadQueue(*this, in_isr);
 }
 
@@ -24,7 +24,7 @@ ErrorCode ReadPort::ReadQueue::PushBatch(const uint8_t* data, size_t size)
   DEV_ASSERT_FROM_CALLBACK(!finished_, in_isr_);
   if (size != 0U)
   {
-    DEV_ASSERT_FROM_CALLBACK(data != nullptr, in_isr_);
+    ASSERT_FROM_CALLBACK(data != nullptr, in_isr_);
   }
 
   const ErrorCode result = port_.queue_data_->PushBatch(data, size);
@@ -90,12 +90,12 @@ bool ReadPort::HasEnough(size_t available, size_t requested) const
   return requested == 0U ? available != 0U : available >= requested;
 }
 
-void ReadPort::ReleaseClaimed(bool in_isr)
+void ReadPort::ReleaseClaimed([[maybe_unused]] bool in_isr)
 {
   uint32_t observed = state_.load(std::memory_order_acquire);
   for (;;)
   {
-    REQUIRE_FROM_CALLBACK(GetPhase(observed) == Phase::CLAIMED, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(GetPhase(observed) == Phase::CLAIMED, in_isr);
     const uint32_t desired = WithPhase(observed, Phase::IDLE);
     if (state_.compare_exchange_weak(observed, desired, std::memory_order_acq_rel,
                                      std::memory_order_acquire))
@@ -129,12 +129,12 @@ bool ReadPort::ClaimBlockCompletion()
   }
 }
 
-void ReadPort::ReleaseBlockCompletion(bool in_isr)
+void ReadPort::ReleaseBlockCompletion([[maybe_unused]] bool in_isr)
 {
   uint32_t observed = state_.load(std::memory_order_acquire);
   for (;;)
   {
-    REQUIRE_FROM_CALLBACK(GetPhase(observed) == Phase::BLOCK_CLAIMED, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(GetPhase(observed) == Phase::BLOCK_CLAIMED, in_isr);
     const uint32_t desired = WithPhase(observed, Phase::IDLE);
     if (state_.compare_exchange_weak(observed, desired, std::memory_order_acq_rel,
                                      std::memory_order_acquire))
@@ -172,7 +172,7 @@ ErrorCode ReadPort::operator()(RawData data, ReadOperation& op, bool in_isr)
 
   if (data.size_ != 0U)
   {
-    REQUIRE_FROM_CALLBACK(data.addr_ != nullptr, in_isr);
+    ASSERT_FROM_CALLBACK(data.addr_ != nullptr, in_isr);
     if (data.size_ > Capacity())
     {
       ReleaseClaimed(in_isr);
@@ -184,9 +184,9 @@ ErrorCode ReadPort::operator()(RawData data, ReadOperation& op, bool in_isr)
   {
     if (data.size_ != 0U)
     {
-      REQUIRE_FROM_CALLBACK(queue_data_->PopBatch(reinterpret_cast<uint8_t*>(data.addr_),
-                                                  data.size_) == ErrorCode::OK,
-                            in_isr);
+      [[maybe_unused]] const auto pop_batch_result =
+          queue_data_->PopBatch(reinterpret_cast<uint8_t*>(data.addr_), data.size_);
+      DEV_ASSERT_FROM_CALLBACK(pop_batch_result == ErrorCode::OK, in_isr);
     }
 
     Request completed{data, op};
@@ -208,7 +208,7 @@ ErrorCode ReadPort::operator()(RawData data, ReadOperation& op, bool in_isr)
   for (;;)
   {
     uint32_t observed = state_.load(std::memory_order_acquire);
-    REQUIRE_FROM_CALLBACK(GetPhase(observed) == Phase::CLAIMED, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(GetPhase(observed) == Phase::CLAIMED, in_isr);
 
     if (HasEvent(observed))
     {
@@ -270,7 +270,7 @@ void ReadPort::ProcessPendingReads(bool in_isr)
         if (current_phase == Phase::CLAIMED_WITH_WAITER)
         {
           Semaphore* const waiter = info_.op.data.sem_info.sem;
-          REQUIRE_FROM_CALLBACK(waiter != nullptr, in_isr);
+          DEV_ASSERT_FROM_CALLBACK(waiter != nullptr, in_isr);
           const uint32_t desired = WithPhase(current, Phase::IDLE);
           if (state_.compare_exchange_weak(current, desired, std::memory_order_acq_rel,
                                            std::memory_order_acquire))
@@ -281,7 +281,7 @@ void ReadPort::ProcessPendingReads(bool in_isr)
           continue;
         }
 
-        REQUIRE_FROM_CALLBACK(current_phase == Phase::CLAIMED, in_isr);
+        DEV_ASSERT_FROM_CALLBACK(current_phase == Phase::CLAIMED, in_isr);
         const uint32_t desired = WithPhase(current, Phase::PENDING);
         if (state_.compare_exchange_weak(current, desired, std::memory_order_acq_rel,
                                          std::memory_order_acquire))
@@ -311,14 +311,14 @@ void ReadPort::ProcessPendingReads(bool in_isr)
 void ReadPort::CompleteClaimedRead(bool in_isr)
 {
   Request completed = info_;
-  REQUIRE_FROM_CALLBACK(completed.op.type != ReadOperation::OperationType::BLOCK, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(completed.op.type != ReadOperation::OperationType::BLOCK,
+                           in_isr);
 
   if (completed.data.size_ != 0U)
   {
-    REQUIRE_FROM_CALLBACK(
-        queue_data_->PopBatch(reinterpret_cast<uint8_t*>(completed.data.addr_),
-                              completed.data.size_) == ErrorCode::OK,
-        in_isr);
+    [[maybe_unused]] const auto pop_batch_result = queue_data_->PopBatch(
+        reinterpret_cast<uint8_t*>(completed.data.addr_), completed.data.size_);
+    DEV_ASSERT_FROM_CALLBACK(pop_batch_result == ErrorCode::OK, in_isr);
   }
 
   ReleaseClaimed(in_isr);
@@ -332,15 +332,16 @@ void ReadPort::CompleteClaimedRead(bool in_isr)
 void ReadPort::CompleteClaimedBlock(bool in_isr)
 {
   Request completed = info_;
-  REQUIRE_FROM_CALLBACK(completed.op.type == ReadOperation::OperationType::BLOCK, in_isr);
-  REQUIRE_FROM_CALLBACK(ClaimBlockCompletion(), in_isr);
+  DEV_ASSERT_FROM_CALLBACK(completed.op.type == ReadOperation::OperationType::BLOCK,
+                           in_isr);
+  [[maybe_unused]] const auto claim_block_completion_result = ClaimBlockCompletion();
+  DEV_ASSERT_FROM_CALLBACK(claim_block_completion_result, in_isr);
 
   if (completed.data.size_ != 0U)
   {
-    REQUIRE_FROM_CALLBACK(
-        queue_data_->PopBatch(reinterpret_cast<uint8_t*>(completed.data.addr_),
-                              completed.data.size_) == ErrorCode::OK,
-        in_isr);
+    [[maybe_unused]] const auto pop_batch_result = queue_data_->PopBatch(
+        reinterpret_cast<uint8_t*>(completed.data.addr_), completed.data.size_);
+    DEV_ASSERT_FROM_CALLBACK(pop_batch_result == ErrorCode::OK, in_isr);
     OnReadQueueSpaceAvailable(in_isr);
   }
 
@@ -353,7 +354,7 @@ ErrorCode ReadPort::WaitForBlock(ReadOperation& op)
   ErrorCode wait_result = op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
   if (wait_result == ErrorCode::OK)
   {
-    REQUIRE(GetPhase(state_.load(std::memory_order_acquire)) == Phase::BLOCK_CLAIMED);
+    DEV_ASSERT(GetPhase(state_.load(std::memory_order_acquire)) == Phase::BLOCK_CLAIMED);
     const ErrorCode result = block_result_;
     ReleaseBlockCompletion(false);
     return result;
@@ -385,7 +386,7 @@ ErrorCode ReadPort::WaitForBlock(ReadOperation& op)
       continue;
     }
 
-    REQUIRE(phase == Phase::CLAIMED_WITH_WAITER || phase == Phase::BLOCK_CLAIMED);
+    DEV_ASSERT(phase == Phase::CLAIMED_WITH_WAITER || phase == Phase::BLOCK_CLAIMED);
     break;
   }
 
@@ -400,7 +401,7 @@ ErrorCode ReadPort::WaitForBlock(ReadOperation& op)
     return ErrorCode::TIMEOUT;
   }
 
-  REQUIRE(completed_phase == Phase::BLOCK_CLAIMED);
+  DEV_ASSERT(completed_phase == Phase::BLOCK_CLAIMED);
   const ErrorCode result = block_result_;
   ReleaseBlockCompletion(false);
   return result;
@@ -425,7 +426,7 @@ ErrorCode ReadPort::ClearQueuedData(bool in_isr)
 
 void ReadPort::BindQueue(SPSCQueue<uint8_t>* queue)
 {
-  REQUIRE(queue != nullptr);
-  REQUIRE(queue_data_ == nullptr);
+  DEV_ASSERT(queue != nullptr);
+  DEV_ASSERT(queue_data_ == nullptr);
   queue_data_ = queue;
 }

--- a/src/core/rw/read_port.hpp
+++ b/src/core/rw/read_port.hpp
@@ -152,7 +152,7 @@ class ReadPort
           {
             const size_t produced = writer(static_cast<uint8_t*>(first), first_size,
                                            static_cast<uint8_t*>(second), second_size);
-            REQUIRE_FROM_CALLBACK(produced <= first_size + second_size, in_isr_);
+            ASSERT_FROM_CALLBACK(produced <= first_size + second_size, in_isr_);
             return produced;
           });
       dirty_ = dirty_ || (produced != 0U);

--- a/src/core/rw/write_port.cpp
+++ b/src/core/rw/write_port.cpp
@@ -61,12 +61,12 @@ bool WritePort::TryClaimProducer()
   }
 }
 
-void WritePort::ReleaseProducer(Phase next, bool in_isr)
+void WritePort::ReleaseProducer(Phase next, [[maybe_unused]] bool in_isr)
 {
   uint32_t observed = state_.load(std::memory_order_acquire);
   for (;;)
   {
-    REQUIRE_FROM_CALLBACK(GetPhase(observed) == Phase::LOCKED, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(GetPhase(observed) == Phase::LOCKED, in_isr);
     const uint32_t desired = WithPhase(observed, next);
     if (state_.compare_exchange_weak(observed, desired, std::memory_order_acq_rel,
                                      std::memory_order_acquire))
@@ -76,14 +76,14 @@ void WritePort::ReleaseProducer(Phase next, bool in_isr)
   }
 }
 
-void WritePort::PublishQueuedRequest(Phase next, bool in_isr)
+void WritePort::PublishQueuedRequest(Phase next, [[maybe_unused]] bool in_isr)
 {
   uint32_t observed = state_.load(std::memory_order_acquire);
   for (;;)
   {
-    REQUIRE_FROM_CALLBACK(GetPhase(observed) == Phase::LOCKED, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(GetPhase(observed) == Phase::LOCKED, in_isr);
     const uint32_t released = GetReleasedCount(observed);
-    REQUIRE_FROM_CALLBACK(released < MAX_RELEASED_REQUESTS, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(released < MAX_RELEASED_REQUESTS, in_isr);
     const uint32_t desired = MakeState(next, released + 1U);
     if (state_.compare_exchange_weak(observed, desired, std::memory_order_acq_rel,
                                      std::memory_order_acquire))
@@ -93,12 +93,12 @@ void WritePort::PublishQueuedRequest(Phase next, bool in_isr)
   }
 }
 
-void WritePort::DecrementReleasedRequest(bool in_isr)
+void WritePort::DecrementReleasedRequest([[maybe_unused]] bool in_isr)
 {
   uint32_t observed = state_.load(std::memory_order_acquire);
   for (;;)
   {
-    REQUIRE_FROM_CALLBACK(GetReleasedCount(observed) != 0U, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(GetReleasedCount(observed) != 0U, in_isr);
     const uint32_t desired = observed - RELEASED_INCREMENT;
     if (state_.compare_exchange_weak(observed, desired, std::memory_order_acq_rel,
                                      std::memory_order_acquire))
@@ -118,24 +118,25 @@ void WritePort::NotifyBackend(bool in_isr)
 
 WritePort::WriteQueue WritePort::GetWriteQueue(bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(queue_requests_ != nullptr, in_isr);
+  ASSERT_FROM_CALLBACK(queue_requests_ != nullptr, in_isr);
 
   if (GetReleasedCount(state_.load(std::memory_order_acquire)) == 0U)
   {
-    REQUIRE_FROM_CALLBACK(front_remaining_ == 0U, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(front_remaining_ == 0U, in_isr);
     return WriteQueue(*this, in_isr, 0U);
   }
 
   Request request{};
-  REQUIRE_FROM_CALLBACK(queue_requests_->Peek(request) == ErrorCode::OK, in_isr);
+  [[maybe_unused]] const auto peek_result = queue_requests_->Peek(request);
+  DEV_ASSERT_FROM_CALLBACK(peek_result == ErrorCode::OK, in_isr);
   if (front_remaining_ == 0U)
   {
-    REQUIRE_FROM_CALLBACK(request.size != 0U, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(request.size != 0U, in_isr);
     front_remaining_ = request.size;
   }
   else
   {
-    REQUIRE_FROM_CALLBACK(front_remaining_ <= request.size, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(front_remaining_ <= request.size, in_isr);
   }
 
   return WriteQueue(*this, in_isr, front_remaining_);
@@ -145,8 +146,8 @@ void WritePort::WriteQueue::PopAll(uint8_t* destination)
 {
   BeginAction();
   const size_t remaining = AvailableSize();
-  REQUIRE_FROM_CALLBACK(remaining != 0U, in_isr_);
-  REQUIRE_FROM_CALLBACK(destination != nullptr, in_isr_);
+  ASSERT_FROM_CALLBACK(remaining != 0U, in_isr_);
+  ASSERT_FROM_CALLBACK(destination != nullptr, in_isr_);
 
   size_t offset = 0U;
   const size_t accepted = port_.queue_data_->ConsumeWithReader(
@@ -166,18 +167,18 @@ void WritePort::WriteQueue::PopAll(uint8_t* destination)
         }
         return first_size + second_size;
       });
-  REQUIRE_FROM_CALLBACK(accepted == remaining, in_isr_);
+  DEV_ASSERT_FROM_CALLBACK(accepted == remaining, in_isr_);
   popped_size_ += accepted;
 }
 
 void WritePort::WriteQueue::FailFront(ErrorCode reason)
 {
   BeginAction();
-  REQUIRE_FROM_CALLBACK(reason != ErrorCode::OK, in_isr_);
-  REQUIRE_FROM_CALLBACK(front_size_ != 0U, in_isr_);
+  ASSERT_FROM_CALLBACK(reason != ErrorCode::OK, in_isr_);
+  ASSERT_FROM_CALLBACK(front_size_ != 0U, in_isr_);
 
   const size_t remaining = AvailableSize();
-  REQUIRE_FROM_CALLBACK(remaining != 0U, in_isr_);
+  ASSERT_FROM_CALLBACK(remaining != 0U, in_isr_);
   if (remaining != 0U)
   {
     const size_t accepted = port_.queue_data_->ConsumeWithReader(
@@ -189,7 +190,7 @@ void WritePort::WriteQueue::FailFront(ErrorCode reason)
           UNUSED(second);
           return first_size + second_size;
         });
-    REQUIRE_FROM_CALLBACK(accepted == remaining, in_isr_);
+    DEV_ASSERT_FROM_CALLBACK(accepted == remaining, in_isr_);
     popped_size_ += accepted;
   }
   settlement_result_ = reason;
@@ -207,8 +208,8 @@ void WritePort::SettleWriteQueue(size_t accepted, ErrorCode result, bool in_isr)
     return;
   }
 
-  REQUIRE_FROM_CALLBACK(queue_requests_ != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(accepted <= front_remaining_, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(queue_requests_ != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(accepted <= front_remaining_, in_isr);
   front_remaining_ -= accepted;
   if (front_remaining_ != 0U)
   {
@@ -216,7 +217,8 @@ void WritePort::SettleWriteQueue(size_t accepted, ErrorCode result, bool in_isr)
   }
 
   Request completed{};
-  REQUIRE_FROM_CALLBACK(queue_requests_->Pop(completed) == ErrorCode::OK, in_isr);
+  [[maybe_unused]] const auto pop_result = queue_requests_->Pop(completed);
+  DEV_ASSERT_FROM_CALLBACK(pop_result == ErrorCode::OK, in_isr);
   DecrementReleasedRequest(in_isr);
   CompleteRequest(completed, result, in_isr);
 }
@@ -269,24 +271,25 @@ void WritePort::CompleteRequest(Request& request, ErrorCode result, bool in_isr)
 
       Semaphore* waiter = admission_waiter_;
       admission_waiter_ = nullptr;
-      REQUIRE_FROM_CALLBACK(waiter != nullptr, in_isr);
+      DEV_ASSERT_FROM_CALLBACK(waiter != nullptr, in_isr);
       waiter->PostFromCallback(in_isr);
       return;
     }
 
-    REQUIRE_FROM_CALLBACK(false, in_isr);
+    DEV_ASSERT_FROM_CALLBACK(false, in_isr);
     return;
   }
 }
 
 ErrorCode WritePort::CommitQueued(size_t size, WriteOperation& op, bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(queue_requests_ != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(queue_data_ != nullptr, in_isr);
-  REQUIRE_FROM_CALLBACK(size != 0U, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(queue_requests_ != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(queue_data_ != nullptr, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(size != 0U, in_isr);
 
   Request request{size, op};
-  REQUIRE_FROM_CALLBACK(queue_requests_->Push(request) == ErrorCode::OK, in_isr);
+  [[maybe_unused]] const auto push_result = queue_requests_->Push(request);
+  DEV_ASSERT_FROM_CALLBACK(push_result == ErrorCode::OK, in_isr);
   request.op.MarkAsRunning();
 
   PublishQueuedRequest(op.type == WriteOperation::OperationType::BLOCK
@@ -299,10 +302,11 @@ ErrorCode WritePort::CommitQueued(size_t size, WriteOperation& op, bool in_isr)
                                                          : ErrorCode::OK;
 }
 
-ErrorCode WritePort::CommitAdmission(size_t size, WriteOperation& op, bool in_isr)
+ErrorCode WritePort::CommitAdmission([[maybe_unused]] size_t size, WriteOperation& op,
+                                     bool in_isr)
 {
-  REQUIRE_FROM_CALLBACK(IsAdmissionMode(), in_isr);
-  REQUIRE_FROM_CALLBACK(size != 0U, in_isr);
+  DEV_ASSERT_FROM_CALLBACK(IsAdmissionMode(), in_isr);
+  DEV_ASSERT_FROM_CALLBACK(size != 0U, in_isr);
 
   WriteOperation completed = op;
   completed.MarkAsRunning();
@@ -318,7 +322,7 @@ ErrorCode WritePort::CommitAdmission(size_t size, WriteOperation& op, bool in_is
 
 bool WritePort::TryRegisterRetirementWait(WriteOperation& op)
 {
-  REQUIRE(op.type == WriteOperation::OperationType::BLOCK);
+  DEV_ASSERT(op.type == WriteOperation::OperationType::BLOCK);
   admission_waiter_ = op.data.sem_info.sem;
   uint32_t observed = state_.load(std::memory_order_acquire);
   for (;;)
@@ -352,7 +356,7 @@ ErrorCode WritePort::WaitForRetirement(WriteOperation& op)
   ErrorCode wait_result = op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
   if (wait_result == ErrorCode::OK)
   {
-    REQUIRE(LoadPhase() == Phase::LOCKED);
+    DEV_ASSERT(LoadPhase() == Phase::LOCKED);
     return ErrorCode::OK;
   }
 
@@ -372,7 +376,7 @@ ErrorCode WritePort::WaitForRetirement(WriteOperation& op)
       continue;
     }
 
-    REQUIRE(phase == Phase::LOCKED);
+    DEV_ASSERT(phase == Phase::LOCKED);
     break;
   }
 
@@ -390,12 +394,12 @@ ErrorCode WritePort::WaitForBlock(WriteOperation& op)
   ErrorCode wait_result = op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
   if (wait_result == ErrorCode::OK)
   {
-    REQUIRE(LoadPhase() == Phase::BLOCK_CLAIMED);
+    DEV_ASSERT(LoadPhase() == Phase::BLOCK_CLAIMED);
     const ErrorCode result = block_result_;
     uint32_t observed = state_.load(std::memory_order_acquire);
     for (;;)
     {
-      REQUIRE(GetPhase(observed) == Phase::BLOCK_CLAIMED);
+      DEV_ASSERT(GetPhase(observed) == Phase::BLOCK_CLAIMED);
       const uint32_t desired = WithPhase(observed, Phase::IDLE);
       if (state_.compare_exchange_weak(observed, desired, std::memory_order_acq_rel,
                                        std::memory_order_acquire))
@@ -421,7 +425,7 @@ ErrorCode WritePort::WaitForBlock(WriteOperation& op)
       continue;
     }
 
-    REQUIRE(phase == Phase::BLOCK_CLAIMED);
+    DEV_ASSERT(phase == Phase::BLOCK_CLAIMED);
     break;
   }
 
@@ -434,7 +438,7 @@ ErrorCode WritePort::WaitForBlock(WriteOperation& op)
   uint32_t observed = state_.load(std::memory_order_acquire);
   for (;;)
   {
-    REQUIRE(GetPhase(observed) == Phase::BLOCK_CLAIMED);
+    DEV_ASSERT(GetPhase(observed) == Phase::BLOCK_CLAIMED);
     const uint32_t desired = WithPhase(observed, Phase::IDLE);
     if (state_.compare_exchange_weak(observed, desired, std::memory_order_acq_rel,
                                      std::memory_order_acquire))
@@ -478,7 +482,7 @@ ErrorCode WritePort::operator()(ConstRawData data, WriteOperation& op, bool in_i
     }
   }
 
-  REQUIRE_FROM_CALLBACK(data.addr_ != nullptr, in_isr);
+  ASSERT_FROM_CALLBACK(data.addr_ != nullptr, in_isr);
 
   if (queue_data_->EmptySize() < data.size_ ||
       (!IsAdmissionMode() && queue_requests_->EmptySize() < 1U))
@@ -487,10 +491,9 @@ ErrorCode WritePort::operator()(ConstRawData data, WriteOperation& op, bool in_i
     return ErrorCode::FULL;
   }
 
-  REQUIRE_FROM_CALLBACK(
-      queue_data_->PushBatch(reinterpret_cast<const uint8_t*>(data.addr_), data.size_) ==
-          ErrorCode::OK,
-      in_isr);
+  [[maybe_unused]] const auto push_batch_result =
+      queue_data_->PushBatch(reinterpret_cast<const uint8_t*>(data.addr_), data.size_);
+  DEV_ASSERT_FROM_CALLBACK(push_batch_result == ErrorCode::OK, in_isr);
 
   return IsAdmissionMode() ? CommitAdmission(data.size_, op, in_isr)
                            : CommitQueued(data.size_, op, in_isr);

--- a/src/core/rw/write_port.hpp
+++ b/src/core/rw/write_port.hpp
@@ -92,7 +92,7 @@ class WritePort
   /// 检查请求容量是否可由状态字表示 / Check that request capacity fits the state word.
   static size_t ValidateQueueSize(size_t queue_size)
   {
-    REQUIRE(queue_size <= MAX_RELEASED_REQUESTS);
+    ASSERT(queue_size <= MAX_RELEASED_REQUESTS);
     return queue_size;
   }
 
@@ -166,7 +166,7 @@ class WritePort
      */
     [[nodiscard]] size_t AvailableSize() const
     {
-      ASSERT_FROM_CALLBACK(popped_size_ <= front_size_, in_isr_);
+      DEV_ASSERT_FROM_CALLBACK(popped_size_ <= front_size_, in_isr_);
       return front_size_ - popped_size_;
     }
 
@@ -226,7 +226,7 @@ class WritePort
               size_t second_size) -> size_t
           {
             const size_t accepted = writer(first, first_size, second, second_size);
-            REQUIRE_FROM_CALLBACK(accepted <= first_size + second_size, in_isr_);
+            ASSERT_FROM_CALLBACK(accepted <= first_size + second_size, in_isr_);
             return accepted;
           });
       popped_size_ += accepted;
@@ -251,7 +251,7 @@ class WritePort
     /// 检查并记录本接口唯一一次出队操作 / Check and record the single permitted action.
     void BeginAction()
     {
-      REQUIRE_FROM_CALLBACK(!action_used_, in_isr_);
+      ASSERT_FROM_CALLBACK(!action_used_, in_isr_);
       action_used_ = true;
     }
 

--- a/src/core/rw/write_stream.cpp
+++ b/src/core/rw/write_stream.cpp
@@ -71,24 +71,24 @@ ErrorCode WritePort::Stream::Write(ConstRawData data)
     return acquire_result;
   }
 
-  REQUIRE(data.addr_ != nullptr);
+  ASSERT(data.addr_ != nullptr);
 
   if (port_->queue_data_ == nullptr || port_->queue_data_->EmptySize() < data.size_)
   {
     return ErrorCode::FULL;
   }
 
-  const ErrorCode result = port_->queue_data_->PushBatch(
+  [[maybe_unused]] const ErrorCode result = port_->queue_data_->PushBatch(
       reinterpret_cast<const uint8_t*>(data.addr_), data.size_);
-  REQUIRE(result == ErrorCode::OK);
+  DEV_ASSERT(result == ErrorCode::OK);
   buffered_size_ += data.size_;
   return ErrorCode::OK;
 }
 
 ErrorCode WritePort::Stream::SubmitBuffered()
 {
-  REQUIRE(owns_port_);
-  REQUIRE(buffered_size_ != 0U);
+  DEV_ASSERT(owns_port_);
+  DEV_ASSERT(buffered_size_ != 0U);
 
   const size_t size = buffered_size_;
   buffered_size_ = 0U;
@@ -103,7 +103,7 @@ void WritePort::Stream::Release()
   {
     return;
   }
-  REQUIRE(buffered_size_ == 0U);
+  DEV_ASSERT(buffered_size_ == 0U);
   owns_port_ = false;
   port_->ReleaseProducer(WritePort::Phase::IDLE, false);
 }

--- a/src/driver/usb/core/bos.hpp
+++ b/src/driver/usb/core/bos.hpp
@@ -207,7 +207,7 @@ class BosManager
     for (size_t i = 0; i < count_; ++i)
     {
       ConstRawData blk = caps_[i]->GetCapabilityDescriptor();
-      ASSERT(offset + blk.size_ <= bos_buffer_.size_);
+      DEV_ASSERT(offset + blk.size_ <= bos_buffer_.size_);
 
       LibXR::Memory::FastCopy(&buffer[offset], blk.addr_, blk.size_);
       offset += blk.size_;
@@ -215,7 +215,7 @@ class BosManager
 
     if (NEED_AUTO_USB2_EXT)
     {
-      ASSERT(offset + sizeof(USB2_EXT_CAP) <= bos_buffer_.size_);
+      DEV_ASSERT(offset + sizeof(USB2_EXT_CAP) <= bos_buffer_.size_);
       LibXR::Memory::FastCopy(&buffer[offset], USB2_EXT_CAP, sizeof(USB2_EXT_CAP));
       offset += sizeof(USB2_EXT_CAP);
     }

--- a/src/driver/usb/core/desc_cfg.cpp
+++ b/src/driver/usb/core/desc_cfg.cpp
@@ -93,14 +93,14 @@ LibXR::ErrorCode ConfigDescriptor::BuildConfigDescriptor(
     }
 
     auto data = item->GetData();
-    ASSERT(offset + data.size_ <= buffer_.size_);
+    DEV_ASSERT(offset + data.size_ <= buffer_.size_);
     LibXR::Memory::FastCopy(&buffer[offset], data.addr_, data.size_);
     offset += data.size_;
 
     total_interfaces = static_cast<uint8_t>(total_interfaces + item->GetInterfaceCount());
   }
 
-  ASSERT(offset <= 0xFFFF);
+  DEV_ASSERT(offset <= 0xFFFF);
   header->wTotalLength = static_cast<uint16_t>(offset);
   header->bNumInterfaces = total_interfaces;
 

--- a/src/driver/usb/device/cdc/cdc_to_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_to_uart.hpp
@@ -64,13 +64,13 @@ class CDCToUart : public CDCUart
               LibXR::min(cdc_to_uart->read_port_->Size(), cdc_to_uart->rx_buffer_.size_);
 
           static ReadOperation op_read_cdc_noblock;
-          auto ans = cdc_to_uart->Read({cdc_to_uart->rx_buffer_.addr_, size},
-                                       op_read_cdc_noblock, in_isr);
-          ASSERT(ans == ErrorCode::OK);
+          [[maybe_unused]] auto ans = cdc_to_uart->Read(
+              {cdc_to_uart->rx_buffer_.addr_, size}, op_read_cdc_noblock, in_isr);
+          DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
 
           ans = cdc_to_uart->uart_.Write({cdc_to_uart->rx_buffer_.addr_, size},
                                          cdc_to_uart->op_write_uart_, in_isr);
-          ASSERT(ans == ErrorCode::OK);
+          DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
         },
         this);
 
@@ -82,8 +82,9 @@ class CDCToUart : public CDCUart
     cb_uart_write_ = Callback<ErrorCode>::CreateGuarded(
         [](bool in_isr, CDCToUart* cdc_to_uart, ErrorCode)
         {
-          auto ans = cdc_to_uart->Read({nullptr, 0}, cdc_to_uart->op_read_cdc_, in_isr);
-          ASSERT(ans == ErrorCode::OK);
+          [[maybe_unused]] auto ans =
+              cdc_to_uart->Read({nullptr, 0}, cdc_to_uart->op_read_cdc_, in_isr);
+          DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
         },
         this);
 
@@ -99,13 +100,13 @@ class CDCToUart : public CDCUart
                                  cdc_to_uart->tx_buffer_.size_);
           static ReadOperation op_read_uart_noblock;
 
-          auto ans = cdc_to_uart->uart_.Read({cdc_to_uart->tx_buffer_.addr_, size},
-                                             op_read_uart_noblock, in_isr);
-          ASSERT(ans == ErrorCode::OK);
+          [[maybe_unused]] auto ans = cdc_to_uart->uart_.Read(
+              {cdc_to_uart->tx_buffer_.addr_, size}, op_read_uart_noblock, in_isr);
+          DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
 
           ans = cdc_to_uart->Write({cdc_to_uart->tx_buffer_.addr_, size},
                                    cdc_to_uart->op_write_cdc_, in_isr);
-          ASSERT(ans == ErrorCode::OK);
+          DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
         },
         this);
 
@@ -117,9 +118,9 @@ class CDCToUart : public CDCUart
     cb_cdc_write_ = Callback<ErrorCode>::CreateGuarded(
         [](bool in_isr, CDCToUart* cdc_to_uart, ErrorCode)
         {
-          auto ans_uart_read =
+          [[maybe_unused]] auto ans_uart_read =
               cdc_to_uart->uart_.Read({nullptr, 0}, cdc_to_uart->op_read_uart_, in_isr);
-          ASSERT(ans_uart_read == ErrorCode::OK);
+          DEV_ASSERT_FROM_CALLBACK(ans_uart_read == ErrorCode::OK, in_isr);
         },
         this);
 

--- a/src/driver/usb/device/cdc/cdc_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_uart.hpp
@@ -156,10 +156,10 @@ class CDCUart : public CDCBase, public LibXR::UART
         return false;
       }
 
-      const auto ans =
+      [[maybe_unused]] const auto ans =
           queue.PushBatch(static_cast<const uint8_t*>(read_port_cdc_.pending_data_.addr_),
                           read_port_cdc_.pending_data_.size_);
-      ASSERT(ans == ErrorCode::OK);
+      DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
       read_port_cdc_.pending_data_ = {nullptr, 0};
       queue.Publish();
     }
@@ -169,7 +169,7 @@ class CDCUart : public CDCBase, public LibXR::UART
       return false;
     }
 
-    const auto ans = ep->Transfer(ep->MaxPacketSize());
+    [[maybe_unused]] const auto ans = ep->Transfer(ep->MaxPacketSize());
     if (ans == ErrorCode::OK)
     {
       read_port_cdc_.recv_pause_ = false;
@@ -224,9 +224,9 @@ class CDCUart : public CDCBase, public LibXR::UART
         return;
       }
 
-      const auto ans =
+      [[maybe_unused]] const auto ans =
           queue.PushBatch(static_cast<const uint8_t*>(data.addr_), data.size_);
-      ASSERT(ans == ErrorCode::OK);
+      DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
       queue.Publish();
     }
     (void)TryRearmOut(in_isr);
@@ -251,8 +251,8 @@ class CDCUart : public CDCBase, public LibXR::UART
     {
       if (ep->GetActiveLength() == 0U && write_port_cdc_.Size() == 0U)
       {
-        const auto ans = ep->TransferZLP();
-        ASSERT(ans == ErrorCode::OK);
+        [[maybe_unused]] const auto ans = ep->TransferZLP();
+        DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
         need_write_zlp_ = false;
         return;
       }
@@ -265,14 +265,15 @@ class CDCUart : public CDCBase, public LibXR::UART
   /**
    * @brief 启动已填充的 IN 缓冲区 / Start the filled IN buffer
    * @param ep 数据 IN 端点 / Data IN endpoint
+   * @param in_isr 是否在中断中调用 / Whether called in an ISR
    */
-  void StartTxBuffer(Endpoint& ep)
+  void StartTxBuffer(Endpoint& ep, [[maybe_unused]] bool in_isr)
   {
     const size_t LENGTH = ep.GetActiveLength();
-    ASSERT(LENGTH != 0U);
+    DEV_ASSERT_FROM_CALLBACK(LENGTH != 0U, in_isr);
     ep.SetActiveLength(0U);
-    const auto ans = ep.Transfer(LENGTH);
-    ASSERT(ans == ErrorCode::OK);
+    [[maybe_unused]] const auto ans = ep.Transfer(LENGTH);
+    DEV_ASSERT_FROM_CALLBACK(ans == ErrorCode::OK, in_isr);
     const size_t MPS = ep.MaxPacketSize();
     need_write_zlp_ = MPS != 0U && LENGTH % MPS == 0U;
   }
@@ -310,12 +311,12 @@ class CDCUart : public CDCBase, public LibXR::UART
                               }
                               return first_size + second_size;
                             });
-    ASSERT(LENGTH != 0U && LENGTH <= UINT16_MAX);
+    DEV_ASSERT_FROM_CALLBACK(LENGTH != 0U && LENGTH <= UINT16_MAX, in_isr);
     ep.SetActiveLength(static_cast<uint16_t>(LENGTH));
     need_write_zlp_ = false;
     if (ep.GetState() == Endpoint::State::IDLE)
     {
-      StartTxBuffer(ep);
+      StartTxBuffer(ep, in_isr);
     }
   }
 
@@ -334,7 +335,7 @@ class CDCUart : public CDCBase, public LibXR::UART
 
     if (ep->GetActiveLength() != 0U)
     {
-      StartTxBuffer(*ep);
+      StartTxBuffer(*ep, in_isr);
     }
     else
     {

--- a/src/driver/usb/device/device_composition.cpp
+++ b/src/driver/usb/device/device_composition.cpp
@@ -744,7 +744,7 @@ void DeviceComposition::RegisterInterfaceStrings()
       // 这样 DeviceCore 之后可以按索引重新生成任意接口字符串，而不必重扫全部 class。
       // Keep a flat source-string table so DeviceCore can later regenerate any
       // interface string by index without re-scanning all classes.
-      ASSERT(registered_count < interface_string_count_);
+      DEV_ASSERT(registered_count < interface_string_count_);
       if (!class_has_string)
       {
         device_class->SetInterfaceStringBaseIndex(next_index);
@@ -755,5 +755,5 @@ void DeviceComposition::RegisterInterfaceStrings()
     }
   }
 
-  ASSERT(registered_count == interface_string_count_);
+  DEV_ASSERT(registered_count == interface_string_count_);
 }

--- a/src/driver/usb/device/uac/uac_mic.hpp
+++ b/src/driver/usb/device/uac/uac_mic.hpp
@@ -533,7 +533,7 @@ class UAC1MicrophoneQ : public DeviceClass
         default:
           break;
       }
-      ASSERT(false);
+
       return ErrorCode::ARG_ERR;  // 长度不符等 / length mismatch, etc.
     }
 
@@ -547,12 +547,10 @@ class UAC1MicrophoneQ : public DeviceClass
 
     if (ITF != itf_ac_num_ || ENT != ID_FU)
     {
-      ASSERT(false);
       return ErrorCode::NOT_SUPPORT;
     }
     if (CH > CHANNELS)
     {
-      ASSERT(false);
       return ErrorCode::ARG_ERR;
     }
 
@@ -569,7 +567,7 @@ class UAC1MicrophoneQ : public DeviceClass
           r.write_data = ConstRawData{&mute_, 1};
           return ErrorCode::OK;
         }
-        ASSERT(false);
+
         return ErrorCode::ARG_ERR;
 
       case FU_VOLUME:
@@ -619,11 +617,11 @@ class UAC1MicrophoneQ : public DeviceClass
           default:
             break;
         }
-        ASSERT(false);
+
         return ErrorCode::ARG_ERR;
 
       default:
-        ASSERT(false);
+
         return ErrorCode::NOT_SUPPORT;
     }
   }
@@ -659,7 +657,6 @@ class UAC1MicrophoneQ : public DeviceClass
   {
     if (itf != itf_as_num_)
     {
-      ASSERT(false);
       return ErrorCode::NOT_SUPPORT;
     }
     alt = streaming_ ? 1 : 0;
@@ -674,12 +671,11 @@ class UAC1MicrophoneQ : public DeviceClass
   {
     if (itf != itf_as_num_)
     {
-      ASSERT(false);
       return ErrorCode::NOT_SUPPORT;
     }
     if (!ep_iso_in_)
     {
-      ASSERT(false);
+      DEV_ASSERT(false);
       return ErrorCode::FAILED;
     }
 
@@ -701,7 +697,7 @@ class UAC1MicrophoneQ : public DeviceClass
         return ErrorCode::OK;
 
       default:
-        ASSERT(false);
+
         return ErrorCode::ARG_ERR;
     }
   }

--- a/src/middleware/database/interface.hpp
+++ b/src/middleware/database/interface.hpp
@@ -74,7 +74,8 @@ class Database
         data_ = init_value;
         if (status == ErrorCode::NOT_FOUND)
         {
-          REQUIRE(database.Add(*this) == ErrorCode::OK);
+          [[maybe_unused]] const auto add_result = database.Add(*this);
+          REQUIRE(add_result == ErrorCode::OK);
         }
       }
     }
@@ -99,7 +100,8 @@ class Database
         Memory::FastSet(&data_, 0, sizeof(Data));
         if (status == ErrorCode::NOT_FOUND)
         {
-          REQUIRE(database.Add(*this) == ErrorCode::OK);
+          [[maybe_unused]] const auto add_result = database.Add(*this);
+          REQUIRE(add_result == ErrorCode::OK);
         }
       }
     }

--- a/src/middleware/database/raw/block_ops.hpp
+++ b/src/middleware/database/raw/block_ops.hpp
@@ -223,7 +223,7 @@ void CopyBlockPrefixAndChecksum(BlockType dst_block, BlockType src_block,
   const size_t src_offset = GetBlockOffset(src_block);
   const size_t checksum_offset = GetChecksumOffset();
 
-  ASSERT(used_size <= checksum_offset);
+  DEV_ASSERT(used_size <= checksum_offset);
   // Only the live key prefix and checksum are needed; erased tail bytes are irrelevant.
   CopyFlashData(dst_offset, src_offset, used_size);
   CopyFlashData(dst_offset + checksum_offset, src_offset + checksum_offset,

--- a/src/middleware/database/raw/flash_io.hpp
+++ b/src/middleware/database/raw/flash_io.hpp
@@ -17,7 +17,8 @@
  */
 void ReadFlashOrExit(size_t offset, RawData data)
 {
-  REQUIRE(flash_.Read(offset, data) == ErrorCode::OK);
+  [[maybe_unused]] const auto flash_io_result = flash_.Read(offset, data);
+  REQUIRE(flash_io_result == ErrorCode::OK);
 }
 
 /**
@@ -41,7 +42,8 @@ void ReadFlashOrExit(size_t offset, Data& data)
  */
 void WriteFlashOrExit(size_t offset, ConstRawData data)
 {
-  REQUIRE(Write(offset, data) == ErrorCode::OK);
+  [[maybe_unused]] const auto flash_io_result = Write(offset, data);
+  REQUIRE(flash_io_result == ErrorCode::OK);
 }
 
 /**
@@ -65,7 +67,8 @@ void WriteFlashOrExit(size_t offset, const Data& data)
  */
 void EraseFlashOrExit(size_t offset, size_t size)
 {
-  REQUIRE(flash_.Erase(offset, size) == ErrorCode::OK);
+  [[maybe_unused]] const auto flash_io_result = flash_.Erase(offset, size);
+  REQUIRE(flash_io_result == ErrorCode::OK);
 }
 
 /**

--- a/src/middleware/database/raw/key_ops.hpp
+++ b/src/middleware/database/raw/key_ops.hpp
@@ -41,7 +41,6 @@ add_again:
     }
     else
     {
-      ASSERT(false);
       return ErrorCode::FULL;
     }
   }
@@ -186,7 +185,6 @@ ErrorCode SetKey(const char* name, const void* data, size_t size, bool recycle =
           }
           else
           {
-            ASSERT(false);
             return ErrorCode::FULL;
           }
         }

--- a/src/middleware/database/raw_sequential.cpp
+++ b/src/middleware/database/raw_sequential.cpp
@@ -63,17 +63,20 @@ uint32_t DatabaseRawSequential::KeyInfo::GetDataSize() const
 
 void DatabaseRawSequential::ReadFlashOrExit(size_t offset, RawData data)
 {
-  REQUIRE(flash_.Read(offset, data) == ErrorCode::OK);
+  [[maybe_unused]] const auto flash_io_result = flash_.Read(offset, data);
+  REQUIRE(flash_io_result == ErrorCode::OK);
 }
 
 void DatabaseRawSequential::WriteFlashOrExit(size_t offset, ConstRawData data)
 {
-  REQUIRE(flash_.Write(offset, data) == ErrorCode::OK);
+  [[maybe_unused]] const auto flash_io_result = flash_.Write(offset, data);
+  REQUIRE(flash_io_result == ErrorCode::OK);
 }
 
 void DatabaseRawSequential::EraseFlashOrExit(size_t offset, size_t size)
 {
-  REQUIRE(flash_.Erase(offset, size) == ErrorCode::OK);
+  [[maybe_unused]] const auto flash_io_result = flash_.Erase(offset, size);
+  REQUIRE(flash_io_result == ErrorCode::OK);
 }
 
 void DatabaseRawSequential::Init()
@@ -334,7 +337,7 @@ ErrorCode DatabaseRawSequential::SetKey(const char* name, const void* data, size
 
 ErrorCode DatabaseRawSequential::SetKey(size_t offset, const void* data, size_t size)
 {
-  ASSERT(offset != 0);
+  DEV_ASSERT(offset != 0);
 
   KeyInfo key;
   ReadFlashOrExit(offset, key);

--- a/src/middleware/message/subscriber/sync.hpp
+++ b/src/middleware/message/subscriber/sync.hpp
@@ -184,7 +184,8 @@ class Topic::SyncSubscriber
       return wait_ans;
     }
 
-    ASSERT(data.wait_state.load(std::memory_order_acquire) == SyncBlock::WAIT_CLAIMED);
+    DEV_ASSERT(data.wait_state.load(std::memory_order_acquire) ==
+               SyncBlock::WAIT_CLAIMED);
 
     ErrorCode finish_wait_ans;
     do

--- a/src/middleware/terminal/display.hpp
+++ b/src/middleware/terminal/display.hpp
@@ -40,8 +40,8 @@ static size_t HistoryLineSize(const HistoryLine& line)
  */
 const HistoryLine& HistoryFromNewest(int index_from_newest)
 {
-  ASSERT(index_from_newest >= 0);
-  ASSERT(index_from_newest < static_cast<int>(history_.Size()));
+  DEV_ASSERT(index_from_newest >= 0);
+  DEV_ASSERT(index_from_newest < static_cast<int>(history_.Size()));
   return history_[-index_from_newest - 1];
 }
 

--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -216,8 +216,8 @@ class BasicObjectPool
         return;
       }
 
-      const ErrorCode ec = pool_->Release(index_);
-      ASSERT(ec == ErrorCode::OK);
+      [[maybe_unused]] const ErrorCode ec = pool_->Release(index_);
+      DEV_ASSERT(ec == ErrorCode::OK);
       pool_ = nullptr;
       index_ = IndexType{};
     }
@@ -353,7 +353,7 @@ class BasicObjectPool
       return ec;
     }
 
-    ASSERT(static_cast<size_t>(index) < slot_count_);
+    DEV_ASSERT(static_cast<size_t>(index) < slot_count_);
     handle = Handle(this, index);
     return ErrorCode::OK;
   }
@@ -417,7 +417,7 @@ class BasicObjectPool
    */
   ErrorCode Release(IndexType index)
   {
-    ASSERT(static_cast<size_t>(index) < slot_count_);
+    DEV_ASSERT(static_cast<size_t>(index) < slot_count_);
     return free_queue_->Push(index);
   }
 
@@ -453,8 +453,9 @@ class BasicObjectPool
     ASSERT(slot_count_ - 1 <= static_cast<size_t>(std::numeric_limits<IndexType>::max()));
     for (size_t index = 0; index < slot_count_; ++index)
     {
-      const ErrorCode ec = free_queue_->Push(static_cast<IndexType>(index));
-      ASSERT(ec == ErrorCode::OK);
+      [[maybe_unused]] const ErrorCode ec =
+          free_queue_->Push(static_cast<IndexType>(index));
+      DEV_ASSERT(ec == ErrorCode::OK);
     }
   }
 

--- a/src/structure/queue/mpmc_queue_base.cpp
+++ b/src/structure/queue/mpmc_queue_base.cpp
@@ -21,9 +21,9 @@ MPMCQueueBase::MPMCQueueBase(size_t element_size, size_t capacity)
       head_(0),
       tail_(0)
 {
-  REQUIRE(element_size_ > 0);
-  REQUIRE(capacity_ > 1);
-  REQUIRE(capacity_ <= static_cast<size_t>(std::numeric_limits<SequenceDiffType>::max()));
+  ASSERT(element_size_ > 0);
+  ASSERT(capacity_ > 1);
+  ASSERT(capacity_ <= static_cast<size_t>(std::numeric_limits<SequenceDiffType>::max()));
 
   const size_t payload_bytes = MultiplyChecked(payload_stride_, capacity_);
   sequences_ = new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_];
@@ -170,8 +170,8 @@ const void* MPMCQueueBase::PayloadPtr(size_t index) const
  */
 size_t MPMCQueueBase::AlignUpChecked(size_t value, size_t align)
 {
-  REQUIRE(align > 0);
-  REQUIRE(value <= std::numeric_limits<size_t>::max() - (align - 1));
+  ASSERT(align > 0);
+  ASSERT(value <= std::numeric_limits<size_t>::max() - (align - 1));
   return ((value + align - 1) / align) * align;
 }
 
@@ -188,7 +188,7 @@ size_t MPMCQueueBase::MultiplyChecked(size_t lhs, size_t rhs)
     return 0;
   }
 
-  REQUIRE(lhs <= std::numeric_limits<size_t>::max() / rhs);
+  ASSERT(lhs <= std::numeric_limits<size_t>::max() / rhs);
   return lhs * rhs;
 }
 

--- a/src/structure/queue/spsc_queue_base.hpp
+++ b/src/structure/queue/spsc_queue_base.hpp
@@ -307,7 +307,7 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
     void* const second = second_count == 0U ? nullptr : PayloadPtr(0U);
     const size_t produced =
         writer(PayloadPtr(current_tail), first_count, second, second_count);
-    REQUIRE(produced <= offered);
+    ASSERT(produced <= offered);
     if (produced != 0U)
     {
       tail_.store((current_tail + produced) % capacity, std::memory_order_release);
@@ -455,7 +455,7 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
     const void* const second = second_count == 0U ? nullptr : PayloadPtr(0U);
     const size_t accepted =
         reader(PayloadPtr(current_head), first_count, second, second_count);
-    REQUIRE(accepted <= offered);
+    ASSERT(accepted <= offered);
     if (accepted != 0U)
     {
       head_.store((current_head + accepted) % capacity, std::memory_order_release);

--- a/system/freertos/libxr_system.cpp
+++ b/system/freertos/libxr_system.cpp
@@ -15,7 +15,7 @@ extern "C" __attribute__((weak)) void vApplicationStackOverflowHook(TaskHandle_t
   static volatile const char* task_name = pcTaskName;
   UNUSED(task_name);
   UNUSED(xTask);
-  ASSERT(false);
+  REQUIRE(false);
 }
 
 uint32_t LibXR::libxr_freertos_timebase_tick_offset = 0;

--- a/system/freertos/mutex.cpp
+++ b/system/freertos/mutex.cpp
@@ -6,7 +6,7 @@ using namespace LibXR;
 
 Mutex::Mutex() : mutex_handle_(xSemaphoreCreateMutex())
 {
-  ASSERT(mutex_handle_ != nullptr);
+  REQUIRE(mutex_handle_ != nullptr);
 }
 
 Mutex::~Mutex()

--- a/system/freertos/semaphore.cpp
+++ b/system/freertos/semaphore.cpp
@@ -8,7 +8,7 @@ using namespace LibXR;
 Semaphore::Semaphore(uint32_t init_count)
     : semaphore_handle_(xSemaphoreCreateCounting(UINT32_MAX, init_count))
 {
-  ASSERT(semaphore_handle_ != nullptr);
+  REQUIRE(semaphore_handle_ != nullptr);
 }
 
 Semaphore::~Semaphore() { vSemaphoreDelete(semaphore_handle_); }

--- a/system/freertos/thread.hpp
+++ b/system/freertos/thread.hpp
@@ -65,7 +65,7 @@ class Thread
   void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
-    ASSERT(configMAX_PRIORITIES >= 6);
+    static_assert(configMAX_PRIORITIES >= 6);
 
     class ThreadBlock
     {
@@ -96,7 +96,7 @@ class Thread
                            static_cast<uint32_t>(priority), &(this->thread_handle_));
     UNUSED(ans);
     UNUSED(block);
-    ASSERT(ans == pdPASS);
+    REQUIRE(ans == pdPASS);
   }
 
   /**

--- a/system/linux/libxr_system.cpp
+++ b/system/linux/libxr_system.cpp
@@ -92,7 +92,8 @@ void StdiThread(LibXR::ReadPort* read_port)
           queue.Publish();
           continue;
         }
-        REQUIRE(queue.PushBatch(read_buff, size) == LibXR::ErrorCode::OK);
+        [[maybe_unused]] const auto push_batch_result = queue.PushBatch(read_buff, size);
+        DEV_ASSERT(push_batch_result == LibXR::ErrorCode::OK);
         queue.Publish();
       }
     }

--- a/system/linux/linux_shared_topic_impl.hpp
+++ b/system/linux/linux_shared_topic_impl.hpp
@@ -449,7 +449,7 @@ class LinuxSharedTopic : public Topic
         {
           topic.subscribers_[i].queue_head.store(0, std::memory_order_release);
           topic.subscribers_[i].queue_tail.store(0, std::memory_order_release);
-          topic.subscribers_[i].ready_sem_count.store(0, std::memory_order_release);
+          topic.subscribers_[i].ready_signal.store(0, std::memory_order_release);
           topic.subscribers_[i].dropped_messages.store(0, std::memory_order_release);
           topic.subscribers_[i].owner_pid.store(topic.self_identity_.pid,
                                                 std::memory_order_release);
@@ -949,7 +949,8 @@ class LinuxSharedTopic : public Topic
     std::atomic<uint32_t> mode;
     std::atomic<uint32_t> queue_head;
     std::atomic<uint32_t> queue_tail;
-    std::atomic<uint32_t> ready_sem_count;
+    std::atomic<uint32_t>
+        ready_signal;  ///< 唤醒提示，不表示队列长度 / Wake hint, not size.
     std::atomic<uint64_t> dropped_messages;
     std::atomic<uint32_t> owner_pid;
     std::atomic<uint64_t> owner_starttime;
@@ -968,7 +969,7 @@ class LinuxSharedTopic : public Topic
   };
 
   static constexpr uint64_t MAGIC = 0x4c58524950435348ULL;
-  static constexpr uint32_t VERSION = 2;
+  static constexpr uint32_t VERSION = 3;
   static constexpr uint32_t INIT_READY = 1;
   static constexpr uint32_t INVALID_INDEX = UINT32_MAX;
 
@@ -1261,7 +1262,7 @@ class LinuxSharedTopic : public Topic
           std::memory_order_release);
       subscribers_[i].queue_head.store(0, std::memory_order_release);
       subscribers_[i].queue_tail.store(0, std::memory_order_release);
-      subscribers_[i].ready_sem_count.store(0, std::memory_order_release);
+      subscribers_[i].ready_signal.store(0, std::memory_order_release);
       subscribers_[i].dropped_messages.store(0, std::memory_order_release);
       subscribers_[i].owner_pid.store(0, std::memory_order_release);
       subscribers_[i].owner_starttime.store(0, std::memory_order_release);
@@ -1637,20 +1638,19 @@ class LinuxSharedTopic : public Topic
 
   static void PostReady(SubscriberControl& control)
   {
-    control.ready_sem_count.fetch_add(1, std::memory_order_release);
-    FutexWake(&control.ready_sem_count);
+    control.ready_signal.store(1, std::memory_order_release);
+    FutexWake(&control.ready_signal);
   }
 
-  static void ConsumeReady(SubscriberControl& control)
+  static bool HasQueuedData(const SubscriberControl& control)
   {
-    [[maybe_unused]] const uint32_t prev =
-        control.ready_sem_count.fetch_sub(1, std::memory_order_acq_rel);
-    DEV_ASSERT(prev > 0);
+    return control.queue_head.load(std::memory_order_acquire) !=
+           control.queue_tail.load(std::memory_order_acquire);
   }
 
   static ErrorCode WaitReady(SubscriberControl& control, uint32_t timeout_ms)
   {
-    if (control.ready_sem_count.load(std::memory_order_acquire) != 0)
+    if (HasQueuedData(control))
     {
       return ErrorCode::OK;
     }
@@ -1660,7 +1660,10 @@ class LinuxSharedTopic : public Topic
 
     while (true)
     {
-      if (control.ready_sem_count.load(std::memory_order_acquire) != 0)
+      // 先清提示再检查队列，覆盖检查与进入 futex 等待之间的发布。
+      // Clear the hint before checking the queue so a later publication prevents sleep.
+      control.ready_signal.exchange(0, std::memory_order_acq_rel);
+      if (HasQueuedData(control))
       {
         return ErrorCode::OK;
       }
@@ -1677,7 +1680,7 @@ class LinuxSharedTopic : public Topic
 
       wait_ms = MonotonicTime::WaitSliceMilliseconds(wait_ms);
 
-      const int futex_ans = FutexWait(&control.ready_sem_count, 0, wait_ms);
+      const int futex_ans = FutexWait(&control.ready_signal, 0, wait_ms);
       if (futex_ans == 0 || errno == EAGAIN || errno == EINTR)
       {
         continue;
@@ -1690,7 +1693,7 @@ class LinuxSharedTopic : public Topic
           continue;
         }
         if (MonotonicTime::RemainingMilliseconds(deadline_ms) == 0 &&
-            control.ready_sem_count.load(std::memory_order_acquire) == 0)
+            !HasQueuedData(control))
         {
           return ErrorCode::TIMEOUT;
         }
@@ -1763,7 +1766,6 @@ class LinuxSharedTopic : public Topic
       if (control.queue_head.compare_exchange_weak(
               head, next_head, std::memory_order_acq_rel, std::memory_order_relaxed))
       {
-        ConsumeReady(control);
         return ErrorCode::OK;
       }
     }
@@ -1789,7 +1791,6 @@ class LinuxSharedTopic : public Topic
               head, next_head, std::memory_order_acq_rel, std::memory_order_relaxed))
       {
         control.dropped_messages.fetch_add(1, std::memory_order_relaxed);
-        ConsumeReady(control);
         ReleaseSlot(descriptor.slot_index);
         return ErrorCode::OK;
       }

--- a/system/linux/linux_shared_topic_impl.hpp
+++ b/system/linux/linux_shared_topic_impl.hpp
@@ -1643,8 +1643,9 @@ class LinuxSharedTopic : public Topic
 
   static void ConsumeReady(SubscriberControl& control)
   {
-    const uint32_t prev = control.ready_sem_count.fetch_sub(1, std::memory_order_acq_rel);
-    ASSERT(prev > 0);
+    [[maybe_unused]] const uint32_t prev =
+        control.ready_sem_count.fetch_sub(1, std::memory_order_acq_rel);
+    DEV_ASSERT(prev > 0);
   }
 
   static ErrorCode WaitReady(SubscriberControl& control, uint32_t timeout_ms)
@@ -1850,7 +1851,7 @@ class LinuxSharedTopic : public Topic
   {
     const uint32_t prev =
         slots_[slot_index].refcount.fetch_sub(1, std::memory_order_acq_rel);
-    ASSERT(prev > 0);
+    DEV_ASSERT(prev > 0);
     if (prev == 1)
     {
       RecycleSlot(slot_index);

--- a/system/threadx/thread.hpp
+++ b/system/threadx/thread.hpp
@@ -87,7 +87,7 @@ class Thread
         thread_handle_, const_cast<char*>(name), ThreadBlock::Port, ULONG(block),
         stack_buffer, stack_depth, static_cast<UINT>(priority),
         static_cast<UINT>(priority), TX_NO_TIME_SLICE, TX_AUTO_START);
-    ASSERT(status == TX_SUCCESS);
+    REQUIRE(status == TX_SUCCESS);
   }
 
   /**

--- a/system/webasm/libxr_system.cpp
+++ b/system/webasm/libxr_system.cpp
@@ -38,8 +38,9 @@ extern "C"
       const size_t accepted = std::min(size, queue.EmptySize());
       if (accepted != 0U)
       {
-        REQUIRE(queue.PushBatch(reinterpret_cast<const uint8_t*>(js_input), accepted) ==
-                LibXR::ErrorCode::OK);
+        [[maybe_unused]] const auto push_batch_result =
+            queue.PushBatch(reinterpret_cast<const uint8_t*>(js_input), accepted);
+        DEV_ASSERT(push_batch_result == LibXR::ErrorCode::OK);
       }
       queue.Publish();
     }
@@ -92,7 +93,7 @@ void LibXR::PlatformInit()
                   emit(second, second_size);
                   return first_size + second_size;
                 });
-            REQUIRE(accepted == offered);
+            DEV_ASSERT(accepted == offered);
           }
         });
   };

--- a/system/webots/libxr_system.cpp
+++ b/system/webots/libxr_system.cpp
@@ -169,7 +169,8 @@ void StdiThread(LibXR::ReadPort* read_port)
           queue.Publish();
           continue;
         }
-        REQUIRE(queue.PushBatch(read_buff, size) == LibXR::ErrorCode::OK);
+        [[maybe_unused]] const auto push_batch_result = queue.PushBatch(read_buff, size);
+        DEV_ASSERT(push_batch_result == LibXR::ErrorCode::OK);
         queue.Publish();
       }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,38 @@ endif()
 
 add_compile_options(-g)
 
+add_library(
+  test_assert_disabled OBJECT
+  framework/assert_disabled_headers.cpp ../src/core/rw/read_port.cpp
+  ../src/core/rw/write_port.cpp ../src/core/rw/write_stream.cpp
+)
+target_include_directories(
+  test_assert_disabled PRIVATE $<TARGET_PROPERTY:xr,INTERFACE_INCLUDE_DIRECTORIES>
+)
+target_compile_definitions(
+  test_assert_disabled PRIVATE $<TARGET_PROPERTY:xr,INTERFACE_COMPILE_DEFINITIONS>
+)
+target_compile_options(
+  test_assert_disabled PRIVATE -ULIBXR_DEBUG_BUILD -ULIBXR_DEV_ASSERT_BUILD -Wall -Werror
+                               -Wunused-parameter
+)
+
+enable_testing()
+foreach(debug RANGE 0 1)
+  foreach(dev RANGE 0 1)
+    set(mode_target test_assert_${debug}_${dev})
+    add_executable(${mode_target} framework/assert_modes.cpp)
+    target_include_directories(${mode_target} PRIVATE framework ../src/core)
+    if(debug)
+      target_compile_definitions(${mode_target} PRIVATE LIBXR_DEBUG_BUILD)
+    endif()
+    if(dev)
+      target_compile_definitions(${mode_target} PRIVATE LIBXR_DEV_ASSERT_BUILD)
+    endif()
+    add_test(NAME ${mode_target} COMMAND ${mode_target})
+  endforeach()
+endforeach()
+
 file(GLOB_RECURSE XR_TEST_BASE_SOURCES CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/base/*.cpp"
 )

--- a/test/base/callback/test_cb_direct.cpp
+++ b/test/base/callback/test_cb_direct.cpp
@@ -11,6 +11,7 @@
  * paths.
  */
 #include "cb_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -31,7 +32,7 @@ void TestEmptyAndDirectCallbacks()
   // with ISR-flag propagation.
   {
     LibXR::Callback<int> empty_cb;
-    ASSERT(empty_cb.Empty());
+    TEST_ASSERT(empty_cb.Empty());
     empty_cb.Run(false, 1);
   }
 
@@ -39,24 +40,24 @@ void TestEmptyAndDirectCallbacks()
     DirectCallbackProbe probe;
     probe.runtime_in_isr = true;
     probe.cb.Run(true, 1);
-    ASSERT(probe.seen_count == 2);
-    ASSERT(probe.seen[0] == 1);
-    ASSERT(probe.seen[1] == 2);
-    ASSERT(probe.seen_in_isr[0] == true);
-    ASSERT(probe.seen_in_isr[1] == true);
-    ASSERT(probe.max_depth == 2);
+    TEST_ASSERT(probe.seen_count == 2);
+    TEST_ASSERT(probe.seen[0] == 1);
+    TEST_ASSERT(probe.seen[1] == 2);
+    TEST_ASSERT(probe.seen_in_isr[0] == true);
+    TEST_ASSERT(probe.seen_in_isr[1] == true);
+    TEST_ASSERT(probe.max_depth == 2);
   }
 
   {
     DirectCallbackProbe probe;
     probe.runtime_in_isr = false;
     probe.cb.Run(false, 1);
-    ASSERT(probe.seen_count == 2);
-    ASSERT(probe.seen[0] == 1);
-    ASSERT(probe.seen[1] == 2);
-    ASSERT(probe.seen_in_isr[0] == false);
-    ASSERT(probe.seen_in_isr[1] == false);
-    ASSERT(probe.max_depth == 2);
+    TEST_ASSERT(probe.seen_count == 2);
+    TEST_ASSERT(probe.seen[0] == 1);
+    TEST_ASSERT(probe.seen[1] == 2);
+    TEST_ASSERT(probe.seen_in_isr[0] == false);
+    TEST_ASSERT(probe.seen_in_isr[1] == false);
+    TEST_ASSERT(probe.max_depth == 2);
   }
 }
 

--- a/test/base/callback/test_cb_guarded.cpp
+++ b/test/base/callback/test_cb_guarded.cpp
@@ -10,6 +10,7 @@
  *          2. Lambda binding still forwards the payload value and ISR flag.
  */
 #include "cb_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -31,19 +32,19 @@ void TestGuardedAndLambdaCallbacks()
   {
     GuardedCreationProbe probe;
     probe.cb.Run(false, 1);
-    ASSERT(probe.seen_count == 2);
-    ASSERT(probe.seen[0] == 1);
-    ASSERT(probe.seen[1] == 2);
-    ASSERT(probe.seen_in_isr[0] == false);
-    ASSERT(probe.seen_in_isr[1] == false);
-    ASSERT(probe.max_depth == 1);
+    TEST_ASSERT(probe.seen_count == 2);
+    TEST_ASSERT(probe.seen[0] == 1);
+    TEST_ASSERT(probe.seen[1] == 2);
+    TEST_ASSERT(probe.seen_in_isr[0] == false);
+    TEST_ASSERT(probe.seen_in_isr[1] == false);
+    TEST_ASSERT(probe.max_depth == 1);
   }
 
   {
     LambdaCreationProbe probe;
     probe.cb.Run(true, 7);
-    ASSERT(probe.seen_value == 7);
-    ASSERT(probe.seen_in_isr == true);
+    TEST_ASSERT(probe.seen_value == 7);
+    TEST_ASSERT(probe.seen_in_isr == true);
   }
 }
 

--- a/test/base/core/test_serialized_service.cpp
+++ b/test/base/core/test_serialized_service.cpp
@@ -7,6 +7,7 @@
 
 #include "serialized_service.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -25,27 +26,28 @@ void TestDeferredAndRecursiveEvents()
   service.Publish(SECOND);
   unsigned calls = 0U;
   unsigned depth = 0U;
-  ASSERT(service.Invoke(FIRST, true,
-                        [&](uint32_t events, bool in_isr)
-                        {
-                          ASSERT(++depth == 1U);
-                          ASSERT(in_isr);
-                          if (calls++ == 0U)
-                          {
-                            ASSERT(events == (FIRST | SECOND));
-                            ASSERT(!service.Invoke(
-                                THIRD, false, [](uint32_t, bool) { ASSERT(false); }));
-                            service.Publish(THIRD);
-                          }
-                          else
-                          {
-                            ASSERT(events == THIRD);
-                          }
-                          --depth;
-                        }));
-  ASSERT(calls == 2U && depth == 0U);
-  ASSERT(service.Invoke(FIRST, false, [](uint32_t events, bool in_isr)
-                        { ASSERT(events == FIRST && !in_isr); }));
+  TEST_ASSERT(service.Invoke(FIRST, true,
+                             [&](uint32_t events, bool in_isr)
+                             {
+                               TEST_ASSERT(++depth == 1U);
+                               TEST_ASSERT(in_isr);
+                               if (calls++ == 0U)
+                               {
+                                 TEST_ASSERT(events == (FIRST | SECOND));
+                                 TEST_ASSERT(!service.Invoke(THIRD, false,
+                                                             [](uint32_t, bool)
+                                                             { TEST_ASSERT(false); }));
+                                 service.Publish(THIRD);
+                               }
+                               else
+                               {
+                                 TEST_ASSERT(events == THIRD);
+                               }
+                               --depth;
+                             }));
+  TEST_ASSERT(calls == 2U && depth == 0U);
+  TEST_ASSERT(service.Invoke(FIRST, false, [](uint32_t events, bool in_isr)
+                             { TEST_ASSERT(events == FIRST && !in_isr); }));
 }
 
 void TestCompetingCallableLifetime()
@@ -58,35 +60,36 @@ void TestCompetingCallableLifetime()
   std::thread owner(
       [&]
       {
-        ASSERT(service.Invoke(FIRST, false,
-                              [&](uint32_t events, bool in_isr)
-                              {
-                                ASSERT(events != 0U);
-                                ASSERT(!in_isr);
-                                if (owner_calls++ == 0U)
-                                {
-                                  ASSERT(events == FIRST);
-                                  entered.release();
-                                  resume.acquire();
-                                }
-                                else
-                                {
-                                  ASSERT(events == (SECOND | THIRD));
-                                  ASSERT(payload == 42);
-                                }
-                              }));
+        TEST_ASSERT(service.Invoke(FIRST, false,
+                                   [&](uint32_t events, bool in_isr)
+                                   {
+                                     TEST_ASSERT(events != 0U);
+                                     TEST_ASSERT(!in_isr);
+                                     if (owner_calls++ == 0U)
+                                     {
+                                       TEST_ASSERT(events == FIRST);
+                                       entered.release();
+                                       resume.acquire();
+                                     }
+                                     else
+                                     {
+                                       TEST_ASSERT(events == (SECOND | THIRD));
+                                       TEST_ASSERT(payload == 42);
+                                     }
+                                   }));
       });
   entered.acquire();
   payload = 42;
   {
     int transient_capture = 7;
-    ASSERT(!service.Invoke(SECOND, true, [&](uint32_t, bool) { transient_capture = 8; }));
-    ASSERT(transient_capture == 7);
+    TEST_ASSERT(
+        !service.Invoke(SECOND, true, [&](uint32_t, bool) { transient_capture = 8; }));
+    TEST_ASSERT(transient_capture == 7);
   }
   service.Publish(THIRD);
   resume.release();
   owner.join();
-  ASSERT(owner_calls == 2U);
+  TEST_ASSERT(owner_calls == 2U);
 }
 
 void TestConcurrentReleaseAndPayloadPublication()
@@ -103,19 +106,19 @@ void TestConcurrentReleaseAndPayloadPublication()
   std::atomic<unsigned> active{0U};
   auto handler = [&](uint32_t events, bool)
   {
-    ASSERT(events != 0U);
-    ASSERT(active.fetch_add(1U, std::memory_order_relaxed) == 0U);
+    TEST_ASSERT(events != 0U);
+    TEST_ASSERT(active.fetch_add(1U, std::memory_order_relaxed) == 0U);
     for (unsigned i = 0U; i < PRODUCERS; ++i)
     {
       if ((events & (1U << i)) != 0U)
       {
         // The producer publishes this plain payload only through the service event.
-        ASSERT(payload[i] == consumed[i] + 1U);
+        TEST_ASSERT(payload[i] == consumed[i] + 1U);
         consumed[i] = payload[i];
         acknowledged[i].release();
       }
     }
-    ASSERT(active.fetch_sub(1U, std::memory_order_relaxed) == 1U);
+    TEST_ASSERT(active.fetch_sub(1U, std::memory_order_relaxed) == 1U);
   };
   for (unsigned i = 0U; i < PRODUCERS; ++i)
   {
@@ -136,9 +139,9 @@ void TestConcurrentReleaseAndPayloadPublication()
   }
   for (uint32_t count : consumed)
   {
-    ASSERT(count == ITERATIONS);
+    TEST_ASSERT(count == ITERATIONS);
   }
-  ASSERT(active.load(std::memory_order_relaxed) == 0U);
+  TEST_ASSERT(active.load(std::memory_order_relaxed) == 0U);
 }
 }  // namespace
 

--- a/test/base/middleware/app_framework/test_application.cpp
+++ b/test/base/middleware/app_framework/test_application.cpp
@@ -19,6 +19,7 @@
  */
 #include "libxr.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -72,20 +73,20 @@ void test_app_framework_application()
   CountingApp app3(2, &seen_mask, &hit_count);
 
   LibXR::ApplicationManager manager;
-  ASSERT(manager.Size() == 0);
+  TEST_ASSERT(manager.Size() == 0);
 
   manager.Register(app1);
-  ASSERT(manager.Size() == 1);
+  TEST_ASSERT(manager.Size() == 1);
 
   manager.Register(app2);
   manager.Register(app3);
-  ASSERT(manager.Size() == 3);
+  TEST_ASSERT(manager.Size() == 3);
 
   manager.MonitorAll();
-  ASSERT(hit_count == 3);
-  ASSERT(seen_mask == 0x07);
+  TEST_ASSERT(hit_count == 3);
+  TEST_ASSERT(seen_mask == 0x07);
 
   manager.MonitorAll();
-  ASSERT(hit_count == 6);
-  ASSERT(seen_mask == 0x07);
+  TEST_ASSERT(hit_count == 6);
+  TEST_ASSERT(seen_mask == 0x07);
 }

--- a/test/base/middleware/app_framework/test_hardware.cpp
+++ b/test/base/middleware/app_framework/test_hardware.cpp
@@ -22,6 +22,7 @@
  */
 #include "libxr.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -68,22 +69,22 @@ void test_app_framework_hardware()
                               LibXR::Entry<DeviceB>{dev_b, {"b", "shared"}},
                               LibXR::Entry<DeviceC>{dev_c, {"c-only"}});
 
-  ASSERT(hw.Find<DeviceA>("a") == &dev_a);
-  ASSERT(hw.Find<DeviceB>("b") == &dev_b);
-  ASSERT(hw.Find<DeviceC>("c-only") == &dev_c);
+  TEST_ASSERT(hw.Find<DeviceA>("a") == &dev_a);
+  TEST_ASSERT(hw.Find<DeviceB>("b") == &dev_b);
+  TEST_ASSERT(hw.Find<DeviceC>("c-only") == &dev_c);
 
-  ASSERT(hw.Find<DeviceA>("shared") == &dev_a);
-  ASSERT(hw.Find<DeviceB>("shared") == &dev_b);
-  ASSERT(hw.Find<DeviceC>("shared") == nullptr);
+  TEST_ASSERT(hw.Find<DeviceA>("shared") == &dev_a);
+  TEST_ASSERT(hw.Find<DeviceB>("shared") == &dev_b);
+  TEST_ASSERT(hw.Find<DeviceC>("shared") == nullptr);
 
-  ASSERT(hw.Find<DeviceA>("missing") == nullptr);
-  ASSERT(hw.Find<DeviceB>({"missing", "shared"}) == &dev_b);
-  ASSERT(hw.Find<DeviceA>({"missing", "fallback-a"}) == &dev_a);
-  ASSERT(hw.Find<DeviceC>({"missing", "shared"}) == nullptr);
-  ASSERT(hw.Find<DeviceA>({}) == nullptr);
+  TEST_ASSERT(hw.Find<DeviceA>("missing") == nullptr);
+  TEST_ASSERT(hw.Find<DeviceB>({"missing", "shared"}) == &dev_b);
+  TEST_ASSERT(hw.Find<DeviceA>({"missing", "fallback-a"}) == &dev_a);
+  TEST_ASSERT(hw.Find<DeviceC>({"missing", "shared"}) == nullptr);
+  TEST_ASSERT(hw.Find<DeviceA>({}) == nullptr);
 
   hw.Register(LibXR::Entry<DeviceD>{dev_d, {"d", "shared-d"}});
-  ASSERT(hw.Find<DeviceD>("d") == &dev_d);
-  ASSERT(hw.Find<DeviceD>({"missing", "shared-d"}) == &dev_d);
-  ASSERT(hw.Find<DeviceA>("shared-d") == nullptr);
+  TEST_ASSERT(hw.Find<DeviceD>("d") == &dev_d);
+  TEST_ASSERT(hw.Find<DeviceD>({"missing", "shared-d"}) == &dev_d);
+  TEST_ASSERT(hw.Find<DeviceA>("shared-d") == nullptr);
 }

--- a/test/base/middleware/database/test_database.cpp
+++ b/test/base/middleware/database/test_database.cpp
@@ -22,6 +22,7 @@
 
 #include "database.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 using namespace LibXR;
 
@@ -58,7 +59,7 @@ class MemoryDatabase : public Database
     set_calls++;
     if (set_result == ErrorCode::OK)
     {
-      ASSERT(data.size_ == sizeof(stored));
+      TEST_ASSERT(data.size_ == sizeof(stored));
       Memory::FastCopy(&stored, data.addr_, sizeof(stored));
     }
     return set_result;
@@ -69,7 +70,7 @@ class MemoryDatabase : public Database
     add_calls++;
     if (add_result == ErrorCode::OK)
     {
-      ASSERT(key.raw_data_.size_ == sizeof(stored));
+      TEST_ASSERT(key.raw_data_.size_ == sizeof(stored));
       Memory::FastCopy(&stored, key.raw_data_.addr_, sizeof(stored));
     }
     return add_result;
@@ -91,19 +92,19 @@ void TestDatabaseKeySaveUsesCurrentData()
   // Test coverage: execute the current helper-scoped test item from this file.
   MemoryDatabase db;
   Database::Key<uint32_t> key(db, "mock", 10);
-  ASSERT(key.data_ == 10);
-  ASSERT(db.add_calls == 1);
-  ASSERT(db.stored == 10);
+  TEST_ASSERT(key.data_ == 10);
+  TEST_ASSERT(db.add_calls == 1);
+  TEST_ASSERT(db.stored == 10);
 
   key.data_ = 20;
-  ASSERT(key.Save() == ErrorCode::OK);
-  ASSERT(db.stored == 20);
+  TEST_ASSERT(key.Save() == ErrorCode::OK);
+  TEST_ASSERT(db.stored == 20);
 
   db.set_result = ErrorCode::FAILED;
   key.data_ = 30;
-  ASSERT(key.Save() == ErrorCode::FAILED);
-  ASSERT(key.data_ == 30);
-  ASSERT(db.stored == 20);
+  TEST_ASSERT(key.Save() == ErrorCode::FAILED);
+  TEST_ASSERT(key.data_ == 30);
+  TEST_ASSERT(db.stored == 20);
 }
 
 /**
@@ -123,9 +124,9 @@ void TestDatabaseKeySetUpdatesCurrentValueBeforeSave()
   Database::Key<uint32_t> key(db, "mock", 10);
 
   db.set_result = ErrorCode::FAILED;
-  ASSERT(key.Set(40) == ErrorCode::FAILED);
-  ASSERT(key.data_ == 40);
-  ASSERT(db.stored == 10);
+  TEST_ASSERT(key.Set(40) == ErrorCode::FAILED);
+  TEST_ASSERT(key.data_ == 40);
+  TEST_ASSERT(db.stored == 10);
 }
 
 /**
@@ -146,14 +147,14 @@ void TestDatabaseKeyUsesDefaultOnGetFailure()
   db.stored = 55;
 
   Database::Key<uint32_t> key(db, "mock", 123);
-  ASSERT(key.data_ == 123);
-  ASSERT(db.add_calls == 0);
+  TEST_ASSERT(key.data_ == 123);
+  TEST_ASSERT(db.add_calls == 0);
 
   MemoryDatabase zero_db;
   zero_db.get_result = ErrorCode::FAILED;
   Database::Key<uint32_t> zero_key(zero_db, "mock");
-  ASSERT(zero_key.data_ == 0);
-  ASSERT(zero_db.add_calls == 0);
+  TEST_ASSERT(zero_key.data_ == 0);
+  TEST_ASSERT(zero_db.add_calls == 0);
 }
 
 }  // namespace

--- a/test/base/middleware/event/test_event.cpp
+++ b/test/base/middleware/event/test_event.cpp
@@ -24,6 +24,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_event`。 Test entry function `test_event`.
@@ -44,7 +45,7 @@ void test_event()
       {
         last_in_isr = in_isr;
         *arg = *arg + 1;
-        ASSERT(event == 0x1234);
+        TEST_ASSERT(event == 0x1234);
       },
       &event_arg);
 
@@ -53,7 +54,7 @@ void test_event()
       {
         last_in_isr = in_isr;
         *arg = *arg + 1;
-        ASSERT(event == 0xF0001234);
+        TEST_ASSERT(event == 0xF0001234);
       },
       &high_event_arg);
 
@@ -62,47 +63,47 @@ void test_event()
   // Direct activation must report non-ISR context.
   event.Register(0x1234, event_cb);
   event.Active(0x1234);
-  ASSERT(event_arg == 1);
-  ASSERT(last_in_isr == false);
+  TEST_ASSERT(event_arg == 1);
+  TEST_ASSERT(last_in_isr == false);
 
   for (int i = 0; i <= 0x1234; i++)
   {
     event.Active(i);
   }
-  ASSERT(event_arg == 2);
-  ASSERT(last_in_isr == false);
+  TEST_ASSERT(event_arg == 2);
+  TEST_ASSERT(last_in_isr == false);
 
   // Callback-safe activation must preserve the explicit in_isr flag.
   event.ActiveFromCallback(event.GetList(0x1234), 0x1234, false);
-  ASSERT(event_arg == 3);
-  ASSERT(last_in_isr == false);
+  TEST_ASSERT(event_arg == 3);
+  TEST_ASSERT(last_in_isr == false);
 
   event.ActiveFromCallback(event.GetList(0x1234), 0x1234, true);
-  ASSERT(event_arg == 4);
-  ASSERT(last_in_isr == true);
+  TEST_ASSERT(event_arg == 4);
+  TEST_ASSERT(last_in_isr == true);
 
   // Default callback-safe behavior remains ISR=true for legacy callers.
   event.ActiveFromCallback(event.GetList(0x1234), 0x1234);
-  ASSERT(event_arg == 5);
-  ASSERT(last_in_isr == true);
+  TEST_ASSERT(event_arg == 5);
+  TEST_ASSERT(last_in_isr == true);
 
   // Bound events must keep the source callback context unchanged.
   event.Bind(event_bind, 0x4321, 0x1234);
   event_bind.Active(0x4321);
-  ASSERT(event_arg == 6);
-  ASSERT(last_in_isr == false);
+  TEST_ASSERT(event_arg == 6);
+  TEST_ASSERT(last_in_isr == false);
 
   event_bind.ActiveFromCallback(event_bind.GetList(0x4321), 0x4321, false);
-  ASSERT(event_arg == 7);
-  ASSERT(last_in_isr == false);
+  TEST_ASSERT(event_arg == 7);
+  TEST_ASSERT(last_in_isr == false);
 
   event_bind.ActiveFromCallback(event_bind.GetList(0x4321), 0x4321, true);
-  ASSERT(event_arg == 8);
-  ASSERT(last_in_isr == true);
+  TEST_ASSERT(event_arg == 8);
+  TEST_ASSERT(last_in_isr == true);
 
   // High-value event IDs must still compare and dispatch correctly.
   event.Register(0xF0001234, high_event_cb);
   event.Active(0xF0001234);
-  ASSERT(high_event_arg == 1);
-  ASSERT(last_in_isr == false);
+  TEST_ASSERT(high_event_arg == 1);
+  TEST_ASSERT(last_in_isr == false);
 }

--- a/test/base/middleware/logger/test_logger.cpp
+++ b/test/base/middleware/logger/test_logger.cpp
@@ -24,6 +24,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 static_assert(LibXR::Detail::LoggerLiteral::SelectFrontend<
                   LibXR::Detail::LoggerLiteral::Frontend::Auto, "brace {}", int>() ==
@@ -73,12 +74,12 @@ std::string ReadPipeText(LibXR::Pipe& pipe)
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
   const size_t output_size = pipe.GetReadPort().Size();
-  ASSERT(output_size > 0);
+  TEST_ASSERT(output_size > 0);
 
   std::string text(output_size, '\0');
   LibXR::ReadOperation read_op;
-  ASSERT(pipe.GetReadPort()(LibXR::RawData{text.data(), output_size}, read_op) ==
-         LibXR::ErrorCode::OK);
+  TEST_ASSERT(pipe.GetReadPort()(LibXR::RawData{text.data(), output_size}, read_op) ==
+              LibXR::ErrorCode::OK);
   return text;
 }
 
@@ -113,13 +114,14 @@ void test_logger()
   LibXR::STDIO::write_ = old_write;
   LibXR::STDIO::write_stream_ = old_stream;
 
-  ASSERT(text.find(
-             LibXR::LIBXR_FOREGROUND_STR[static_cast<size_t>(LibXR::Foreground::RED)]) !=
-         std::string::npos);
-  ASSERT(text.find("(logger_test.cpp:123) brace 7") != std::string::npos);
-  ASSERT(text.find("(logger_test.cpp:124) printf 9") != std::string::npos);
-  ASSERT(text.find("(logger_test.cpp:125) plain literal") != std::string::npos);
-  ASSERT(text.find(LibXR::LIBXR_TERMINAL_CONTROL_STR[static_cast<size_t>(
-             LibXR::TerminalControl::RESET)]) != std::string::npos);
-  ASSERT(CountSubstring(text, "\r\n") == 3);
+  TEST_ASSERT(
+      text.find(
+          LibXR::LIBXR_FOREGROUND_STR[static_cast<size_t>(LibXR::Foreground::RED)]) !=
+      std::string::npos);
+  TEST_ASSERT(text.find("(logger_test.cpp:123) brace 7") != std::string::npos);
+  TEST_ASSERT(text.find("(logger_test.cpp:124) printf 9") != std::string::npos);
+  TEST_ASSERT(text.find("(logger_test.cpp:125) plain literal") != std::string::npos);
+  TEST_ASSERT(text.find(LibXR::LIBXR_TERMINAL_CONTROL_STR[static_cast<size_t>(
+                  LibXR::TerminalControl::RESET)]) != std::string::npos);
+  TEST_ASSERT(CountSubstring(text, "\r\n") == 3);
 }

--- a/test/base/middleware/message/test_packet_alignment.cpp
+++ b/test/base/middleware/message/test_packet_alignment.cpp
@@ -4,6 +4,7 @@
  * alignment and length compatibility.
  */
 #include "message_packet_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -28,7 +29,7 @@ void TestPacketAlignmentAndLengthCompatibility()
   auto aligned_cb = LibXR::Topic::Callback::Create(
       [](bool, void*, const LibXR::Topic::MessageView<WideAlignedPayload>& message)
       {
-        ASSERT(message.data != nullptr);
+        TEST_ASSERT(message.data != nullptr);
         aligned_view_value = message.data->right;
       },
       reinterpret_cast<void*>(0));
@@ -37,12 +38,12 @@ void TestPacketAlignmentAndLengthCompatibility()
   aligned_server.Register(aligned_topic);
   WideAlignedPayload aligned_tx{0x1122334455667788ULL, 0x8877665544332211ULL};
   LibXR::Topic::PackedData<WideAlignedPayload> aligned_packet;
-  ASSERT(aligned_topic.PackData(aligned_tx, aligned_packet,
-                                LibXR::MicrosecondTimestamp(6106)) ==
-         LibXR::ErrorCode::OK);
+  TEST_ASSERT(aligned_topic.PackData(aligned_tx, aligned_packet,
+                                     LibXR::MicrosecondTimestamp(6106)) ==
+              LibXR::ErrorCode::OK);
   aligned_view_value = 0;
-  ASSERT(aligned_server.ParseData(LibXR::ConstRawData(aligned_packet)) == 1);
-  ASSERT(aligned_view_value == aligned_tx.right);
+  TEST_ASSERT(aligned_server.ParseData(LibXR::ConstRawData(aligned_packet)) == 1);
+  TEST_ASSERT(aligned_view_value == aligned_tx.right);
 
   auto prefix_topic =
       LibXR::Topic::CreateTopic<PrefixIntPayload>("prefix_int_tp", &domain);
@@ -55,14 +56,14 @@ void TestPacketAlignmentAndLengthCompatibility()
   prefix_server.Register(prefix_topic);
   PrefixIntPayload prefix_tx{0x11223344, 0x55667788};
   LibXR::Topic::PackedData<PrefixIntPayload> prefix_packet;
-  ASSERT(prefix_topic.PackData(prefix_tx, prefix_packet,
-                               LibXR::MicrosecondTimestamp(6116)) ==
-         LibXR::ErrorCode::OK);
+  TEST_ASSERT(prefix_topic.PackData(prefix_tx, prefix_packet,
+                                    LibXR::MicrosecondTimestamp(6116)) ==
+              LibXR::ErrorCode::OK);
   RewritePacketPayloadLengthForTest(prefix_packet, sizeof(int32_t));
   prefix_rx = PrefixIntPayload{-1, -1};
-  ASSERT(prefix_server.ParseData(LibXR::ConstRawData(
-             &prefix_packet, LibXR::Topic::PACK_BASE_SIZE + sizeof(int32_t))) == 1);
-  ASSERT(prefix_rx.value == prefix_tx.value);
+  TEST_ASSERT(prefix_server.ParseData(LibXR::ConstRawData(
+                  &prefix_packet, LibXR::Topic::PACK_BASE_SIZE + sizeof(int32_t))) == 1);
+  TEST_ASSERT(prefix_rx.value == prefix_tx.value);
 }
 
 }  // namespace

--- a/test/base/middleware/message/test_packet_parse.cpp
+++ b/test/base/middleware/message/test_packet_parse.cpp
@@ -4,6 +4,7 @@
  * encoding and parsing.
  */
 #include "message_packet_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -45,75 +46,77 @@ void TestPacketHeaderAndServerParse()
 
   const double value0 = 48.48;
   const LibXR::MicrosecondTimestamp timestamp0(4004);
-  ASSERT(topic.PackData(value0, packed_data, timestamp0) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(topic.PackData(value0, packed_data, timestamp0) == LibXR::ErrorCode::OK);
   rx_value = -1.0;
   cb_in_isr = false;
-  ASSERT(topic_server.ParseDataFromCallback(LibXR::ConstRawData(packed_data), true) == 1);
-  ASSERT(rx_value == value0);
-  ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp0));
-  ASSERT(cb_in_isr);
+  TEST_ASSERT(
+      topic_server.ParseDataFromCallback(LibXR::ConstRawData(packed_data), true) == 1);
+  TEST_ASSERT(rx_value == value0);
+  TEST_ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp0));
+  TEST_ASSERT(cb_in_isr);
 
   const double value1 = 56.56;
   const LibXR::MicrosecondTimestamp timestamp1(5005);
-  ASSERT(topic.PackData(value1, packed_data, timestamp1) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(topic.PackData(value1, packed_data, timestamp1) == LibXR::ErrorCode::OK);
   rx_value = -1.0;
   cb_in_isr = true;
-  ASSERT(topic_server.ParseDataFromCallback(LibXR::ConstRawData(packed_data), false) ==
-         1);
-  ASSERT(rx_value == value1);
-  ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp1));
-  ASSERT(!cb_in_isr);
+  TEST_ASSERT(
+      topic_server.ParseDataFromCallback(LibXR::ConstRawData(packed_data), false) == 1);
+  TEST_ASSERT(rx_value == value1);
+  TEST_ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp1));
+  TEST_ASSERT(!cb_in_isr);
 
   const double value2 = 64.64;
   const LibXR::MicrosecondTimestamp timestamp2(0x010203040506ULL);
-  ASSERT(topic.PackData(value2, packed_data, timestamp2) == LibXR::ErrorCode::OK);
-  ASSERT(packed_data.raw.header_.prefix == LibXR::Topic::PACKET_PREFIX);
-  ASSERT(packed_data.raw.header_.version == LibXR::Topic::PACKET_VERSION);
-  ASSERT(packed_data.raw.header_.data_len_raw[0] == sizeof(double));
-  ASSERT(packed_data.raw.header_.data_len_raw[1] == 0);
-  ASSERT(packed_data.raw.header_.data_len_raw[2] == 0);
-  ASSERT(packed_data.raw.header_.timestamp_us_raw[0] == 0x06);
-  ASSERT(packed_data.raw.header_.timestamp_us_raw[1] == 0x05);
-  ASSERT(packed_data.raw.header_.timestamp_us_raw[2] == 0x04);
-  ASSERT(packed_data.raw.header_.timestamp_us_raw[3] == 0x03);
-  ASSERT(packed_data.raw.header_.timestamp_us_raw[4] == 0x02);
-  ASSERT(packed_data.raw.header_.timestamp_us_raw[5] == 0x01);
-  ASSERT(TimestampUs(packed_data.GetTimestamp()) == TimestampUs(timestamp2));
+  TEST_ASSERT(topic.PackData(value2, packed_data, timestamp2) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(packed_data.raw.header_.prefix == LibXR::Topic::PACKET_PREFIX);
+  TEST_ASSERT(packed_data.raw.header_.version == LibXR::Topic::PACKET_VERSION);
+  TEST_ASSERT(packed_data.raw.header_.data_len_raw[0] == sizeof(double));
+  TEST_ASSERT(packed_data.raw.header_.data_len_raw[1] == 0);
+  TEST_ASSERT(packed_data.raw.header_.data_len_raw[2] == 0);
+  TEST_ASSERT(packed_data.raw.header_.timestamp_us_raw[0] == 0x06);
+  TEST_ASSERT(packed_data.raw.header_.timestamp_us_raw[1] == 0x05);
+  TEST_ASSERT(packed_data.raw.header_.timestamp_us_raw[2] == 0x04);
+  TEST_ASSERT(packed_data.raw.header_.timestamp_us_raw[3] == 0x03);
+  TEST_ASSERT(packed_data.raw.header_.timestamp_us_raw[4] == 0x02);
+  TEST_ASSERT(packed_data.raw.header_.timestamp_us_raw[5] == 0x01);
+  TEST_ASSERT(TimestampUs(packed_data.GetTimestamp()) == TimestampUs(timestamp2));
 
   auto* packet = reinterpret_cast<uint8_t*>(&packed_data);
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(packet, 3)) == 0);
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(packet + 3, PACKET_SIZE - 3)) == 1);
-  ASSERT(rx_value == value2);
-  ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp2));
+  TEST_ASSERT(topic_server.ParseData(LibXR::ConstRawData(packet, 3)) == 0);
+  TEST_ASSERT(topic_server.ParseData(LibXR::ConstRawData(packet + 3, PACKET_SIZE - 3)) ==
+              1);
+  TEST_ASSERT(rx_value == value2);
+  TEST_ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp2));
 
   LibXR::Topic::Server exact_size_server(PACKET_SIZE);
   exact_size_server.Register(topic);
-  ASSERT(exact_size_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
-  ASSERT(rx_value == value2);
-  ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp2));
+  TEST_ASSERT(exact_size_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
+  TEST_ASSERT(rx_value == value2);
+  TEST_ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp2));
 
   const double raw_value = 72.72;
   const LibXR::MicrosecondTimestamp raw_timestamp(6006);
   uint8_t raw_packet[PACKET_SIZE] = {};
-  ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value),
-                       LibXR::RawData(raw_packet, sizeof(raw_packet)),
-                       raw_timestamp) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value),
+                            LibXR::RawData(raw_packet, sizeof(raw_packet)),
+                            raw_timestamp) == LibXR::ErrorCode::OK);
   rx_value = -1.0;
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(raw_packet, sizeof(raw_packet))) ==
-         1);
-  ASSERT(rx_value == raw_value);
-  ASSERT(TimestampUs(cb_timestamp) == TimestampUs(raw_timestamp));
+  TEST_ASSERT(
+      topic_server.ParseData(LibXR::ConstRawData(raw_packet, sizeof(raw_packet))) == 1);
+  TEST_ASSERT(rx_value == raw_value);
+  TEST_ASSERT(TimestampUs(cb_timestamp) == TimestampUs(raw_timestamp));
 
   uint8_t small_packet[PACKET_SIZE - 1] = {};
   uint32_t wrong_size_payload = 0;
-  ASSERT(topic.PackRaw(LibXR::ConstRawData(wrong_size_payload),
-                       LibXR::RawData(raw_packet, sizeof(raw_packet)),
-                       raw_timestamp) == LibXR::ErrorCode::SIZE_ERR);
-  ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value),
-                       LibXR::RawData(small_packet, sizeof(small_packet)),
-                       raw_timestamp) == LibXR::ErrorCode::NO_BUFF);
-  ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value), LibXR::RawData(), raw_timestamp) ==
-         LibXR::ErrorCode::PTR_NULL);
+  TEST_ASSERT(topic.PackRaw(LibXR::ConstRawData(wrong_size_payload),
+                            LibXR::RawData(raw_packet, sizeof(raw_packet)),
+                            raw_timestamp) == LibXR::ErrorCode::SIZE_ERR);
+  TEST_ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value),
+                            LibXR::RawData(small_packet, sizeof(small_packet)),
+                            raw_timestamp) == LibXR::ErrorCode::NO_BUFF);
+  TEST_ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value), LibXR::RawData(),
+                            raw_timestamp) == LibXR::ErrorCode::PTR_NULL);
 }
 
 }  // namespace

--- a/test/base/middleware/message/test_packet_validation.cpp
+++ b/test/base/middleware/message/test_packet_validation.cpp
@@ -4,6 +4,7 @@
  * validation-failure scenarios.
  */
 #include "message_packet_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -32,8 +33,8 @@ void TestPacketValidationFailures()
   topic.RegisterCallback(msg_cb);
 
   LibXR::Topic::PackedData<double> packed_data;
-  ASSERT(topic.PackData(77.77, packed_data, LibXR::MicrosecondTimestamp(123456)) ==
-         LibXR::ErrorCode::OK);
+  TEST_ASSERT(topic.PackData(77.77, packed_data, LibXR::MicrosecondTimestamp(123456)) ==
+              LibXR::ErrorCode::OK);
 
   LibXR::Topic::Server topic_server(512);
   topic_server.Register(topic);
@@ -45,7 +46,7 @@ void TestPacketValidationFailures()
                              sizeof(LibXR::Topic::PackedDataHeader) - sizeof(uint8_t));
   unknown_topic_packet.crc8_ =
       LibXR::CRC8::Calculate(&unknown_topic_packet, PACKET_SIZE - sizeof(uint8_t));
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(unknown_topic_packet)) == 0);
+  TEST_ASSERT(topic_server.ParseData(LibXR::ConstRawData(unknown_topic_packet)) == 0);
 
   auto unknown_version_packet = packed_data;
   unknown_version_packet.raw.header_.version ^= 0x5A;
@@ -54,14 +55,14 @@ void TestPacketValidationFailures()
                              sizeof(LibXR::Topic::PackedDataHeader) - sizeof(uint8_t));
   unknown_version_packet.crc8_ =
       LibXR::CRC8::Calculate(&unknown_version_packet, PACKET_SIZE - sizeof(uint8_t));
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(unknown_version_packet)) == 0);
+  TEST_ASSERT(topic_server.ParseData(LibXR::ConstRawData(unknown_version_packet)) == 0);
 
   auto truncated_packet = packed_data;
   RewritePacketPayloadLengthForTest(truncated_packet, sizeof(double) - 1);
   rx_value = -1.0;
-  ASSERT(topic_server.ParseData(
-             LibXR::ConstRawData(&truncated_packet, PACKET_SIZE - 1)) == 1);
-  ASSERT(rx_value != 77.77);
+  TEST_ASSERT(topic_server.ParseData(
+                  LibXR::ConstRawData(&truncated_packet, PACKET_SIZE - 1)) == 1);
+  TEST_ASSERT(rx_value != 77.77);
 
   auto legacy_prefix_packet = packed_data;
   legacy_prefix_packet.raw.header_.prefix = 0xA5;
@@ -70,18 +71,18 @@ void TestPacketValidationFailures()
                              sizeof(LibXR::Topic::PackedDataHeader) - sizeof(uint8_t));
   legacy_prefix_packet.crc8_ =
       LibXR::CRC8::Calculate(&legacy_prefix_packet, PACKET_SIZE - sizeof(uint8_t));
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(legacy_prefix_packet)) == 0);
+  TEST_ASSERT(topic_server.ParseData(LibXR::ConstRawData(legacy_prefix_packet)) == 0);
 
   auto bad_header_packet = packed_data;
   bad_header_packet.raw.header_.pack_header_crc8 ^= 0x5A;
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(bad_header_packet)) == 0);
+  TEST_ASSERT(topic_server.ParseData(LibXR::ConstRawData(bad_header_packet)) == 0);
 
   auto bad_payload_packet = packed_data;
   bad_payload_packet.crc8_ ^= 0xA5;
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(bad_payload_packet)) == 0);
+  TEST_ASSERT(topic_server.ParseData(LibXR::ConstRawData(bad_payload_packet)) == 0);
 
-  ASSERT(topic_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
-  ASSERT(rx_value == 77.77);
+  TEST_ASSERT(topic_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
+  TEST_ASSERT(rx_value == 77.77);
 }
 
 }  // namespace

--- a/test/base/middleware/message/test_topic_dispatch.cpp
+++ b/test/base/middleware/message/test_topic_dispatch.cpp
@@ -14,6 +14,7 @@
  *             TypeID matching.
  *          4. Typed delivery of non-trivial payloads.
  */
+#include "test_assert.hpp"
 #include "topic_test_common.hpp"
 
 namespace
@@ -33,7 +34,7 @@ void TestTopicSubscriberDispatch()
   // 测试内容：验证同一发布在不同订阅者类型上的 fan-out 与时间戳/ISR 语义。
   // Test coverage: verify fan-out of one publish across subscriber types plus
   // timestamp/ISR semantics.
-  ASSERT(LibXR::Topic::Find("missing_default_topic") == nullptr);
+  TEST_ASSERT(LibXR::Topic::Find("missing_default_topic") == nullptr);
 
   auto domain = LibXR::Topic::Domain("message_topic_domain");
   auto topic = LibXR::Topic::CreateTopic<double>("message_topic_tp", &domain);
@@ -73,7 +74,7 @@ void TestTopicSubscriberDispatch()
       [](bool, void*, const LibXR::Topic::MessageView<double>& message)
       {
         view_cb_timestamp = message.timestamp;
-        ASSERT(message.data != nullptr);
+        TEST_ASSERT(message.data != nullptr);
         view_cb_value = *message.data;
       },
       reinterpret_cast<void*>(0));
@@ -84,7 +85,7 @@ void TestTopicSubscriberDispatch()
       {
         raw_view_timestamp = message.timestamp;
         raw_view_size = message.payload.size_;
-        ASSERT(message.payload.addr_ != nullptr);
+        TEST_ASSERT(message.payload.addr_ != nullptr);
         raw_view_value = *static_cast<const double*>(message.payload.addr_);
       },
       reinterpret_cast<void*>(0));
@@ -96,7 +97,7 @@ void TestTopicSubscriberDispatch()
       {
         raw_arg_timestamp = timestamp;
         raw_arg_size = data.size_;
-        ASSERT(data.addr_ != nullptr);
+        TEST_ASSERT(data.addr_ != nullptr);
         raw_arg_value = *static_cast<const double*>(data.addr_);
       },
       reinterpret_cast<void*>(0));
@@ -106,44 +107,44 @@ void TestTopicSubscriberDispatch()
       [](bool, void*, LibXR::ConstRawData& data)
       {
         raw_mutable_arg_size = data.size_;
-        ASSERT(data.addr_ != nullptr);
+        TEST_ASSERT(data.addr_ != nullptr);
         raw_mutable_arg_value = *static_cast<const double*>(data.addr_);
       },
       reinterpret_cast<void*>(0));
   topic.RegisterCallback(raw_mutable_arg_cb);
 
-  ASSERT(!async_suber.Available());
+  TEST_ASSERT(!async_suber.Available());
 
   msg[0] = 16.16;
   const LibXR::MicrosecondTimestamp timestamp0(1001);
   async_suber.StartWaiting();
   topic.Publish(msg[0], timestamp0);
-  ASSERT(async_suber.Available());
-  ASSERT(async_suber.GetData() == msg[0]);
-  ASSERT(TimestampUs(async_suber.GetTimestamp()) == TimestampUs(timestamp0));
-  ASSERT(!async_suber.Available());
-  ASSERT(msg_queue.Size() == 1);
+  TEST_ASSERT(async_suber.Available());
+  TEST_ASSERT(async_suber.GetData() == msg[0]);
+  TEST_ASSERT(TimestampUs(async_suber.GetTimestamp()) == TimestampUs(timestamp0));
+  TEST_ASSERT(!async_suber.Available());
+  TEST_ASSERT(msg_queue.Size() == 1);
   double queue_value = 0.0;
   msg_queue.Pop(queue_value);
-  ASSERT(queue_value == msg[0]);
-  ASSERT(timed_msg_queue.Size() == 1);
+  TEST_ASSERT(queue_value == msg[0]);
+  TEST_ASSERT(timed_msg_queue.Size() == 1);
   LibXR::Topic::Message<double> queue_msg;
   timed_msg_queue.Pop(queue_msg);
-  ASSERT(queue_msg.data == msg[0]);
-  ASSERT(TimestampUs(queue_msg.timestamp) == TimestampUs(timestamp0));
-  ASSERT(msg[3] == msg[0]);
-  ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp0));
-  ASSERT(view_cb_value == msg[0]);
-  ASSERT(TimestampUs(view_cb_timestamp) == TimestampUs(timestamp0));
-  ASSERT(raw_view_value == msg[0]);
-  ASSERT(raw_view_size == sizeof(double));
-  ASSERT(TimestampUs(raw_view_timestamp) == TimestampUs(timestamp0));
-  ASSERT(raw_arg_value == msg[0]);
-  ASSERT(raw_arg_size == sizeof(double));
-  ASSERT(TimestampUs(raw_arg_timestamp) == TimestampUs(timestamp0));
-  ASSERT(raw_mutable_arg_value == msg[0]);
-  ASSERT(raw_mutable_arg_size == sizeof(double));
-  ASSERT(!cb_in_isr);
+  TEST_ASSERT(queue_msg.data == msg[0]);
+  TEST_ASSERT(TimestampUs(queue_msg.timestamp) == TimestampUs(timestamp0));
+  TEST_ASSERT(msg[3] == msg[0]);
+  TEST_ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp0));
+  TEST_ASSERT(view_cb_value == msg[0]);
+  TEST_ASSERT(TimestampUs(view_cb_timestamp) == TimestampUs(timestamp0));
+  TEST_ASSERT(raw_view_value == msg[0]);
+  TEST_ASSERT(raw_view_size == sizeof(double));
+  TEST_ASSERT(TimestampUs(raw_view_timestamp) == TimestampUs(timestamp0));
+  TEST_ASSERT(raw_arg_value == msg[0]);
+  TEST_ASSERT(raw_arg_size == sizeof(double));
+  TEST_ASSERT(TimestampUs(raw_arg_timestamp) == TimestampUs(timestamp0));
+  TEST_ASSERT(raw_mutable_arg_value == msg[0]);
+  TEST_ASSERT(raw_mutable_arg_size == sizeof(double));
+  TEST_ASSERT(!cb_in_isr);
 
   auto byte_stable_topic =
       LibXR::Topic::CreateTopic<ByteStablePayload>("byte_stable_tp", &domain);
@@ -153,7 +154,7 @@ void TestTopicSubscriberDispatch()
       [](bool, void*, const LibXR::Topic::MessageView<ByteStablePayload>& message)
       {
         byte_stable_view_timestamp = message.timestamp;
-        ASSERT(message.data != nullptr);
+        TEST_ASSERT(message.data != nullptr);
         byte_stable_view_value = message.data->data[2];
       },
       reinterpret_cast<void*>(0));
@@ -161,37 +162,38 @@ void TestTopicSubscriberDispatch()
   ByteStablePayload byte_stable_tx{1.0f, 2.0f, 3.0f, 4.0f};
   const LibXR::MicrosecondTimestamp byte_stable_timestamp(1501);
   byte_stable_topic.Publish(byte_stable_tx, byte_stable_timestamp);
-  ASSERT(byte_stable_view_value == byte_stable_tx.data[2]);
-  ASSERT(TimestampUs(byte_stable_view_timestamp) == TimestampUs(byte_stable_timestamp));
+  TEST_ASSERT(byte_stable_view_value == byte_stable_tx.data[2]);
+  TEST_ASSERT(TimestampUs(byte_stable_view_timestamp) ==
+              TimestampUs(byte_stable_timestamp));
 
   msg[0] = 32.32;
   msg[3] = -1.0f;
   const LibXR::MicrosecondTimestamp timestamp1(2002);
   async_suber.StartWaiting();
   topic.PublishFromCallback(msg[0], timestamp1, true);
-  ASSERT(async_suber.Available());
-  ASSERT(async_suber.GetData() == msg[0]);
-  ASSERT(TimestampUs(async_suber.GetTimestamp()) == TimestampUs(timestamp1));
-  ASSERT(msg_queue.Size() == 1);
+  TEST_ASSERT(async_suber.Available());
+  TEST_ASSERT(async_suber.GetData() == msg[0]);
+  TEST_ASSERT(TimestampUs(async_suber.GetTimestamp()) == TimestampUs(timestamp1));
+  TEST_ASSERT(msg_queue.Size() == 1);
   msg_queue.Pop(queue_value);
-  ASSERT(queue_value == msg[0]);
-  ASSERT(timed_msg_queue.Size() == 1);
+  TEST_ASSERT(queue_value == msg[0]);
+  TEST_ASSERT(timed_msg_queue.Size() == 1);
   timed_msg_queue.Pop(queue_msg);
-  ASSERT(queue_msg.data == msg[0]);
-  ASSERT(TimestampUs(queue_msg.timestamp) == TimestampUs(timestamp1));
-  ASSERT(msg[3] == msg[0]);
-  ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp1));
-  ASSERT(cb_in_isr);
-  ASSERT(view_cb_value == msg[0]);
-  ASSERT(TimestampUs(view_cb_timestamp) == TimestampUs(timestamp1));
-  ASSERT(raw_view_value == msg[0]);
-  ASSERT(raw_view_size == sizeof(double));
-  ASSERT(TimestampUs(raw_view_timestamp) == TimestampUs(timestamp1));
-  ASSERT(raw_arg_value == msg[0]);
-  ASSERT(raw_arg_size == sizeof(double));
-  ASSERT(TimestampUs(raw_arg_timestamp) == TimestampUs(timestamp1));
-  ASSERT(raw_mutable_arg_value == msg[0]);
-  ASSERT(raw_mutable_arg_size == sizeof(double));
+  TEST_ASSERT(queue_msg.data == msg[0]);
+  TEST_ASSERT(TimestampUs(queue_msg.timestamp) == TimestampUs(timestamp1));
+  TEST_ASSERT(msg[3] == msg[0]);
+  TEST_ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp1));
+  TEST_ASSERT(cb_in_isr);
+  TEST_ASSERT(view_cb_value == msg[0]);
+  TEST_ASSERT(TimestampUs(view_cb_timestamp) == TimestampUs(timestamp1));
+  TEST_ASSERT(raw_view_value == msg[0]);
+  TEST_ASSERT(raw_view_size == sizeof(double));
+  TEST_ASSERT(TimestampUs(raw_view_timestamp) == TimestampUs(timestamp1));
+  TEST_ASSERT(raw_arg_value == msg[0]);
+  TEST_ASSERT(raw_arg_size == sizeof(double));
+  TEST_ASSERT(TimestampUs(raw_arg_timestamp) == TimestampUs(timestamp1));
+  TEST_ASSERT(raw_mutable_arg_value == msg[0]);
+  TEST_ASSERT(raw_mutable_arg_size == sizeof(double));
 }
 
 }  // namespace

--- a/test/base/middleware/message/test_topic_mutation.cpp
+++ b/test/base/middleware/message/test_topic_mutation.cpp
@@ -9,6 +9,7 @@
  *          1. Mutable callback subscribers can modify the caller-visible payload.
  *          2. Queued subscribers drop later publishes when the queue is full.
  */
+#include "test_assert.hpp"
 #include "topic_test_common.hpp"
 
 namespace
@@ -36,7 +37,7 @@ void TestTopicMutationAndQueueDrop()
   mutable_topic.RegisterCallback(mutable_cb);
   int mutable_payload = 1234;
   mutable_topic.Publish(mutable_payload, LibXR::MicrosecondTimestamp(7037));
-  ASSERT(mutable_payload == 5678);
+  TEST_ASSERT(mutable_payload == 5678);
 
   auto queue_drop_topic = LibXR::Topic::CreateTopic<int>("queue_drop_tp", &domain);
   LibXR::SPSCQueue<int> drop_queue(1);
@@ -47,18 +48,18 @@ void TestTopicMutationAndQueueDrop()
     auto value = static_cast<int>(i);
     queue_drop_topic.Publish(value, LibXR::MicrosecondTimestamp(8000 + i));
   }
-  ASSERT(drop_queue.Size() == drop_queue.MaxSize());
+  TEST_ASSERT(drop_queue.Size() == drop_queue.MaxSize());
   int dropped_value = -123;
   queue_drop_topic.Publish(dropped_value, LibXR::MicrosecondTimestamp(9009));
-  ASSERT(drop_queue.Size() == drop_queue.MaxSize());
+  TEST_ASSERT(drop_queue.Size() == drop_queue.MaxSize());
   for (size_t i = 0; i < drop_queue.MaxSize(); ++i)
   {
     int value = 0;
-    ASSERT(drop_queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == static_cast<int>(i));
+    TEST_ASSERT(drop_queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == static_cast<int>(i));
   }
   int dropped_message = 0;
-  ASSERT(drop_queue.Pop(dropped_message) == LibXR::ErrorCode::EMPTY);
+  TEST_ASSERT(drop_queue.Pop(dropped_message) == LibXR::ErrorCode::EMPTY);
 }
 
 }  // namespace

--- a/test/base/middleware/ramfs/test_ramfs.cpp
+++ b/test/base/middleware/ramfs/test_ramfs.cpp
@@ -23,6 +23,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_ramfs`。 Test entry function `test_ramfs`.
@@ -50,8 +51,8 @@ void test_ramfs()
       &ramfs_arg);
 
   auto file_1 = LibXR::RamFS::CreateFile("test_file1", ramfs_arg);
-  ASSERT(command.IsExecutable());
-  ASSERT(!file_1.IsExecutable());
+  TEST_ASSERT(command.IsExecutable());
+  TEST_ASSERT(!file_1.IsExecutable());
 
   auto dir = LibXR::RamFS::CreateDir("test_dir");
   auto nested_dir = LibXR::RamFS::CreateDir("nested_dir");
@@ -59,18 +60,18 @@ void test_ramfs()
   for (int i = 1; i < 10; i++)
   {
     command.Run(0, nullptr);
-    ASSERT(file_1.Data<const int>() == i);
+    TEST_ASSERT(file_1.Data<const int>() == i);
   }
 
   file_1.Data<int>() = 42;
-  ASSERT(ramfs_arg == 42);
+  TEST_ASSERT(ramfs_arg == 42);
 
   const uint32_t ro_value = 0x12345678;
   auto ro_file = LibXR::RamFS::CreateFile("ro_file", ro_value);
-  ASSERT(ro_file.IsReadOnly());
-  ASSERT(ro_file.Data<const uint32_t>() == ro_value);
+  TEST_ASSERT(ro_file.IsReadOnly());
+  TEST_ASSERT(ro_file.Data<const uint32_t>() == ro_value);
   const auto& ro_file_view = ro_file;
-  ASSERT(ro_file_view.Data().size_ == sizeof(ro_value));
+  TEST_ASSERT(ro_file_view.Data().size_ == sizeof(ro_value));
 
   uint16_t nested_value = 0x55AA;
   auto nested_file = LibXR::RamFS::CreateFile("nested_file", nested_value);
@@ -86,25 +87,25 @@ void test_ramfs()
   dir.Add(custom);
   nested_dir.Add(nested_file);
 
-  ASSERT(ramfs.FindDir("test") == nullptr);
-  ASSERT(ramfs.FindFile("test") == nullptr);
-  ASSERT(ramfs.FindCustom("test") == nullptr);
-  ASSERT(dir.FindFile("test") == nullptr);
+  TEST_ASSERT(ramfs.FindDir("test") == nullptr);
+  TEST_ASSERT(ramfs.FindFile("test") == nullptr);
+  TEST_ASSERT(ramfs.FindCustom("test") == nullptr);
+  TEST_ASSERT(dir.FindFile("test") == nullptr);
 
-  ASSERT(ramfs.FindDir("test_dir") == &dir);
-  ASSERT(ramfs.FindFile("test_file1") == &file_1);
-  ASSERT(ramfs.FindFile("test_command") == &command);
-  ASSERT(ramfs.FindFile("nested_file") == &nested_file);
-  ASSERT(ramfs.FindCustom("custom_node") == &custom);
-  ASSERT(dir.FindFile("test_command") == &command);
-  ASSERT(dir.FindCustom("custom_node") == &custom);
-  ASSERT(dir.FindNode("custom_node") == &custom);
-  ASSERT(custom.kind_ == 0x42);
-  ASSERT(custom.context_ == &custom_context);
-  ASSERT(dir.FindFile("ro_file") == &ro_file);
-  ASSERT(dir.FindDir(".") == &dir);
-  ASSERT(dir.FindDir("..") == &ramfs.root_);
-  ASSERT(nested_dir.FindDir("..") == &dir);
+  TEST_ASSERT(ramfs.FindDir("test_dir") == &dir);
+  TEST_ASSERT(ramfs.FindFile("test_file1") == &file_1);
+  TEST_ASSERT(ramfs.FindFile("test_command") == &command);
+  TEST_ASSERT(ramfs.FindFile("nested_file") == &nested_file);
+  TEST_ASSERT(ramfs.FindCustom("custom_node") == &custom);
+  TEST_ASSERT(dir.FindFile("test_command") == &command);
+  TEST_ASSERT(dir.FindCustom("custom_node") == &custom);
+  TEST_ASSERT(dir.FindNode("custom_node") == &custom);
+  TEST_ASSERT(custom.kind_ == 0x42);
+  TEST_ASSERT(custom.context_ == &custom_context);
+  TEST_ASSERT(dir.FindFile("ro_file") == &ro_file);
+  TEST_ASSERT(dir.FindDir(".") == &dir);
+  TEST_ASSERT(dir.FindDir("..") == &ramfs.root_);
+  TEST_ASSERT(nested_dir.FindDir("..") == &dir);
 
   uint32_t direct_child_count = 0;
   uint32_t direct_file_count = 0;
@@ -126,13 +127,13 @@ void test_ramfs()
             direct_custom_count++;
             break;
           default:
-            ASSERT(false);
+            TEST_ASSERT(false);
             break;
         }
         return LibXR::ErrorCode::OK;
       });
-  ASSERT(direct_child_count == 4);
-  ASSERT(direct_file_count == 2);
-  ASSERT(direct_dir_count == 1);
-  ASSERT(direct_custom_count == 1);
+  TEST_ASSERT(direct_child_count == 4);
+  TEST_ASSERT(direct_file_count == 2);
+  TEST_ASSERT(direct_dir_count == 1);
+  TEST_ASSERT(direct_custom_count == 1);
 }

--- a/test/base/middleware/terminal/terminal_display_test_common.hpp
+++ b/test/base/middleware/terminal/terminal_display_test_common.hpp
@@ -18,6 +18,7 @@
 #include "libxr_def.hpp"
 #include "libxr_pipe.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -47,7 +48,7 @@ struct TerminalDisplayFixture
    */
   std::string FlushOutput()
   {
-    ASSERT(terminal.write_stream_.Commit() == LibXR::ErrorCode::OK);
+    TEST_ASSERT(terminal.write_stream_.Commit() == LibXR::ErrorCode::OK);
 
     const size_t output_size = output.GetReadPort().Size();
     if (output_size == 0)
@@ -57,8 +58,8 @@ struct TerminalDisplayFixture
 
     std::string text(output_size, '\0');
     LibXR::ReadOperation read_op;
-    ASSERT(output.GetReadPort()(LibXR::RawData{text.data(), output_size}, read_op) ==
-           LibXR::ErrorCode::OK);
+    TEST_ASSERT(output.GetReadPort()(LibXR::RawData{text.data(), output_size}, read_op) ==
+                LibXR::ErrorCode::OK);
     return text;
   }
 };

--- a/test/base/middleware/terminal/terminal_session_test_common.hpp
+++ b/test/base/middleware/terminal/terminal_session_test_common.hpp
@@ -20,6 +20,7 @@
 #include "libxr_def.hpp"
 #include "libxr_pipe.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -42,10 +43,10 @@ int CountCommand(CommandState* state, int argc, char** argv)
 {
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
-  ASSERT(state != nullptr);
-  ASSERT(state->count != nullptr);
-  ASSERT(argc == 1);
-  ASSERT(std::strcmp(argv[0], state->expected_name) == 0);
+  TEST_ASSERT(state != nullptr);
+  TEST_ASSERT(state->count != nullptr);
+  TEST_ASSERT(argc == 1);
+  TEST_ASSERT(std::strcmp(argv[0], state->expected_name) == 0);
   (*state->count)++;
   return 0;
 }
@@ -106,7 +107,7 @@ struct TerminalFixture
         return;
       }
     }
-    ASSERT(false);
+    TEST_ASSERT(false);
   }
 
   /**
@@ -127,8 +128,8 @@ struct TerminalFixture
 
     std::string text(output_size, '\0');
     LibXR::ReadOperation read_op;
-    ASSERT(output.GetReadPort()(LibXR::RawData{text.data(), output_size}, read_op) ==
-           LibXR::ErrorCode::OK);
+    TEST_ASSERT(output.GetReadPort()(LibXR::RawData{text.data(), output_size}, read_op) ==
+                LibXR::ErrorCode::OK);
     return text;
   }
 
@@ -143,8 +144,8 @@ struct TerminalFixture
   std::string SendRaw(const void* data, size_t size)
   {
     LibXR::WriteOperation write_op;
-    ASSERT(input.GetWritePort()(LibXR::ConstRawData{data, size}, write_op) ==
-           LibXR::ErrorCode::OK);
+    TEST_ASSERT(input.GetWritePort()(LibXR::ConstRawData{data, size}, write_op) ==
+                LibXR::ErrorCode::OK);
     RunUntilIdle();
     return DrainOutput();
   }

--- a/test/base/middleware/terminal/test_command_cd.cpp
+++ b/test/base/middleware/terminal/test_command_cd.cpp
@@ -10,6 +10,7 @@
  *          2. Invalid paths do not corrupt the current directory or prompt.
  */
 #include "terminal_session_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -34,29 +35,29 @@ void TestCdBuiltins()
   dir1.Add(dir2);
 
   auto output = fixture.SendText("cd dir1\n");
-  ASSERT(fixture.terminal.current_dir_ == &dir1);
-  ASSERT(output.find("ramfs:dir1$ ") != std::string::npos);
+  TEST_ASSERT(fixture.terminal.current_dir_ == &dir1);
+  TEST_ASSERT(output.find("ramfs:dir1$ ") != std::string::npos);
 
   output = fixture.SendText("cd .\n");
-  ASSERT(fixture.terminal.current_dir_ == &dir1);
-  ASSERT(output.find("ramfs:dir1$ ") != std::string::npos);
+  TEST_ASSERT(fixture.terminal.current_dir_ == &dir1);
+  TEST_ASSERT(output.find("ramfs:dir1$ ") != std::string::npos);
 
   output = fixture.SendText("cd dir2\n");
-  ASSERT(fixture.terminal.current_dir_ == &dir2);
-  ASSERT(output.find("ramfs:dir2$ ") != std::string::npos);
+  TEST_ASSERT(fixture.terminal.current_dir_ == &dir2);
+  TEST_ASSERT(output.find("ramfs:dir2$ ") != std::string::npos);
 
   output = fixture.SendText("cd ..\n");
-  ASSERT(fixture.terminal.current_dir_ == &dir1);
-  ASSERT(output.find("ramfs:dir1$ ") != std::string::npos);
+  TEST_ASSERT(fixture.terminal.current_dir_ == &dir1);
+  TEST_ASSERT(output.find("ramfs:dir1$ ") != std::string::npos);
 
   output = fixture.SendText("cd /\n");
-  ASSERT(fixture.terminal.current_dir_ == &fixture.ramfs.root_);
-  ASSERT(output.find("ramfs:/$ ") != std::string::npos);
+  TEST_ASSERT(fixture.terminal.current_dir_ == &fixture.ramfs.root_);
+  TEST_ASSERT(output.find("ramfs:/$ ") != std::string::npos);
 
   output = fixture.SendText("cd missing\n");
-  ASSERT(fixture.terminal.current_dir_ == &fixture.ramfs.root_);
-  ASSERT(output.find("Command not found.") == std::string::npos);
-  ASSERT(output.find("ramfs:/$ ") != std::string::npos);
+  TEST_ASSERT(fixture.terminal.current_dir_ == &fixture.ramfs.root_);
+  TEST_ASSERT(output.find("Command not found.") == std::string::npos);
+  TEST_ASSERT(output.find("ramfs:/$ ") != std::string::npos);
 }
 
 }  // namespace

--- a/test/base/middleware/terminal/test_command_ls.cpp
+++ b/test/base/middleware/terminal/test_command_ls.cpp
@@ -10,6 +10,7 @@
  *          2. Listing scope follows the current directory after changing directories.
  */
 #include "terminal_session_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -50,21 +51,21 @@ void TestLsBuiltin()
   dir1.Add(nested);
 
   auto output = fixture.SendText("ls\n");
-  ASSERT(output.find("d dir1") != std::string::npos);
-  ASSERT(output.find("x run") != std::string::npos);
-  ASSERT(output.find("f file") != std::string::npos);
-  ASSERT(output.find("? custom") != std::string::npos);
-  ASSERT(output.find("ramfs:/$ ") != std::string::npos);
+  TEST_ASSERT(output.find("d dir1") != std::string::npos);
+  TEST_ASSERT(output.find("x run") != std::string::npos);
+  TEST_ASSERT(output.find("f file") != std::string::npos);
+  TEST_ASSERT(output.find("? custom") != std::string::npos);
+  TEST_ASSERT(output.find("ramfs:/$ ") != std::string::npos);
 
   output = fixture.SendText("cd dir1\n");
-  ASSERT(fixture.terminal.current_dir_ == &dir1);
+  TEST_ASSERT(fixture.terminal.current_dir_ == &dir1);
 
   output = fixture.SendText("ls\n");
-  ASSERT(output.find("d nested") != std::string::npos);
-  ASSERT(output.find("x run") == std::string::npos);
-  ASSERT(output.find("f file") == std::string::npos);
-  ASSERT(output.find("? custom") == std::string::npos);
-  ASSERT(output.find("ramfs:dir1$ ") != std::string::npos);
+  TEST_ASSERT(output.find("d nested") != std::string::npos);
+  TEST_ASSERT(output.find("x run") == std::string::npos);
+  TEST_ASSERT(output.find("f file") == std::string::npos);
+  TEST_ASSERT(output.find("? custom") == std::string::npos);
+  TEST_ASSERT(output.find("ramfs:dir1$ ") != std::string::npos);
 }
 
 }  // namespace

--- a/test/base/middleware/terminal/test_display_history.cpp
+++ b/test/base/middleware/terminal/test_display_history.cpp
@@ -10,6 +10,7 @@
  *          2. Insert/delete redraw suffixes with a non-zero cursor offset.
  */
 #include "terminal_display_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -38,18 +39,18 @@ void TestHistoryDisplayAndRestore()
   fixture.terminal.history_index_ = 0;
   fixture.terminal.offset_ = -3;
   fixture.terminal.ShowHistory();
-  ASSERT(fixture.terminal.offset_ == 0);
-  ASSERT(fixture.FlushOutput() == "\033[2K\rramfs:/$ beta");
+  TEST_ASSERT(fixture.terminal.offset_ == 0);
+  TEST_ASSERT(fixture.FlushOutput() == "\033[2K\rramfs:/$ beta");
 
   fixture.terminal.history_index_ = 1;
   fixture.terminal.ShowHistory();
-  ASSERT(fixture.FlushOutput() == "\033[2K\rramfs:/$ alpha");
+  TEST_ASSERT(fixture.FlushOutput() == "\033[2K\rramfs:/$ alpha");
 
   fixture.terminal.CopyHistoryToInputLine();
-  ASSERT(fixture.terminal.history_index_ == -1);
-  ASSERT(fixture.terminal.offset_ == 0);
-  ASSERT(fixture.terminal.input_line_.Size() == 5);
-  ASSERT(std::strcmp(&fixture.terminal.input_line_[0], "alpha") == 0);
+  TEST_ASSERT(fixture.terminal.history_index_ == -1);
+  TEST_ASSERT(fixture.terminal.offset_ == 0);
+  TEST_ASSERT(fixture.terminal.input_line_.Size() == 5);
+  TEST_ASSERT(std::strcmp(&fixture.terminal.input_line_[0], "alpha") == 0);
 }
 
 /**
@@ -71,12 +72,12 @@ void TestMidLineDisplayEditing()
   FillInputLine(fixture.terminal, "ab");
   fixture.terminal.offset_ = -1;
   fixture.terminal.DisplayChar('X');
-  ASSERT(std::strcmp(&fixture.terminal.input_line_[0], "aXb") == 0);
-  ASSERT(fixture.FlushOutput() == "X\033[s\033[Kb\033[u");
+  TEST_ASSERT(std::strcmp(&fixture.terminal.input_line_[0], "aXb") == 0);
+  TEST_ASSERT(fixture.FlushOutput() == "X\033[s\033[Kb\033[u");
 
   fixture.terminal.DeleteChar();
-  ASSERT(std::strcmp(&fixture.terminal.input_line_[0], "ab") == 0);
-  ASSERT(fixture.FlushOutput() == "\b \b\033[s\033[Kb\033[u");
+  TEST_ASSERT(std::strcmp(&fixture.terminal.input_line_[0], "ab") == 0);
+  TEST_ASSERT(fixture.FlushOutput() == "\b \b\033[s\033[Kb\033[u");
 }
 
 }  // namespace

--- a/test/base/middleware/terminal/test_display_modes.cpp
+++ b/test/base/middleware/terminal/test_display_modes.cpp
@@ -10,6 +10,7 @@
  *          2. Prompt, clear-line, and clear-screen sequence output.
  */
 #include "terminal_display_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -29,15 +30,15 @@ void TestLineFeedModes()
   // modes.
   TerminalDisplayFixture<LibXR::Terminal<>::Mode::CRLF> crlf_fixture;
   crlf_fixture.terminal.LineFeed();
-  ASSERT(crlf_fixture.FlushOutput() == "\r\n");
+  TEST_ASSERT(crlf_fixture.FlushOutput() == "\r\n");
 
   TerminalDisplayFixture<LibXR::Terminal<>::Mode::LF> lf_fixture;
   lf_fixture.terminal.LineFeed();
-  ASSERT(lf_fixture.FlushOutput() == "\n");
+  TEST_ASSERT(lf_fixture.FlushOutput() == "\n");
 
   TerminalDisplayFixture<LibXR::Terminal<>::Mode::CR> cr_fixture;
   cr_fixture.terminal.LineFeed();
-  ASSERT(cr_fixture.FlushOutput() == "\r");
+  TEST_ASSERT(cr_fixture.FlushOutput() == "\r");
 }
 
 /**
@@ -57,19 +58,19 @@ void TestHeaderAndClearSequences()
   TerminalDisplayFixture<LibXR::Terminal<>::Mode::CRLF> fixture;
 
   fixture.terminal.ShowHeader();
-  ASSERT(fixture.FlushOutput() == "ramfs:/$ ");
+  TEST_ASSERT(fixture.FlushOutput() == "ramfs:/$ ");
 
   auto dir = LibXR::RamFS::CreateDir("dir1");
   fixture.ramfs.Add(dir);
   fixture.terminal.current_dir_ = &dir;
   fixture.terminal.ShowHeader();
-  ASSERT(fixture.FlushOutput() == "ramfs:dir1$ ");
+  TEST_ASSERT(fixture.FlushOutput() == "ramfs:dir1$ ");
 
   fixture.terminal.ClearLine();
-  ASSERT(fixture.FlushOutput() == "\033[2K\r");
+  TEST_ASSERT(fixture.FlushOutput() == "\033[2K\r");
 
   fixture.terminal.Clear();
-  ASSERT(fixture.FlushOutput() == "\033[2J\033[1H");
+  TEST_ASSERT(fixture.FlushOutput() == "\033[2J\033[1H");
 }
 
 }  // namespace

--- a/test/base/middleware/terminal/test_input_edit.cpp
+++ b/test/base/middleware/terminal/test_input_edit.cpp
@@ -10,6 +10,7 @@
  *          2. The final command name after inline editing executes as expected.
  */
 #include "terminal_session_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -40,9 +41,9 @@ void TestMidLineInputEditing()
 
   fixture.SendText("abd");
   auto cursor_moves = fixture.SendRaw(KEY_LEFT_LEFT, sizeof(KEY_LEFT_LEFT) - 1);
-  ASSERT(CountSubstring(cursor_moves, "\033[D") == 2);
+  TEST_ASSERT(CountSubstring(cursor_moves, "\033[D") == 2);
   fixture.SendText("c\n");
-  ASSERT(acbd_count == 1);
+  TEST_ASSERT(acbd_count == 1);
 }
 
 }  // namespace

--- a/test/base/middleware/terminal/test_input_history.cpp
+++ b/test/base/middleware/terminal/test_input_history.cpp
@@ -10,6 +10,7 @@
  *          2. `Up` / `Down` history navigation recalls newer and older commands.
  */
 #include "terminal_session_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -44,29 +45,29 @@ void TestInputCrLfAndHistory()
   fixture.ramfs.Add(two_cmd);
 
   fixture.SendText("one\r\n");
-  ASSERT(one_count == 1);
-  ASSERT(two_count == 0);
+  TEST_ASSERT(one_count == 1);
+  TEST_ASSERT(two_count == 0);
 
   fixture.SendText("two\n");
-  ASSERT(two_count == 1);
+  TEST_ASSERT(two_count == 1);
 
   constexpr char KEY_UP[] = "\033[A";
   constexpr char KEY_DOWN[] = "\033[B";
 
   auto newest_history = fixture.SendRaw(KEY_UP, sizeof(KEY_UP) - 1);
-  ASSERT(newest_history.find("\033[2K\r") != std::string::npos);
-  ASSERT(newest_history.find("two") != std::string::npos);
+  TEST_ASSERT(newest_history.find("\033[2K\r") != std::string::npos);
+  TEST_ASSERT(newest_history.find("two") != std::string::npos);
   fixture.SendText("\n");
-  ASSERT(two_count == 2);
+  TEST_ASSERT(two_count == 2);
 
   fixture.SendRaw(KEY_UP, sizeof(KEY_UP) - 1);
   fixture.SendRaw(KEY_UP, sizeof(KEY_UP) - 1);
   auto older_history = fixture.SendRaw(KEY_UP, sizeof(KEY_UP) - 1);
-  ASSERT(older_history.find("one") != std::string::npos);
+  TEST_ASSERT(older_history.find("one") != std::string::npos);
   auto move_forward_history = fixture.SendRaw(KEY_DOWN, sizeof(KEY_DOWN) - 1);
-  ASSERT(move_forward_history.find("two") != std::string::npos);
+  TEST_ASSERT(move_forward_history.find("two") != std::string::npos);
   fixture.SendText("\n");
-  ASSERT(two_count == 3);
+  TEST_ASSERT(two_count == 3);
 }
 
 }  // namespace

--- a/test/base/middleware/terminal/test_integration.cpp
+++ b/test/base/middleware/terminal/test_integration.cpp
@@ -26,6 +26,7 @@
 #include "libxr_def.hpp"
 #include "libxr_pipe.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_terminal`。 Test entry function `test_terminal`.
@@ -52,9 +53,9 @@ void test_terminal()
       "run",
       [](int* count, int argc, char** argv)
       {
-        ASSERT(argc == 1);
-        ASSERT(std::strcmp(argv[0], "dir1/dir2/dir3/run") == 0 ||
-               std::strcmp(argv[0], "/dir1/dir2/dir3/run") == 0);
+        TEST_ASSERT(argc == 1);
+        TEST_ASSERT(std::strcmp(argv[0], "dir1/dir2/dir3/run") == 0 ||
+                    std::strcmp(argv[0], "/dir1/dir2/dir3/run") == 0);
         (*count)++;
         return 0;
       },
@@ -72,16 +73,16 @@ void test_terminal()
   dir_3.Add(data_file);
 
   char absolute_path[] = "/dir1/dir2/dir3";
-  ASSERT(terminal.Path2Dir(absolute_path) == &dir_3);
-  ASSERT(std::strcmp(absolute_path, "/dir1/dir2/dir3") == 0);
+  TEST_ASSERT(terminal.Path2Dir(absolute_path) == &dir_3);
+  TEST_ASSERT(std::strcmp(absolute_path, "/dir1/dir2/dir3") == 0);
 
   char root_path[] = "/";
-  ASSERT(terminal.Path2Dir(root_path) == &ramfs.root_);
-  ASSERT(std::strcmp(root_path, "/") == 0);
+  TEST_ASSERT(terminal.Path2Dir(root_path) == &ramfs.root_);
+  TEST_ASSERT(std::strcmp(root_path, "/") == 0);
 
   char relative_path[] = "dir1/dir2/dir3";
-  ASSERT(terminal.Path2Dir(relative_path) == &dir_3);
-  ASSERT(std::strcmp(relative_path, "dir1/dir2/dir3") == 0);
+  TEST_ASSERT(terminal.Path2Dir(relative_path) == &dir_3);
+  TEST_ASSERT(std::strcmp(relative_path, "dir1/dir2/dir3") == 0);
 
   auto run_terminal_until_idle = [&]()
   {
@@ -94,14 +95,14 @@ void test_terminal()
         return;
       }
     }
-    ASSERT(false);
+    TEST_ASSERT(false);
   };
 
   auto write_raw = [&](const void* data, size_t size)
   {
     LibXR::WriteOperation write_op;
-    ASSERT(input.GetWritePort()(LibXR::ConstRawData{data, size}, write_op) ==
-           LibXR::ErrorCode::OK);
+    TEST_ASSERT(input.GetWritePort()(LibXR::ConstRawData{data, size}, write_op) ==
+                LibXR::ErrorCode::OK);
     run_terminal_until_idle();
   };
 
@@ -109,11 +110,11 @@ void test_terminal()
   { write_raw(command_line, std::strlen(command_line)); };
 
   write_line("dir1/dir2/dir3/run\n");
-  ASSERT(command_count == 1);
+  TEST_ASSERT(command_count == 1);
   write_line("/dir1/dir2/dir3/run\n");
-  ASSERT(command_count == 2);
+  TEST_ASSERT(command_count == 2);
   write_line("/dir1/dir2/dir3/data\n");
-  ASSERT(command_count == 2);
+  TEST_ASSERT(command_count == 2);
   write_line("unknown\n");
   write_line("alph\t\n");
   const unsigned char non_printable_unknown[] = {0xFF, 'u', 'n', 'k', 'n',
@@ -121,18 +122,18 @@ void test_terminal()
   write_raw(non_printable_unknown, sizeof(non_printable_unknown));
 
   const size_t output_size = output.GetReadPort().Size();
-  ASSERT(output_size > 0);
+  TEST_ASSERT(output_size > 0);
 
   std::vector<char> terminal_output(output_size + 1, '\0');
   LibXR::ReadOperation read_op;
-  ASSERT(output.GetReadPort()(LibXR::RawData{terminal_output.data(), output_size},
-                              read_op) == LibXR::ErrorCode::OK);
-  ASSERT(std::strstr(terminal_output.data(), "Not an executable file.") != nullptr);
-  ASSERT(std::strstr(terminal_output.data(), "Command not found.") != nullptr);
-  ASSERT(std::memchr(terminal_output.data(), static_cast<unsigned char>(0xFF),
-                     output_size) == nullptr);
-  ASSERT(std::strstr(terminal_output.data(), "alpha") != nullptr);
-  ASSERT(std::strstr(terminal_output.data(), "alphabet") != nullptr);
+  TEST_ASSERT(output.GetReadPort()(LibXR::RawData{terminal_output.data(), output_size},
+                                   read_op) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(std::strstr(terminal_output.data(), "Not an executable file.") != nullptr);
+  TEST_ASSERT(std::strstr(terminal_output.data(), "Command not found.") != nullptr);
+  TEST_ASSERT(std::memchr(terminal_output.data(), static_cast<unsigned char>(0xFF),
+                          output_size) == nullptr);
+  TEST_ASSERT(std::strstr(terminal_output.data(), "alpha") != nullptr);
+  TEST_ASSERT(std::strstr(terminal_output.data(), "alphabet") != nullptr);
 
   size_t command_not_found_count = 0;
   const char* search = terminal_output.data();
@@ -141,5 +142,5 @@ void test_terminal()
     command_not_found_count++;
     search += std::strlen("Command not found.");
   }
-  ASSERT(command_not_found_count == 2);
+  TEST_ASSERT(command_not_found_count == 2);
 }

--- a/test/base/rw/test_pipe_basic.cpp
+++ b/test/base/rw/test_pipe_basic.cpp
@@ -3,6 +3,7 @@
  * @brief Pipe 读写顺序与分批传输测试 / Pipe ordering and chunked transfer tests.
  */
 #include "rw_test_common.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 验证后续写入完成挂起读 / Verify that a later write completes a pending read.
@@ -22,12 +23,12 @@ void test_pipe_basic()
   WriteOperation wop;
 
   ErrorCode ec = r(RawData{rx, sizeof(rx)}, rop);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
   ec = w(ConstRawData{TX, sizeof(TX)}, wop);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
-  ASSERT(std::memcmp(rx, TX, sizeof(TX)) == 0);
+  TEST_ASSERT(std::memcmp(rx, TX, sizeof(TX)) == 0);
 }
 
 /**
@@ -49,12 +50,12 @@ void test_pipe_write_then_read()
   WriteOperation wop;
 
   ErrorCode ec = w(ConstRawData{TX, sizeof(TX)}, wop);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
   ec = r(RawData{rx, sizeof(rx)}, rop);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
-  ASSERT(std::memcmp(rx, TX, sizeof(TX)) == 0);
+  TEST_ASSERT(std::memcmp(rx, TX, sizeof(TX)) == 0);
 }
 
 /**
@@ -78,15 +79,15 @@ void test_pipe_chunked_rw()
   WriteOperation w2;
 
   ErrorCode ec = r(RawData{rx, sizeof(rx)}, rop);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
   ec = w(ConstRawData{TX1, sizeof(TX1)}, w1);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
   ec = w(ConstRawData{TX2, sizeof(TX2)}, w2);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
   static const uint8_t EXPECT[] = {'H', 'e', 'l', 'l', 'o', ' ', 'X', 'R'};
-  ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
+  TEST_ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
 }
 
 /**
@@ -106,17 +107,17 @@ void test_pipe_stream_api()
 
   ReadOperation rop;
   ErrorCode ec = r(RawData{rx, sizeof(rx)}, rop);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
   WritePort::Stream ws(&w, wop);
   static const uint8_t A[] = {0xAA, 0xBB, 0xCC};
   static const uint8_t B[] = {0x11, 0x22, 0x33, 0x44, 0x55};
   ws << ConstRawData{A, sizeof(A)} << ConstRawData{B, sizeof(B)};
   ec = ws.Commit();
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
   static const uint8_t EXPECT[] = {0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33, 0x44, 0x55};
-  ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
+  TEST_ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
 }
 
 /**

--- a/test/base/rw/test_pipe_stream.cpp
+++ b/test/base/rw/test_pipe_stream.cpp
@@ -3,6 +3,7 @@
  * @brief Pipe 流提交与复用测试 / Pipe stream submission and reuse tests.
  */
 #include "rw_test_common.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 验证 Pipe 阻塞流提交不残留信号量
@@ -18,7 +19,7 @@ void test_pipe_stream_block_immediate_path()
 
   uint8_t rx[8] = {0};
   ReadOperation rop;
-  ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
+  TEST_ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
 
   Semaphore sem;
   WriteOperation wop(sem, 100);
@@ -28,11 +29,11 @@ void test_pipe_stream_block_immediate_path()
   ws << ConstRawData{A, sizeof(A)} << ConstRawData{B, sizeof(B)};
 
   auto ec = ws.Commit();
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
   static const uint8_t EXPECT[] = {0x21, 0x22, 0x23, 0x31, 0x32, 0x33, 0x34, 0x35};
-  ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
+  TEST_ASSERT(sem.Value() == 0);
 }
 
 /**
@@ -51,20 +52,20 @@ void test_pipe_stream_commit_releases_lock_for_next_stream()
   uint8_t rx[sizeof(A) + sizeof(B)] = {0};
 
   ReadOperation rop;
-  ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
+  TEST_ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
 
   WriteOperation op1;
   WritePort::Stream ws1(&w, op1);
   ws1 << ConstRawData{A, sizeof(A)};
-  ASSERT(ws1.Commit() == ErrorCode::OK);
+  TEST_ASSERT(ws1.Commit() == ErrorCode::OK);
 
   WriteOperation op2;
   WritePort::Stream ws2(&w, op2);
   ws2 << ConstRawData{B, sizeof(B)};
-  ASSERT(ws2.Commit() == ErrorCode::OK);
+  TEST_ASSERT(ws2.Commit() == ErrorCode::OK);
 
   static const uint8_t EXPECT[] = {0x10, 0x11, 0x12, 0x20, 0x21, 0x22, 0x23};
-  ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
+  TEST_ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
 }
 
 /**
@@ -85,23 +86,23 @@ void test_pipe_stream_commit_allows_persistent_and_external_streams()
   uint8_t rx[sizeof(A) + sizeof(B) + sizeof(C)] = {0};
 
   ReadOperation rop;
-  ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
+  TEST_ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
 
   WriteOperation owner_op;
   WritePort::Stream owner(&w, owner_op);
   owner << ConstRawData{A, sizeof(A)};
-  ASSERT(owner.Commit() == ErrorCode::OK);
+  TEST_ASSERT(owner.Commit() == ErrorCode::OK);
 
   WriteOperation external_op;
   WritePort::Stream external(&w, external_op);
   external << ConstRawData{B, sizeof(B)};
-  ASSERT(external.Commit() == ErrorCode::OK);
+  TEST_ASSERT(external.Commit() == ErrorCode::OK);
 
   owner << ConstRawData{C, sizeof(C)};
-  ASSERT(owner.Commit() == ErrorCode::OK);
+  TEST_ASSERT(owner.Commit() == ErrorCode::OK);
 
   static const uint8_t EXPECT[] = {'T', '1', 'E', 'X', 'T', 'T', '2', '!'};
-  ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
+  TEST_ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
 }
 
 /**

--- a/test/base/rw/test_pipe_stress.cpp
+++ b/test/base/rw/test_pipe_stress.cpp
@@ -4,6 +4,7 @@
  * mode scenarios.
  */
 #include "rw_test_common.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_pipe_mode_matrix`。 Test entry function
@@ -60,7 +61,7 @@ void test_pipe_reuse_stress()
 
     if ((iter & 1u) == 0)
     {
-      ASSERT(r(RawData{rx.data(), rx.size()}, read.op) == ErrorCode::OK);
+      TEST_ASSERT(r(RawData{rx.data(), rx.size()}, read.op) == ErrorCode::OK);
       read.ExpectPendingSubmitted();
       ExpectCallResult(write, w(ConstRawData{tx.data(), tx.size()}, write.op),
                        ErrorCode::OK);
@@ -73,9 +74,9 @@ void test_pipe_reuse_stress()
       ExpectCallResult(read, r(RawData{rx.data(), rx.size()}, read.op), ErrorCode::OK);
     }
 
-    ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
-    ASSERT(r.Size() == 0);
-    ASSERT(w.Size() == 0);
+    TEST_ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
+    TEST_ASSERT(r.Size() == 0);
+    TEST_ASSERT(w.Size() == 0);
   }
 }
 
@@ -117,7 +118,7 @@ void test_pipe_block_reuse_stress()
       Thread writer;
       StartDelayedPipeWriter(writer, ctx, "pipe_block_async");
 
-      ASSERT(r(RawData{rx.data(), rx.size()}, read.op) == ErrorCode::OK);
+      TEST_ASSERT(r(RawData{rx.data(), rx.size()}, read.op) == ErrorCode::OK);
       ExpectWaitOk(write_done);
       JoinThreadIfNeeded(writer);
       ExpectCallResult(write, ctx.result, ErrorCode::OK);
@@ -129,9 +130,9 @@ void test_pipe_block_reuse_stress()
       ExpectCallResult(read, r(RawData{rx.data(), rx.size()}, read.op), ErrorCode::OK);
     }
 
-    ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
-    ASSERT(r.Size() == 0);
-    ASSERT(w.Size() == 0);
+    TEST_ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
+    TEST_ASSERT(r.Size() == 0);
+    TEST_ASSERT(w.Size() == 0);
   }
 }
 

--- a/test/base/rw/test_rw_block_timeout.cpp
+++ b/test/base/rw/test_rw_block_timeout.cpp
@@ -4,6 +4,7 @@
  *        / RW timeout, unconfigured-port, and capacity tests.
  */
 #include "rw_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -25,23 +26,23 @@ void test_rw_block_read_timeout_detaches_pending()
   ReadOperation block_op(sem, 0);
 
   auto ec = r(RawData{timed_out_rx, sizeof(timed_out_rx)}, block_op);
-  ASSERT(ec == ErrorCode::TIMEOUT);
+  TEST_ASSERT(ec == ErrorCode::TIMEOUT);
 
   static const uint8_t STALE_EXPECT[] = {0xA1, 0xA2, 0xA3, 0xA4};
-  ASSERT(std::memcmp(timed_out_rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
+  TEST_ASSERT(std::memcmp(timed_out_rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
 
   static const uint8_t TX[] = {0x10, 0x20, 0x30, 0x40};
   WriteOperation wop;
   ec = w(ConstRawData{TX, sizeof(TX)}, wop);
-  ASSERT(ec == ErrorCode::OK);
-  ASSERT(std::memcmp(timed_out_rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(std::memcmp(timed_out_rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
+  TEST_ASSERT(sem.Value() == 0);
 
   uint8_t fresh_rx[sizeof(TX)] = {0};
   ReadOperation rop;
   ec = r(RawData{fresh_rx, sizeof(fresh_rx)}, rop);
-  ASSERT(ec == ErrorCode::OK);
-  ASSERT(std::memcmp(fresh_rx, TX, sizeof(TX)) == 0);
+  TEST_ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(std::memcmp(fresh_rx, TX, sizeof(TX)) == 0);
 }
 
 /**
@@ -61,30 +62,30 @@ void test_rw_block_write_timeout_detaches_waiter()
   Semaphore sem1;
   WriteOperation op1(sem1, 0);
   auto ec = w(ConstRawData{TX1, sizeof(TX1)}, op1);
-  ASSERT(ec == ErrorCode::TIMEOUT);
-  ASSERT(sem1.Value() == 0);
+  TEST_ASSERT(ec == ErrorCode::TIMEOUT);
+  TEST_ASSERT(sem1.Value() == 0);
 
   static uint8_t sink[sizeof(TX1)] = {};
   {
     auto queue = w.GetWriteQueue(false);
-    ASSERT(!queue.Empty());
+    TEST_ASSERT(!queue.Empty());
     queue.PopAll(sink);
   }
 
   Semaphore sem2;
   WriteOperation op2(sem2, 0);
   ec = w(ConstRawData{TX2, sizeof(TX2)}, op2);
-  ASSERT(ec == ErrorCode::TIMEOUT);
-  ASSERT(sem2.Value() == 0);
+  TEST_ASSERT(ec == ErrorCode::TIMEOUT);
+  TEST_ASSERT(sem2.Value() == 0);
 
   static uint8_t sink2[sizeof(TX2)] = {};
   {
     auto queue = w.GetWriteQueue(false);
-    ASSERT(!queue.Empty());
+    TEST_ASSERT(!queue.Empty());
     queue.PopAll(sink2);
   }
-  ASSERT(sem1.Value() == 0);
-  ASSERT(sem2.Value() == 0);
+  TEST_ASSERT(sem1.Value() == 0);
+  TEST_ASSERT(sem2.Value() == 0);
 }
 
 /**
@@ -98,22 +99,22 @@ void test_rw_admission_and_capacity_errors()
   ReadPort unbound(0);
   ReadOperation read_op;
   uint8_t byte = 0;
-  ASSERT(unbound(RawData{&byte, 1}, read_op) == ErrorCode::NOT_SUPPORT);
-  ASSERT(unbound(RawData{nullptr, 0}, read_op) == ErrorCode::NOT_SUPPORT);
+  TEST_ASSERT(unbound(RawData{&byte, 1}, read_op) == ErrorCode::NOT_SUPPORT);
+  TEST_ASSERT(unbound(RawData{nullptr, 0}, read_op) == ErrorCode::NOT_SUPPORT);
 
   ReadPort read(1);
-  ASSERT(read(RawData{&byte, 2}, read_op) == ErrorCode::SIZE_ERR);
-  ASSERT(read.Size() == 0);
+  TEST_ASSERT(read(RawData{&byte, 2}, read_op) == ErrorCode::SIZE_ERR);
+  TEST_ASSERT(read.Size() == 0);
 
   WritePort unconfigured(2, 1);
   WriteOperation write_op;
-  ASSERT(unconfigured(ConstRawData{&byte, 1}, write_op) == ErrorCode::NOT_SUPPORT);
+  TEST_ASSERT(unconfigured(ConstRawData{&byte, 1}, write_op) == ErrorCode::NOT_SUPPORT);
 
   WritePort full(2, 1);
   full = PendingWriteFun;
   const uint8_t pair[2] = {0x55, 0x66};
-  ASSERT(full(ConstRawData{pair, sizeof(pair)}, write_op) == ErrorCode::FULL);
-  ASSERT(full.Size() == 0);
+  TEST_ASSERT(full(ConstRawData{pair, sizeof(pair)}, write_op) == ErrorCode::FULL);
+  TEST_ASSERT(full.Size() == 0);
 }
 
 }  // namespace

--- a/test/base/rw/test_rw_block_waiter.cpp
+++ b/test/base/rw/test_rw_block_waiter.cpp
@@ -11,6 +11,7 @@
  * next wait cycle.
  */
 #include "rw_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -40,7 +41,7 @@ void test_rw_write_port_block_pending_result_propagates()
   StartWriteFinisher(finisher, w, done, ErrorCode::FAILED, "wr_finish");
 
   auto ec = w(ConstRawData{TX, sizeof(TX)}, op);
-  ASSERT(ec == ErrorCode::FAILED);
+  TEST_ASSERT(ec == ErrorCode::FAILED);
   ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
 }
@@ -71,20 +72,20 @@ void test_rw_write_port_block_reused_waiter_discards_stale_signal()
   StartWriteFinisher(finisher1, w, done1, ErrorCode::FAILED, "wr_stale1");
 
   auto ec = w(ConstRawData{TX1, sizeof(TX1)}, op);
-  ASSERT(ec == ErrorCode::FAILED);
+  TEST_ASSERT(ec == ErrorCode::FAILED);
   ExpectWaitOk(done1, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher1);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(sem.Value() == 0);
 
   Semaphore done2;
   Thread finisher2;
   StartWriteFinisher(finisher2, w, done2, ErrorCode::OK, "wr_stale2");
 
   ec = w(ConstRawData{TX2, sizeof(TX2)}, op);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
   ExpectWaitOk(done2, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher2);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(sem.Value() == 0);
 }
 
 }  // namespace

--- a/test/base/rw/test_rw_pending.cpp
+++ b/test/base/rw/test_rw_pending.cpp
@@ -3,6 +3,7 @@
  * @brief 异步 RW 完成与容量边界测试 / Asynchronous RW completion and capacity tests.
  */
 #include "rw_test_common.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 验证异步读完成与写错误通知
@@ -38,14 +39,14 @@ void test_rw_edge_cases()
   WriteOperation op2;
   std::vector<uint8_t> tx1(w.EmptySize(), 0x3C);
 
-  ASSERT(!tx1.empty());
-  ASSERT(w(ConstRawData{tx1.data(), tx1.size()}, op1) == ErrorCode::OK);
+  TEST_ASSERT(!tx1.empty());
+  TEST_ASSERT(w(ConstRawData{tx1.data(), tx1.size()}, op1) == ErrorCode::OK);
   auto second_result = w(ConstRawData{tx2, sizeof(tx2)}, op2);
-  ASSERT(second_result == ErrorCode::FULL);
+  TEST_ASSERT(second_result == ErrorCode::FULL);
 
   {
     auto queue = w.GetWriteQueue(false);
-    ASSERT(!queue.Empty());
+    TEST_ASSERT(!queue.Empty());
     static uint8_t sink[4];
     queue.PopAll(sink);
   }

--- a/test/base/rw/test_rw_read_queue_clear.cpp
+++ b/test/base/rw/test_rw_read_queue_clear.cpp
@@ -3,6 +3,7 @@
  * @brief 接收队列清空与空间通知测试 / RX queue clearing and space notification tests.
  */
 #include "rw_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -20,14 +21,14 @@ void test_rw_read_port_clear_queued_data_clears_idle_queue()
   static const uint8_t TX[] = {0x21, 0x43, 0x65, 0x87};
   {
     auto queue = r.GetReadQueue(false);
-    ASSERT(queue.PushBatch(TX, sizeof(TX)) == ErrorCode::OK);
+    TEST_ASSERT(queue.PushBatch(TX, sizeof(TX)) == ErrorCode::OK);
     queue.Publish();
   }
-  ASSERT(r.Size() == sizeof(TX));
+  TEST_ASSERT(r.Size() == sizeof(TX));
 
-  ASSERT(r.ClearQueuedData() == ErrorCode::OK);
-  ASSERT(r.Size() == 0);
-  ASSERT(r.dequeue_count == 1);
+  TEST_ASSERT(r.ClearQueuedData() == ErrorCode::OK);
+  TEST_ASSERT(r.Size() == 0);
+  TEST_ASSERT(r.dequeue_count == 1);
 }
 
 /**
@@ -43,13 +44,13 @@ void test_rw_read_port_clear_queued_data_clears_event_queue()
   static const uint8_t TX[] = {0x12, 0x34, 0x56};
   {
     auto queue = r.GetReadQueue(false);
-    ASSERT(queue.PushBatch(TX, sizeof(TX)) == ErrorCode::OK);
+    TEST_ASSERT(queue.PushBatch(TX, sizeof(TX)) == ErrorCode::OK);
     queue.Publish();
   }
 
-  ASSERT(r.ClearQueuedData() == ErrorCode::OK);
-  ASSERT(r.Size() == 0);
-  ASSERT(r.dequeue_count == 1);
+  TEST_ASSERT(r.ClearQueuedData() == ErrorCode::OK);
+  TEST_ASSERT(r.Size() == 0);
+  TEST_ASSERT(r.dequeue_count == 1);
 }
 
 /**
@@ -64,27 +65,27 @@ void test_rw_read_port_clear_queued_data_busy_pending_read()
   uint8_t queued = 0x5A;
   {
     auto queue = r.GetReadQueue(false);
-    ASSERT(queue.PushBatch(&queued, 1) == ErrorCode::OK);
+    TEST_ASSERT(queue.PushBatch(&queued, 1) == ErrorCode::OK);
     queue.Publish();
   }
 
   uint8_t rx[2] = {0xA1, 0xA2};
   ReadHarness read(TestMode::POLLING);
-  ASSERT(r(RawData{rx, sizeof(rx)}, read.op) == ErrorCode::OK);
+  TEST_ASSERT(r(RawData{rx, sizeof(rx)}, read.op) == ErrorCode::OK);
   read.ExpectPendingSubmitted();
 
-  ASSERT(r.ClearQueuedData() == ErrorCode::BUSY);
-  ASSERT(r.Size() == 1);
-  ASSERT(r.dequeue_count == 0);
+  TEST_ASSERT(r.ClearQueuedData() == ErrorCode::BUSY);
+  TEST_ASSERT(r.Size() == 1);
+  TEST_ASSERT(r.dequeue_count == 0);
 
   const uint8_t completed = 0x6B;
   {
     auto queue = r.GetReadQueue(false);
-    ASSERT(queue.PushBatch(&completed, 1) == ErrorCode::OK);
+    TEST_ASSERT(queue.PushBatch(&completed, 1) == ErrorCode::OK);
     queue.Publish();
   }
   read.ExpectFinal(ErrorCode::OK);
-  ASSERT(r.Size() == 0);
+  TEST_ASSERT(r.Size() == 0);
 }
 
 }  // namespace

--- a/test/base/rw/test_rw_read_queue_pending.cpp
+++ b/test/base/rw/test_rw_read_queue_pending.cpp
@@ -4,6 +4,7 @@
  *        / Zero-length reads and background RX production tests.
  */
 #include "rw_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -29,7 +30,7 @@ void test_rw_zero_read_pending_notifies_without_dequeue()
     StartReadQueueCompleter(finisher, r, done, TX, sizeof(TX), "rd_zero_ready");
 
     auto ec = r(RawData{&dummy, 0}, read.op);
-    ASSERT(ec == ErrorCode::OK);
+    TEST_ASSERT(ec == ErrorCode::OK);
     ExpectWaitOk(done, SHORT_WAIT_MS);
     JoinThreadIfNeeded(finisher);
 
@@ -38,16 +39,16 @@ void test_rw_zero_read_pending_notifies_without_dequeue()
       read.ExpectFinal(ErrorCode::OK);
     }
 
-    ASSERT(dummy == 0xA0);
-    ASSERT(r.dequeue_count == 0);
-    ASSERT(r.Size() == sizeof(TX));
+    TEST_ASSERT(dummy == 0xA0);
+    TEST_ASSERT(r.dequeue_count == 0);
+    TEST_ASSERT(r.Size() == sizeof(TX));
 
     uint8_t follow_up[sizeof(TX)] = {};
     ReadOperation follow_op;
     ec = r(RawData{follow_up, sizeof(follow_up)}, follow_op);
-    ASSERT(ec == ErrorCode::OK);
-    ASSERT(std::memcmp(follow_up, TX, sizeof(TX)) == 0);
-    ASSERT(r.dequeue_count == 1);
+    TEST_ASSERT(ec == ErrorCode::OK);
+    TEST_ASSERT(std::memcmp(follow_up, TX, sizeof(TX)) == 0);
+    TEST_ASSERT(r.dequeue_count == 1);
   }
 }
 
@@ -70,11 +71,11 @@ void test_rw_read_port_block_queue_completion_copies_data()
   StartReadQueueCompleter(finisher, r, done, TX, sizeof(TX), "rd_queue_block");
 
   auto ec = r(RawData{rx, sizeof(rx)}, op);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
   ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
-  ASSERT(std::memcmp(rx, TX, sizeof(TX)) == 0);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(std::memcmp(rx, TX, sizeof(TX)) == 0);
+  TEST_ASSERT(sem.Value() == 0);
 }
 
 }  // namespace

--- a/test/base/string/test_string_errors.cpp
+++ b/test/base/string/test_string_errors.cpp
@@ -11,6 +11,7 @@
  * semantics.
  */
 #include "string_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -30,26 +31,26 @@ void TestRuntimeStringErrors()
   // Test coverage: verify error code, empty-view, and safe-storage semantics for
   // null-pointer inputs.
   LibXR::RuntimeStringView<> null_part("camera", static_cast<const char*>(nullptr));
-  ASSERT(null_part.Empty());
-  ASSERT(null_part.Status() == LibXR::ErrorCode::PTR_NULL);
-  ASSERT(null_part.Size() == 0);
+  TEST_ASSERT(null_part.Empty());
+  TEST_ASSERT(null_part.Status() == LibXR::ErrorCode::PTR_NULL);
+  TEST_ASSERT(null_part.Size() == 0);
 
   LibXR::RuntimeStringView<> null_copy(static_cast<const char*>(nullptr));
-  ASSERT(null_copy.Empty());
-  ASSERT(null_copy.Status() == LibXR::ErrorCode::PTR_NULL);
-  ASSERT(null_copy.Size() == 0);
-  ASSERT(null_copy.View().empty());
-  ASSERT(null_copy.CStr()[0] == '\0');
+  TEST_ASSERT(null_copy.Empty());
+  TEST_ASSERT(null_copy.Status() == LibXR::ErrorCode::PTR_NULL);
+  TEST_ASSERT(null_copy.Size() == 0);
+  TEST_ASSERT(null_copy.View().empty());
+  TEST_ASSERT(null_copy.CStr()[0] == '\0');
 
   LibXR::RuntimeStringView<> bare_null(nullptr);
-  ASSERT(bare_null.Empty());
-  ASSERT(bare_null.Status() == LibXR::ErrorCode::PTR_NULL);
-  ASSERT(bare_null.View().empty());
+  TEST_ASSERT(bare_null.Empty());
+  TEST_ASSERT(bare_null.Status() == LibXR::ErrorCode::PTR_NULL);
+  TEST_ASSERT(bare_null.View().empty());
 
   LibXR::RuntimeStringView<> bare_null_part("camera", nullptr);
-  ASSERT(bare_null_part.Empty());
-  ASSERT(bare_null_part.Status() == LibXR::ErrorCode::PTR_NULL);
-  ASSERT(bare_null_part.View().empty());
+  TEST_ASSERT(bare_null_part.Empty());
+  TEST_ASSERT(bare_null_part.Status() == LibXR::ErrorCode::PTR_NULL);
+  TEST_ASSERT(bare_null_part.View().empty());
 }
 
 }  // namespace

--- a/test/base/string/test_string_format.cpp
+++ b/test/base/string/test_string_format.cpp
@@ -13,6 +13,7 @@
  * output.
  */
 #include "string_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -32,40 +33,40 @@ void TestRuntimeStringFormat()
   // Test coverage: verify runtime formatting output, stable storage reuse, and
   // boundary-value paths.
   LibXR::RuntimeStringView<"camera_{}", unsigned int> formatted;
-  ASSERT(formatted.Reformat(7U) == LibXR::ErrorCode::OK);
-  ASSERT(formatted.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!formatted.Empty());
-  ASSERT(formatted.View() == std::string_view("camera_7"));
-  ASSERT(formatted.CStr()[formatted.Size()] == '\0');
+  TEST_ASSERT(formatted.Reformat(7U) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(formatted.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!formatted.Empty());
+  TEST_ASSERT(formatted.View() == std::string_view("camera_7"));
+  TEST_ASSERT(formatted.CStr()[formatted.Size()] == '\0');
 
   LibXR::RuntimeStringView<"frame_%03u", unsigned int> printf_formatted;
-  ASSERT(printf_formatted.Reprintf(5U) == LibXR::ErrorCode::OK);
-  ASSERT(printf_formatted.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!printf_formatted.Empty());
-  ASSERT(printf_formatted.View() == std::string_view("frame_005"));
-  ASSERT(printf_formatted.CStr()[printf_formatted.Size()] == '\0');
+  TEST_ASSERT(printf_formatted.Reprintf(5U) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(printf_formatted.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!printf_formatted.Empty());
+  TEST_ASSERT(printf_formatted.View() == std::string_view("frame_005"));
+  TEST_ASSERT(printf_formatted.CStr()[printf_formatted.Size()] == '\0');
 
   LibXR::RuntimeStringView<"stamp_%u", unsigned int> timestamp;
-  ASSERT(timestamp.Reprintf(1U) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(timestamp.Reprintf(1U) == LibXR::ErrorCode::OK);
   const char* timestamp_storage = timestamp.CStr();
-  ASSERT(timestamp.Reprintf(1234567890U) == LibXR::ErrorCode::OK);
-  ASSERT(timestamp.CStr() == timestamp_storage);
-  ASSERT(timestamp.View() == std::string_view("stamp_1234567890"));
+  TEST_ASSERT(timestamp.Reprintf(1234567890U) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(timestamp.CStr() == timestamp_storage);
+  TEST_ASSERT(timestamp.View() == std::string_view("stamp_1234567890"));
 
   LibXR::RuntimeStringView<"stamp_{}", std::uint32_t> format_timestamp;
-  ASSERT(format_timestamp.Reformat(std::uint32_t{1}) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(format_timestamp.Reformat(std::uint32_t{1}) == LibXR::ErrorCode::OK);
   const char* format_storage = format_timestamp.CStr();
-  ASSERT(format_timestamp.Reformat(std::numeric_limits<std::uint32_t>::max()) ==
-         LibXR::ErrorCode::OK);
-  ASSERT(format_timestamp.CStr() == format_storage);
-  ASSERT(format_timestamp.View() == std::string_view("stamp_4294967295"));
+  TEST_ASSERT(format_timestamp.Reformat(std::numeric_limits<std::uint32_t>::max()) ==
+              LibXR::ErrorCode::OK);
+  TEST_ASSERT(format_timestamp.CStr() == format_storage);
+  TEST_ASSERT(format_timestamp.View() == std::string_view("stamp_4294967295"));
 
   LibXR::RuntimeStringView<"float_%.0f", float> float_fixed;
-  ASSERT(float_fixed.Reprintf(1.0F) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(float_fixed.Reprintf(1.0F) == LibXR::ErrorCode::OK);
   const char* float_storage = float_fixed.CStr();
-  ASSERT(float_fixed.Reprintf(12345.0F) == LibXR::ErrorCode::OK);
-  ASSERT(float_fixed.CStr() == float_storage);
-  ASSERT(float_fixed.View() == std::string_view("float_12345"));
+  TEST_ASSERT(float_fixed.Reprintf(12345.0F) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(float_fixed.CStr() == float_storage);
+  TEST_ASSERT(float_fixed.View() == std::string_view("float_12345"));
 }
 
 }  // namespace

--- a/test/base/string/test_string_text.cpp
+++ b/test/base/string/test_string_text.cpp
@@ -10,6 +10,7 @@
  *          2. Embedded-NUL input and suffix-appending construction.
  */
 #include "string_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -28,82 +29,82 @@ void TestRuntimeStringText()
   // Test coverage: verify that different text sources preserve the expected view and
   // stable storage.
   LibXR::RuntimeStringView<> copied("camera");
-  ASSERT(copied.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!copied.Empty());
-  ASSERT(copied.View() == std::string_view("camera"));
-  ASSERT(copied.CStr()[copied.Size()] == '\0');
+  TEST_ASSERT(copied.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!copied.Empty());
+  TEST_ASSERT(copied.View() == std::string_view("camera"));
+  TEST_ASSERT(copied.CStr()[copied.Size()] == '\0');
 
   std::string_view copied_view = copied;
   const char* copied_cstr = copied;
-  ASSERT(copied_view == std::string_view("camera"));
-  ASSERT(copied_cstr == copied.CStr());
+  TEST_ASSERT(copied_view == std::string_view("camera"));
+  TEST_ASSERT(copied_cstr == copied.CStr());
 
   LibXR::RuntimeStringView<> empty_text("");
-  ASSERT(empty_text.Status() == LibXR::ErrorCode::OK);
-  ASSERT(empty_text.Empty());
-  ASSERT(empty_text.View().empty());
+  TEST_ASSERT(empty_text.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(empty_text.Empty());
+  TEST_ASSERT(empty_text.View().empty());
 
   char single_bounded_name[3] = {'i', 'm', 'u'};
   LibXR::RuntimeStringView<> single_bounded(single_bounded_name);
-  ASSERT(single_bounded.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!single_bounded.Empty());
-  ASSERT(single_bounded.View() == std::string_view("imu"));
+  TEST_ASSERT(single_bounded.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!single_bounded.Empty());
+  TEST_ASSERT(single_bounded.View() == std::string_view("imu"));
 
   const char const_single_bounded_name[3] = {'g', 'p', 'u'};
   LibXR::RuntimeStringView<> const_single_bounded(const_single_bounded_name);
-  ASSERT(const_single_bounded.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!const_single_bounded.Empty());
-  ASSERT(const_single_bounded.View() == std::string_view("gpu"));
+  TEST_ASSERT(const_single_bounded.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!const_single_bounded.Empty());
+  TEST_ASSERT(const_single_bounded.View() == std::string_view("gpu"));
 
   LibXR::RuntimeStringView<> text_embedded("ab\0cd");
-  ASSERT(text_embedded.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!text_embedded.Empty());
-  ASSERT(text_embedded.View() == std::string_view("ab"));
+  TEST_ASSERT(text_embedded.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!text_embedded.Empty());
+  TEST_ASSERT(text_embedded.View() == std::string_view("ab"));
 
   LibXR::RuntimeStringView<> raw_embedded(std::string_view("ab\0cd", 5));
-  ASSERT(raw_embedded.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!raw_embedded.Empty());
-  ASSERT(raw_embedded.View() == std::string_view("ab\0cd", 5));
-  ASSERT(raw_embedded.CStr()[raw_embedded.Size()] == '\0');
+  TEST_ASSERT(raw_embedded.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!raw_embedded.Empty());
+  TEST_ASSERT(raw_embedded.View() == std::string_view("ab\0cd", 5));
+  TEST_ASSERT(raw_embedded.CStr()[raw_embedded.Size()] == '\0');
 
   LibXR::RuntimeStringView gyro(std::string_view("camera"), "_gyro");
-  ASSERT(gyro.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!gyro.Empty());
-  ASSERT(gyro.View() == std::string_view("camera_gyro"));
+  TEST_ASSERT(gyro.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!gyro.Empty());
+  TEST_ASSERT(gyro.View() == std::string_view("camera_gyro"));
 
   std::string base = "camera";
   LibXR::RuntimeStringView<> accl(base, "_accl");
-  ASSERT(accl.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!accl.Empty());
-  ASSERT(accl.View() == std::string_view("camera_accl"));
+  TEST_ASSERT(accl.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!accl.Empty());
+  TEST_ASSERT(accl.View() == std::string_view("camera_accl"));
 
   LibXR::RuntimeStringView<> quat(copied, "_quat");
-  ASSERT(quat.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!quat.Empty());
-  ASSERT(quat.View() == std::string_view("camera_quat"));
+  TEST_ASSERT(quat.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!quat.Empty());
+  TEST_ASSERT(quat.View() == std::string_view("camera_quat"));
 
   char bounded_name[3] = {'i', 'm', 'u'};
   LibXR::RuntimeStringView<> bounded(bounded_name, "_rx");
-  ASSERT(bounded.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!bounded.Empty());
-  ASSERT(bounded.View() == std::string_view("imu_rx"));
+  TEST_ASSERT(bounded.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!bounded.Empty());
+  TEST_ASSERT(bounded.View() == std::string_view("imu_rx"));
 
   const char const_bounded_name[3] = {'g', 'p', 'u'};
   LibXR::RuntimeStringView<> const_bounded(const_bounded_name, "_tx");
-  ASSERT(const_bounded.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!const_bounded.Empty());
-  ASSERT(const_bounded.View() == std::string_view("gpu_tx"));
+  TEST_ASSERT(const_bounded.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!const_bounded.Empty());
+  TEST_ASSERT(const_bounded.View() == std::string_view("gpu_tx"));
 
   char padded_name[8] = {'a', '\0', 'x', 'x'};
   LibXR::RuntimeStringView<> padded(padded_name, "_1");
-  ASSERT(padded.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!padded.Empty());
-  ASSERT(padded.View() == std::string_view("a_1"));
+  TEST_ASSERT(padded.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!padded.Empty());
+  TEST_ASSERT(padded.View() == std::string_view("a_1"));
 
   LibXR::RuntimeStringView<> embedded_text_suffix("ab\0cd", "_x");
-  ASSERT(embedded_text_suffix.Status() == LibXR::ErrorCode::OK);
-  ASSERT(!embedded_text_suffix.Empty());
-  ASSERT(embedded_text_suffix.View() == std::string_view("ab_x"));
+  TEST_ASSERT(embedded_text_suffix.Status() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(!embedded_text_suffix.Empty());
+  TEST_ASSERT(embedded_text_suffix.View() == std::string_view("ab_x"));
 }
 
 }  // namespace

--- a/test/base/structure/test_double_buffer.cpp
+++ b/test/base/structure/test_double_buffer.cpp
@@ -24,6 +24,7 @@
 #include "libxr_def.hpp"
 #include "libxr_type.hpp"
 #include "test.hpp"  // 提供 ASSERT 宏
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_double_buffer`。 Test entry function `test_double_buffer`.
@@ -40,63 +41,65 @@ void test_double_buffer()
 
   LibXR::DoubleBuffer init_later;
   init_later.Init(raw);
-  ASSERT(init_later.Size() == 64);
-  ASSERT((reinterpret_cast<uintptr_t>(init_later.ActiveBuffer()) % alignof(size_t)) ==
-         0U);
-  ASSERT((reinterpret_cast<uintptr_t>(init_later.PendingBuffer()) % alignof(size_t)) ==
-         0U);
+  TEST_ASSERT(init_later.Size() == 64);
+  TEST_ASSERT(
+      (reinterpret_cast<uintptr_t>(init_later.ActiveBuffer()) % alignof(size_t)) == 0U);
+  TEST_ASSERT(
+      (reinterpret_cast<uintptr_t>(init_later.PendingBuffer()) % alignof(size_t)) == 0U);
 
   LibXR::DoubleBuffer empty_buffer;
   LibXR::RawData empty_raw(nullptr, 0);
   empty_buffer.Init(empty_raw);
-  ASSERT(empty_buffer.Size() == 0);
-  ASSERT(empty_buffer.ActiveBuffer() == nullptr);
-  ASSERT(empty_buffer.PendingBuffer() == nullptr);
-  ASSERT(empty_buffer.HasPending() == false);
-  ASSERT(empty_buffer.FillPending(nullptr, 0) == true);
-  ASSERT(empty_buffer.HasPending() == true);
-  ASSERT(empty_buffer.GetPendingLength() == 0);
+  TEST_ASSERT(empty_buffer.Size() == 0);
+  TEST_ASSERT(empty_buffer.ActiveBuffer() == nullptr);
+  TEST_ASSERT(empty_buffer.PendingBuffer() == nullptr);
+  TEST_ASSERT(empty_buffer.HasPending() == false);
+  TEST_ASSERT(empty_buffer.FillPending(nullptr, 0) == true);
+  TEST_ASSERT(empty_buffer.HasPending() == true);
+  TEST_ASSERT(empty_buffer.GetPendingLength() == 0);
   empty_buffer.Switch();
-  ASSERT(empty_buffer.ActiveBuffer() == nullptr);
-  ASSERT(empty_buffer.FillActive(nullptr, 0) == true);
+  TEST_ASSERT(empty_buffer.ActiveBuffer() == nullptr);
+  TEST_ASSERT(empty_buffer.FillActive(nullptr, 0) == true);
 
   LibXR::DoubleBuffer buffer(raw);
 
-  ASSERT(buffer.Size() == 64);  // 被平分成两块
-  ASSERT((reinterpret_cast<uintptr_t>(buffer.ActiveBuffer()) % alignof(size_t)) == 0U);
-  ASSERT((reinterpret_cast<uintptr_t>(buffer.PendingBuffer()) % alignof(size_t)) == 0U);
+  TEST_ASSERT(buffer.Size() == 64);  // 被平分成两块
+  TEST_ASSERT((reinterpret_cast<uintptr_t>(buffer.ActiveBuffer()) % alignof(size_t)) ==
+              0U);
+  TEST_ASSERT((reinterpret_cast<uintptr_t>(buffer.PendingBuffer()) % alignof(size_t)) ==
+              0U);
 
   // 1. 检查初始状态
-  ASSERT(buffer.HasPending() == false);
+  TEST_ASSERT(buffer.HasPending() == false);
 
   // 2. 写入 pending buffer
   uint8_t test_data[16];
   for (int i = 0; i < 16; ++i) test_data[i] = i;
 
-  ASSERT(buffer.FillPending(test_data, 16) == true);
-  ASSERT(buffer.HasPending() == true);
-  ASSERT(buffer.GetPendingLength() == 16);
-  ASSERT(std::memcmp(buffer.PendingBuffer(), test_data, 16) == 0);
+  TEST_ASSERT(buffer.FillPending(test_data, 16) == true);
+  TEST_ASSERT(buffer.HasPending() == true);
+  TEST_ASSERT(buffer.GetPendingLength() == 16);
+  TEST_ASSERT(std::memcmp(buffer.PendingBuffer(), test_data, 16) == 0);
 
   // 3. 禁止重复填充未发送的 buffer
-  ASSERT(buffer.FillPending(test_data, 8) == false);
+  TEST_ASSERT(buffer.FillPending(test_data, 8) == false);
 
   // 4. 执行 Switch() 切换
   buffer.Switch();
-  ASSERT(buffer.HasPending() == false);
-  ASSERT(buffer.ActiveBuffer() == buff + 64);  // 被切换为另一半
+  TEST_ASSERT(buffer.HasPending() == false);
+  TEST_ASSERT(buffer.ActiveBuffer() == buff + 64);  // 被切换为另一半
 
   // 5. 再次填充
   for (int i = 0; i < 10; ++i) test_data[i] = i + 100;
-  ASSERT(buffer.FillPending(test_data, 10) == true);
-  ASSERT(std::memcmp(buffer.PendingBuffer(), test_data, 10) == 0);
+  TEST_ASSERT(buffer.FillPending(test_data, 10) == true);
+  TEST_ASSERT(std::memcmp(buffer.PendingBuffer(), test_data, 10) == 0);
 
   buffer.Switch();
-  ASSERT(buffer.ActiveBuffer() == buff);  // 又回到了原来的 A 区
+  TEST_ASSERT(buffer.ActiveBuffer() == buff);  // 又回到了原来的 A 区
 
   buffer.FlipActiveBlock();
-  ASSERT(buffer.ActiveBuffer() == buff + 64);
+  TEST_ASSERT(buffer.ActiveBuffer() == buff + 64);
 
   // 6. 不合法长度填充
-  ASSERT(buffer.FillPending(test_data, 80) == false);  // 超过单 buffer 长度
+  TEST_ASSERT(buffer.FillPending(test_data, 80) == false);  // 超过单 buffer 长度
 }

--- a/test/base/structure/test_list.cpp
+++ b/test/base/structure/test_list.cpp
@@ -20,6 +20,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 static uint32_t counter = 0;
 
@@ -43,7 +44,7 @@ void test_list()
   list.Add(node2);
   list.Add(node3);
 
-  ASSERT(list.Size() == 3);
+  TEST_ASSERT(list.Size() == 3);
 
   auto node_foreach_fn = [](int& node)
   {
@@ -55,18 +56,18 @@ void test_list()
 
   list.Foreach<int>(node_foreach_fn);
 
-  ASSERT(counter == 3);
+  TEST_ASSERT(counter == 3);
 
-  ASSERT(list.Delete(node2) == LibXR::ErrorCode::OK);
-  ASSERT(list.Size() == 2);
+  TEST_ASSERT(list.Delete(node2) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(list.Size() == 2);
 
-  ASSERT(list.Delete(node1) == LibXR::ErrorCode::OK);
-  ASSERT(list.Size() == 1);
+  TEST_ASSERT(list.Delete(node1) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(list.Size() == 1);
 
-  ASSERT(list.Delete(node3) == LibXR::ErrorCode::OK);
-  ASSERT(list.Size() == 0);
+  TEST_ASSERT(list.Delete(node3) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(list.Size() == 0);
 
-  ASSERT(list.Delete(node1) == LibXR::ErrorCode::NOT_FOUND);
+  TEST_ASSERT(list.Delete(node1) == LibXR::ErrorCode::NOT_FOUND);
 
   LibXR::LockFreeList::Node<int> node4(10);
   LibXR::LockFreeList::Node<int> node5(20);
@@ -78,9 +79,9 @@ void test_list()
   list_lock_free.Add(node5);
   list_lock_free.Add(node6);
 
-  ASSERT(list_lock_free.Size() == 3);
+  TEST_ASSERT(list_lock_free.Size() == 3);
 
   list_lock_free.Foreach<int>(node_foreach_fn);
 
-  ASSERT(counter == 6);
+  TEST_ASSERT(counter == 6);
 }

--- a/test/base/structure/test_lockfree_list.cpp
+++ b/test/base/structure/test_lockfree_list.cpp
@@ -21,6 +21,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_lockfree_list`。 Test entry function `test_lockfree_list`.
@@ -41,18 +42,18 @@ void test_lockfree_list()
   list.Add(node2);
   list.Add(node3);
 
-  ASSERT(list.Size() == 3);
+  TEST_ASSERT(list.Size() == 3);
 
   const int expected[] = {30, 20, 10};
   uint32_t index = 0;
-  ASSERT(list.Foreach<int>(
-             [&](int& value)
-             {
-               ASSERT(value == expected[index]);
-               ++index;
-               return LibXR::ErrorCode::OK;
-             }) == LibXR::ErrorCode::OK);
-  ASSERT(index == 3);
+  TEST_ASSERT(list.Foreach<int>(
+                  [&](int& value)
+                  {
+                    TEST_ASSERT(value == expected[index]);
+                    ++index;
+                    return LibXR::ErrorCode::OK;
+                  }) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(index == 3);
 
   index = 0;
   const auto stop_result = list.Foreach<int>(
@@ -61,6 +62,6 @@ void test_lockfree_list()
         ++index;
         return value == 20 ? LibXR::ErrorCode::BUSY : LibXR::ErrorCode::OK;
       });
-  ASSERT(stop_result == LibXR::ErrorCode::BUSY);
-  ASSERT(index == 2);
+  TEST_ASSERT(stop_result == LibXR::ErrorCode::BUSY);
+  TEST_ASSERT(index == 2);
 }

--- a/test/base/structure/test_mpmc_queue.cpp
+++ b/test/base/structure/test_mpmc_queue.cpp
@@ -7,6 +7,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -69,7 +70,7 @@ void ProducerTask(ProducerArg arg)
   for (size_t offset = 0; offset < arg.count; ++offset)
   {
     const size_t value = arg.begin + offset;
-    ASSERT(value <= UINT16_MAX);
+    TEST_ASSERT(value <= UINT16_MAX);
     while (arg.queue->Push(static_cast<uint16_t>(value)) != LibXR::ErrorCode::OK)
     {
       LibXR::Thread::Yield();
@@ -90,14 +91,14 @@ void ConsumerTask(ConsumerArg arg)
     const auto ec = arg.queue->Pop(value);
     if (ec == LibXR::ErrorCode::OK)
     {
-      ASSERT(value < arg.total_items);
+      TEST_ASSERT(value < arg.total_items);
       const auto previous = arg.seen[value].exchange(1, std::memory_order_relaxed);
-      ASSERT(previous == 0);
+      TEST_ASSERT(previous == 0);
 
       arg.pop_sum->fetch_add(static_cast<unsigned long long>(value),
                              std::memory_order_relaxed);
       const size_t pop_index = arg.pop_count->fetch_add(1, std::memory_order_relaxed) + 1;
-      ASSERT(pop_index <= arg.total_items);
+      TEST_ASSERT(pop_index <= arg.total_items);
       continue;
     }
 
@@ -131,27 +132,27 @@ void test_mpmc_queue()
     Queue queue(3);
     Queue::ValueType value = 0;
 
-    ASSERT(queue.MaxSize() == 3);
-    ASSERT(queue.Size() == 0);
-    ASSERT(queue.EmptySize() == 3);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.MaxSize() == 3);
+    TEST_ASSERT(queue.Size() == 0);
+    TEST_ASSERT(queue.EmptySize() == 3);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
 
-    ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(22) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(33) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(44) == LibXR::ErrorCode::FULL);
-    ASSERT(queue.Size() == 3);
-    ASSERT(queue.EmptySize() == 0);
+    TEST_ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(22) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(33) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(44) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(queue.Size() == 3);
+    TEST_ASSERT(queue.EmptySize() == 0);
 
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 11);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 22);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 33);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
-    ASSERT(queue.Size() == 0);
-    ASSERT(queue.EmptySize() == 3);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 11);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 22);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 33);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Size() == 0);
+    TEST_ASSERT(queue.EmptySize() == 3);
   }
 
   // Repeat fill-and-drain cycles to verify FIFO order stays stable.
@@ -161,21 +162,21 @@ void test_mpmc_queue()
 
     for (size_t round = 0; round < 256; ++round)
     {
-      ASSERT(queue.Push(round * 4 + 0) == LibXR::ErrorCode::OK);
-      ASSERT(queue.Push(round * 4 + 1) == LibXR::ErrorCode::OK);
-      ASSERT(queue.Push(round * 4 + 2) == LibXR::ErrorCode::OK);
-      ASSERT(queue.Push(round * 4 + 3) == LibXR::ErrorCode::OK);
-      ASSERT(queue.Push(9999) == LibXR::ErrorCode::FULL);
+      TEST_ASSERT(queue.Push(round * 4 + 0) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(queue.Push(round * 4 + 1) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(queue.Push(round * 4 + 2) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(queue.Push(round * 4 + 3) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(queue.Push(9999) == LibXR::ErrorCode::FULL);
 
-      ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-      ASSERT(value == round * 4 + 0);
-      ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-      ASSERT(value == round * 4 + 1);
-      ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-      ASSERT(value == round * 4 + 2);
-      ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-      ASSERT(value == round * 4 + 3);
-      ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+      TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(value == round * 4 + 0);
+      TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(value == round * 4 + 1);
+      TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(value == round * 4 + 2);
+      TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(value == round * 4 + 3);
+      TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
     }
   }
 
@@ -184,15 +185,15 @@ void test_mpmc_queue()
     LibXR::MPMCQueue<double> queue(2);
     double value = 0.0;
 
-    ASSERT(queue.Push(1.25) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(2.5) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(3.75) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(queue.Push(1.25) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(2.5) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(3.75) == LibXR::ErrorCode::FULL);
 
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(EqualDouble(value, 1.25));
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(EqualDouble(value, 2.5));
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(EqualDouble(value, 1.25));
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(EqualDouble(value, 2.5));
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
   // Normal Push/Pop use byte payloads and do not require Payload{}.
@@ -201,10 +202,10 @@ void test_mpmc_queue()
     NoDefaultPayload pushed(77);
     NoDefaultPayload popped(0);
 
-    ASSERT(queue.Push(pushed) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Pop(popped) == LibXR::ErrorCode::OK);
-    ASSERT(popped.value == 77);
-    ASSERT(queue.Pop(popped) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Push(pushed) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Pop(popped) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(popped.value == 77);
+    TEST_ASSERT(queue.Pop(popped) == LibXR::ErrorCode::EMPTY);
   }
 
   // Two producers and two consumers with the smallest legal capacity.
@@ -254,23 +255,23 @@ void test_mpmc_queue()
       LibXR::Thread::Sleep(1);
     }
 
-    ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
-    ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
+    TEST_ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
+    TEST_ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
     for (auto& producer : producers)
     {
-      ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+      TEST_ASSERT(producer.Join() == LibXR::ErrorCode::OK);
     }
     for (auto& consumer : consumers)
     {
-      ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
+      TEST_ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
     }
-    ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
-    ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
+    TEST_ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
 
     for (size_t index = 0; index < TOTAL_ITEMS; ++index)
     {
-      ASSERT(seen[index].load(std::memory_order_relaxed) == 1);
+      TEST_ASSERT(seen[index].load(std::memory_order_relaxed) == 1);
     }
   }
 
@@ -321,23 +322,23 @@ void test_mpmc_queue()
       LibXR::Thread::Sleep(1);
     }
 
-    ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
-    ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
+    TEST_ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
+    TEST_ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
     for (auto& producer : producers)
     {
-      ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+      TEST_ASSERT(producer.Join() == LibXR::ErrorCode::OK);
     }
     for (auto& consumer : consumers)
     {
-      ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
+      TEST_ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
     }
-    ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
-    ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
+    TEST_ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
 
     for (size_t index = 0; index < TOTAL_ITEMS; ++index)
     {
-      ASSERT(seen[index].load(std::memory_order_relaxed) == 1);
+      TEST_ASSERT(seen[index].load(std::memory_order_relaxed) == 1);
     }
   }
 }

--- a/test/base/structure/test_object_pool.cpp
+++ b/test/base/structure/test_object_pool.cpp
@@ -1,5 +1,6 @@
 #include "libxr.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -18,13 +19,13 @@ void RunExternalQueueChecks()
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle b;
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle c;
 
-  ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
-  ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
-  ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
-  ASSERT(pool.EmptySize() == 0);
+  TEST_ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(pool.EmptySize() == 0);
 
   b.Reset();
-  ASSERT(pool.EmptySize() == 1);
+  TEST_ASSERT(pool.EmptySize() == 1);
 }
 
 template <typename QueueType>
@@ -34,9 +35,9 @@ void RunExternalSlotChecks()
   LibXR::BasicObjectPool<Payload, QueueType> pool(3, slots);
 
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle handle;
-  ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
   handle->value = 123;
-  ASSERT(slots[handle.Index()].value == 123);
+  TEST_ASSERT(slots[handle.Index()].value == 123);
 }
 
 template <typename QueueType>
@@ -47,9 +48,9 @@ void RunExternalQueueAndSlotChecks()
   LibXR::BasicObjectPool<Payload, QueueType> pool(free_queue, 3, slots);
 
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle handle;
-  ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
   handle->value = 456;
-  ASSERT(slots[handle.Index()].value == 456);
+  TEST_ASSERT(slots[handle.Index()].value == 456);
 }
 }  // namespace
 
@@ -64,26 +65,26 @@ void test_object_pool()
     LibXR::ObjectPool<Payload>::Handle c;
     LibXR::ObjectPool<Payload>::Handle d;
 
-    ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
-    ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
-    ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
-    ASSERT(pool.EmptySize() == 0);
-    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.EmptySize() == 0);
+    TEST_ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
 
     a->value = 11;
     b->value = 22;
     c->value = 33;
-    ASSERT((*a).value == 11);
-    ASSERT((*b).value == 22);
-    ASSERT((*c).value == 33);
+    TEST_ASSERT((*a).value == 11);
+    TEST_ASSERT((*b).value == 22);
+    TEST_ASSERT((*c).value == 33);
 
     const auto a_index = a.Index();
     a.Reset();
-    ASSERT(pool.EmptySize() == 1);
-    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
-    ASSERT(d.Index() == a_index);
+    TEST_ASSERT(pool.EmptySize() == 1);
+    TEST_ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(d.Index() == a_index);
     d->value = 44;
-    ASSERT(pool.UnsafeAt(d.Index()).value == 44);
+    TEST_ASSERT(pool.UnsafeAt(d.Index()).value == 44);
   }
 
   // The same pool contract should work with the typed SPSC free-index queue.
@@ -95,26 +96,26 @@ void test_object_pool()
     LibXR::SPSCObjectPool<Payload>::Handle c;
     LibXR::SPSCObjectPool<Payload>::Handle d;
 
-    ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
-    ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
-    ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
-    ASSERT(pool.EmptySize() == 0);
-    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.EmptySize() == 0);
+    TEST_ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
 
     a->value = 11;
     b->value = 22;
     c->value = 33;
-    ASSERT((*a).value == 11);
-    ASSERT((*b).value == 22);
-    ASSERT((*c).value == 33);
+    TEST_ASSERT((*a).value == 11);
+    TEST_ASSERT((*b).value == 22);
+    TEST_ASSERT((*c).value == 33);
 
     const auto a_index = a.Index();
     a.Reset();
-    ASSERT(pool.EmptySize() == 1);
-    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
-    ASSERT(d.Index() == a_index);
+    TEST_ASSERT(pool.EmptySize() == 1);
+    TEST_ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(d.Index() == a_index);
     d->value = 44;
-    ASSERT(pool.UnsafeAt(d.Index()).value == 44);
+    TEST_ASSERT(pool.UnsafeAt(d.Index()).value == 44);
   }
 
   // The same pool contract should work with the typed MPMC free-index queue.
@@ -126,17 +127,17 @@ void test_object_pool()
     LibXR::MPMCObjectPool<Payload>::Handle c;
     LibXR::MPMCObjectPool<Payload>::Handle d;
 
-    ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
-    ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
-    ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
-    ASSERT(pool.EmptySize() == 0);
-    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.EmptySize() == 0);
+    TEST_ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
 
     const auto a_index = a.Index();
     a.Reset();
-    ASSERT(pool.EmptySize() == 1);
-    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
-    ASSERT(d.Index() == a_index);
+    TEST_ASSERT(pool.EmptySize() == 1);
+    TEST_ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(d.Index() == a_index);
   }
 
   // External queue should also be supported.
@@ -163,12 +164,12 @@ void test_object_pool()
 
     {
       LibXR::ObjectPool<Payload>::Handle handle;
-      ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
       handle->value = 77;
-      ASSERT(pool.EmptySize() == 1);
+      TEST_ASSERT(pool.EmptySize() == 1);
     }
 
-    ASSERT(pool.EmptySize() == 2);
+    TEST_ASSERT(pool.EmptySize() == 2);
   }
 
   // Move-only handle ownership should transfer the return responsibility.
@@ -176,16 +177,16 @@ void test_object_pool()
     LibXR::ObjectPool<Payload> pool(1);
 
     LibXR::ObjectPool<Payload>::Handle first;
-    ASSERT(pool.Acquire(first) == LibXR::ErrorCode::OK);
-    ASSERT(pool.EmptySize() == 0);
+    TEST_ASSERT(pool.Acquire(first) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(pool.EmptySize() == 0);
 
     auto second = std::move(first);
-    ASSERT(!first.Valid());
-    ASSERT(second.Valid());
+    TEST_ASSERT(!first.Valid());
+    TEST_ASSERT(second.Valid());
     second->value = 99;
-    ASSERT(pool.UnsafeAt(second.Index()).value == 99);
+    TEST_ASSERT(pool.UnsafeAt(second.Index()).value == 99);
 
     second.Reset();
-    ASSERT(pool.EmptySize() == 1);
+    TEST_ASSERT(pool.EmptySize() == 1);
   }
 }

--- a/test/base/structure/test_queue.cpp
+++ b/test/base/structure/test_queue.cpp
@@ -26,6 +26,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -60,21 +61,21 @@ void test_queue()
     uint16_t output = 0;
 
     LibXR::QueueBase queue_base(sizeof(input), 2);
-    ASSERT(queue_base.PushBytes(&input) == LibXR::ErrorCode::OK);
-    ASSERT(queue_base.PopBytes(&output) == LibXR::ErrorCode::OK);
-    ASSERT(output == input);
+    TEST_ASSERT(queue_base.PushBytes(&input) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue_base.PopBytes(&output) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(output == input);
 
     output = 0;
     LibXR::SPSCQueueBase spsc_base(sizeof(input), 2);
-    ASSERT(spsc_base.PushBytes(&input) == LibXR::ErrorCode::OK);
-    ASSERT(spsc_base.PopBytes(&output) == LibXR::ErrorCode::OK);
-    ASSERT(output == input);
+    TEST_ASSERT(spsc_base.PushBytes(&input) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(spsc_base.PopBytes(&output) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(output == input);
 
     output = 0;
     LibXR::MPMCQueueBase mpmc_base(sizeof(input), 2);
-    ASSERT(mpmc_base.PushBytes(&input) == LibXR::ErrorCode::OK);
-    ASSERT(mpmc_base.PopBytes(&output) == LibXR::ErrorCode::OK);
-    ASSERT(output == input);
+    TEST_ASSERT(mpmc_base.PushBytes(&input) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(mpmc_base.PopBytes(&output) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(output == input);
   }
 
   // Queue::Overwrite replaces the queue contents with exactly one new element.
@@ -84,15 +85,15 @@ void test_queue()
 
     for (uint32_t item = 0; item < queue.MaxSize(); ++item)
     {
-      ASSERT(queue.Push(item) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(queue.Push(item) == LibXR::ErrorCode::OK);
     }
-    ASSERT(queue.Size() == queue.MaxSize());
+    TEST_ASSERT(queue.Size() == queue.MaxSize());
 
-    ASSERT(queue.Overwrite(0xA5A5A5A5U) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Size() == 1);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 0xA5A5A5A5U);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Overwrite(0xA5A5A5A5U) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Size() == 1);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 0xA5A5A5A5U);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
   // The ordinary FIFO queue supports capacity 1 and no-default payloads for normal byte
@@ -102,22 +103,22 @@ void test_queue()
     uint32_t value = 0;
     uint32_t batch[1] = {44};
 
-    ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(22) == LibXR::ErrorCode::FULL);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 11);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(22) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 11);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
 
-    ASSERT(queue.PushBatch(batch, 1) == LibXR::ErrorCode::OK);
-    ASSERT(queue.PopBatch(&value, 1) == LibXR::ErrorCode::OK);
-    ASSERT(value == 44);
+    TEST_ASSERT(queue.PushBatch(batch, 1) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PopBatch(&value, 1) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 44);
 
     LibXR::Queue<NoDefaultPayload> no_default_queue(1);
     NoDefaultPayload pushed(88);
     NoDefaultPayload popped(0);
-    ASSERT(no_default_queue.Push(pushed) == LibXR::ErrorCode::OK);
-    ASSERT(no_default_queue.Pop(popped) == LibXR::ErrorCode::OK);
-    ASSERT(popped.value == 88);
+    TEST_ASSERT(no_default_queue.Push(pushed) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(no_default_queue.Pop(popped) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(popped.value == 88);
   }
 
   // Batch operations preserve FIFO order across wraparound.
@@ -125,26 +126,26 @@ void test_queue()
     LibXR::Queue<int> batch_queue(5);
 
     int initial[5] = {1, 2, 3, 4, 5};
-    ASSERT(batch_queue.PushBatch(initial, 5) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(batch_queue.PushBatch(initial, 5) == LibXR::ErrorCode::OK);
 
     int peek_buffer[5] = {};
-    ASSERT(batch_queue.PeekBatch(peek_buffer, 5) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(batch_queue.PeekBatch(peek_buffer, 5) == LibXR::ErrorCode::OK);
     for (int i = 0; i < 5; ++i)
     {
-      ASSERT(peek_buffer[i] == initial[i]);
+      TEST_ASSERT(peek_buffer[i] == initial[i]);
     }
 
     int dummy[2] = {};
-    ASSERT(batch_queue.PopBatch(dummy, 2) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(batch_queue.PopBatch(dummy, 2) == LibXR::ErrorCode::OK);
 
     int wrap[2] = {6, 7};
-    ASSERT(batch_queue.PushBatch(wrap, 2) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(batch_queue.PushBatch(wrap, 2) == LibXR::ErrorCode::OK);
 
     int expected[5] = {3, 4, 5, 6, 7};
-    ASSERT(batch_queue.PeekBatch(peek_buffer, 5) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(batch_queue.PeekBatch(peek_buffer, 5) == LibXR::ErrorCode::OK);
     for (int i = 0; i < 5; ++i)
     {
-      ASSERT(peek_buffer[i] == expected[i]);
+      TEST_ASSERT(peek_buffer[i] == expected[i]);
     }
   }
 }

--- a/test/base/structure/test_rbt.cpp
+++ b/test/base/structure/test_rbt.cpp
@@ -18,6 +18,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_rbt`。 Test entry function `test_rbt`.
@@ -43,10 +44,10 @@ void test_rbt()
   for (int i = 0; i < 100; i++)
   {
     node_pos = rbtree.ForeachDisc(node_pos);
-    ASSERT(*node_pos == i);
+    TEST_ASSERT(*node_pos == i);
   }
 
-  ASSERT(rbtree.GetNum() == 100);
+  TEST_ASSERT(rbtree.GetNum() == 100);
 
   static int rbt_arg = 0;
 
@@ -54,17 +55,17 @@ void test_rbt()
       [&](LibXR::RBTree<int>::Node<int>& node)
       {
         rbt_arg = rbt_arg + 1;
-        ASSERT(rbt_arg == node + 1);
+        TEST_ASSERT(rbt_arg == node + 1);
         return LibXR::ErrorCode::OK;
       });
 
   for (int i = 0; i < 100; i++)
   {
     rbtree.Delete(nodes[i]);
-    ASSERT(rbtree.GetNum() == 99 - i);
+    TEST_ASSERT(rbtree.GetNum() == 99 - i);
   }
 
-  ASSERT(rbtree.GetNum() == 0);
+  TEST_ASSERT(rbtree.GetNum() == 0);
 
   LibXR::RBTree<uint32_t> uint32_tree([](const uint32_t& a, const uint32_t& b)
                                       { return (a > b) - (a < b); });
@@ -81,8 +82,8 @@ void test_rbt()
   for (size_t i = 0; i < std::size(keys); i++)
   {
     uint32_node_pos = uint32_tree.ForeachDisc(uint32_node_pos);
-    ASSERT(uint32_node_pos != nullptr);
-    ASSERT(*uint32_node_pos == keys[i]);
-    ASSERT(uint32_tree.Search<uint32_t>(keys[i]) == &uint32_nodes[i]);
+    TEST_ASSERT(uint32_node_pos != nullptr);
+    TEST_ASSERT(*uint32_node_pos == keys[i]);
+    TEST_ASSERT(uint32_tree.Search<uint32_t>(keys[i]) == &uint32_nodes[i]);
   }
 }

--- a/test/base/structure/test_spsc_prefix.cpp
+++ b/test/base/structure/test_spsc_prefix.cpp
@@ -8,6 +8,7 @@
 
 #include "spsc_queue.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -17,21 +18,21 @@ void PositionEmptyQueue(Queue& queue, size_t offset)
 {
   for (size_t i = 0; i < offset; ++i)
   {
-    ASSERT(queue.Push(0U) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(0U) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
   }
 }
 
 void CheckContents(Queue& queue, const std::vector<uint32_t>& expected)
 {
-  ASSERT(queue.Size() == expected.size());
+  TEST_ASSERT(queue.Size() == expected.size());
   for (uint32_t value : expected)
   {
     uint32_t actual = 0U;
-    ASSERT(queue.Pop(actual) == LibXR::ErrorCode::OK);
-    ASSERT(actual == value);
+    TEST_ASSERT(queue.Pop(actual) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(actual == value);
   }
-  ASSERT(queue.Size() == 0U);
+  TEST_ASSERT(queue.Size() == 0U);
 }
 
 void FillQueue(Queue& queue, size_t offset, size_t used, std::vector<uint32_t>& expected)
@@ -41,7 +42,7 @@ void FillQueue(Queue& queue, size_t offset, size_t used, std::vector<uint32_t>& 
   {
     const uint32_t value = static_cast<uint32_t>(10U + index);
     expected.push_back(value);
-    ASSERT(queue.Push(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(value) == LibXR::ErrorCode::OK);
   }
 }
 
@@ -59,10 +60,10 @@ void CheckProducePrefix(size_t capacity, size_t offset, size_t used, size_t limi
       [&](uint32_t* first, size_t first_size, uint32_t* second, size_t second_size)
       {
         ++calls;
-        ASSERT(first != nullptr && first_size > 0U);
-        ASSERT(first_size + second_size == offer);
-        ASSERT((second == nullptr) == (second_size == 0U));
-        ASSERT(queue.Size() == used);
+        TEST_ASSERT(first != nullptr && first_size > 0U);
+        TEST_ASSERT(first_size + second_size == offer);
+        TEST_ASSERT((second == nullptr) == (second_size == 0U));
+        TEST_ASSERT(queue.Size() == used);
         for (size_t index = 0U; index < prefix; ++index)
         {
           (index < first_size ? first[index] : second[index - first_size]) =
@@ -71,8 +72,8 @@ void CheckProducePrefix(size_t capacity, size_t offset, size_t used, size_t limi
         return prefix;
       });
 
-  ASSERT(produced == prefix);
-  ASSERT(calls == (offer == 0U ? 0U : 1U));
+  TEST_ASSERT(produced == prefix);
+  TEST_ASSERT(calls == (offer == 0U ? 0U : 1U));
   for (size_t index = 0U; index < prefix; ++index)
   {
     expected.push_back(static_cast<uint32_t>(100U + index));
@@ -95,20 +96,20 @@ void CheckConsumePrefix(size_t capacity, size_t offset, size_t used, size_t limi
           size_t second_size)
       {
         ++calls;
-        ASSERT(first != nullptr && first_size > 0U);
-        ASSERT(first_size + second_size == offer);
-        ASSERT((second == nullptr) == (second_size == 0U));
+        TEST_ASSERT(first != nullptr && first_size > 0U);
+        TEST_ASSERT(first_size + second_size == offer);
+        TEST_ASSERT((second == nullptr) == (second_size == 0U));
         for (size_t index = 0U; index < offer; ++index)
         {
-          ASSERT((index < first_size ? first[index] : second[index - first_size]) ==
-                 expected[index]);
+          TEST_ASSERT((index < first_size ? first[index] : second[index - first_size]) ==
+                      expected[index]);
         }
-        ASSERT(queue.Size() == used);
+        TEST_ASSERT(queue.Size() == used);
         return prefix;
       });
 
-  ASSERT(consumed == prefix);
-  ASSERT(calls == (offer == 0U ? 0U : 1U));
+  TEST_ASSERT(consumed == prefix);
+  TEST_ASSERT(calls == (offer == 0U ? 0U : 1U));
   expected.erase(expected.begin(), expected.begin() + prefix);
   CheckContents(queue, expected);
 }
@@ -147,34 +148,35 @@ void TestOppositeSideProgress()
       queue.ProduceWithWriter(std::numeric_limits<size_t>::max(),
                               [&](uint32_t* first, size_t n1, uint32_t*, size_t n2)
                               {
-                                ASSERT(n1 == 3U && n2 == 0U);
+                                TEST_ASSERT(n1 == 3U && n2 == 0U);
                                 first[0] = 71U;
                                 uint32_t value = 0U;
-                                ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+                                TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
                                 return 1U;
                               });
-  ASSERT(produced == 1U);
-  ASSERT(queue.ConsumeWithReader(
-             3U,
-             [&](const uint32_t* first, size_t n1, const uint32_t*, size_t n2)
-             {
-               ASSERT(n1 == 1U && n2 == 0U && first[0] == 71U);
-               ASSERT(queue.Push(72U) == LibXR::ErrorCode::OK);
-               return 1U;
-             }) == 1U);
+  TEST_ASSERT(produced == 1U);
+  TEST_ASSERT(queue.ConsumeWithReader(
+                  3U,
+                  [&](const uint32_t* first, size_t n1, const uint32_t*, size_t n2)
+                  {
+                    TEST_ASSERT(n1 == 1U && n2 == 0U && first[0] == 71U);
+                    TEST_ASSERT(queue.Push(72U) == LibXR::ErrorCode::OK);
+                    return 1U;
+                  }) == 1U);
   CheckContents(queue, {72U});
 
-  ASSERT(queue.PushBatch(static_cast<const uint32_t*>(nullptr), 0U) ==
-         LibXR::ErrorCode::OK);
+  TEST_ASSERT(queue.PushBatch(static_cast<const uint32_t*>(nullptr), 0U) ==
+              LibXR::ErrorCode::OK);
   const uint32_t full[] = {1U, 2U, 3U};
-  ASSERT(queue.PushBatch(full, 3U) == LibXR::ErrorCode::OK);
-  ASSERT(queue.ConsumeWithReader(3U,
-                                 [&](const uint32_t*, size_t, const uint32_t*, size_t)
-                                 {
-                                   ASSERT(queue.Push(99U) == LibXR::ErrorCode::FULL);
-                                   return 2U;
-                                 }) == 2U);
-  ASSERT(queue.Push(99U) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(queue.PushBatch(full, 3U) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(
+      queue.ConsumeWithReader(3U,
+                              [&](const uint32_t*, size_t, const uint32_t*, size_t)
+                              {
+                                TEST_ASSERT(queue.Push(99U) == LibXR::ErrorCode::FULL);
+                                return 2U;
+                              }) == 2U);
+  TEST_ASSERT(queue.Push(99U) == LibXR::ErrorCode::OK);
   CheckContents(queue, {3U, 99U});
 }
 
@@ -187,50 +189,54 @@ void TestAlignedPayloadAndRawStride()
 {
   LibXR::SPSCQueue<AlignedPayload> queue(3U);
   AlignedPayload seed{0U};
-  ASSERT(queue.Push(seed) == LibXR::ErrorCode::OK);
-  ASSERT(queue.Push(seed) == LibXR::ErrorCode::OK);
-  ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
-  ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
-  ASSERT(queue.ProduceWithWriter(
-             3U,
-             [](AlignedPayload* first, size_t n1, AlignedPayload* second, size_t n2)
-             {
-               ASSERT(n1 == 2U && n2 == 1U);
-               ASSERT(reinterpret_cast<uintptr_t>(first) % alignof(AlignedPayload) == 0U);
-               ASSERT(reinterpret_cast<uintptr_t>(second) % alignof(AlignedPayload) ==
-                      0U);
-               first[0] = AlignedPayload{11U};
-               first[1] = AlignedPayload{12U};
-               second[0] = AlignedPayload{13U};
-               return 3U;
-             }) == 3U);
+  TEST_ASSERT(queue.Push(seed) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(queue.Push(seed) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(
+      queue.ProduceWithWriter(
+          3U,
+          [](AlignedPayload* first, size_t n1, AlignedPayload* second, size_t n2)
+          {
+            TEST_ASSERT(n1 == 2U && n2 == 1U);
+            TEST_ASSERT(reinterpret_cast<uintptr_t>(first) % alignof(AlignedPayload) ==
+                        0U);
+            TEST_ASSERT(reinterpret_cast<uintptr_t>(second) % alignof(AlignedPayload) ==
+                        0U);
+            first[0] = AlignedPayload{11U};
+            first[1] = AlignedPayload{12U};
+            second[0] = AlignedPayload{13U};
+            return 3U;
+          }) == 3U);
   for (uint32_t expected = 11U; expected <= 13U; ++expected)
   {
     AlignedPayload actual{};
-    ASSERT(queue.Pop(actual) == LibXR::ErrorCode::OK);
-    ASSERT(actual.value == expected);
+    TEST_ASSERT(queue.Pop(actual) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(actual.value == expected);
   }
 
   LibXR::SPSCQueueBase raw(3U, 4U, 2U);
-  ASSERT(raw.ProduceWithWriter(2U,
-                               [](void* first, size_t n1, void*, size_t n2)
-                               {
-                                 ASSERT(n1 == 2U && n2 == 0U);
-                                 auto* bytes = static_cast<uint8_t*>(first);
-                                 for (size_t i = 0U; i < n1; ++i)
-                                 {
-                                   for (size_t byte = 0U; byte < 3U; ++byte)
-                                   {
-                                     bytes[i * 4U + byte] = static_cast<uint8_t>(i + 1U);
-                                   }
-                                 }
-                                 return n1;
-                               }) == 2U);
+  TEST_ASSERT(raw.ProduceWithWriter(2U,
+                                    [](void* first, size_t n1, void*, size_t n2)
+                                    {
+                                      TEST_ASSERT(n1 == 2U && n2 == 0U);
+                                      auto* bytes = static_cast<uint8_t*>(first);
+                                      for (size_t i = 0U; i < n1; ++i)
+                                      {
+                                        for (size_t byte = 0U; byte < 3U; ++byte)
+                                        {
+                                          bytes[i * 4U + byte] =
+                                              static_cast<uint8_t>(i + 1U);
+                                        }
+                                      }
+                                      return n1;
+                                    }) == 2U);
   uint8_t payload[3]{};
   for (uint8_t expected = 1U; expected <= 2U; ++expected)
   {
-    ASSERT(raw.PopBytes(payload) == LibXR::ErrorCode::OK);
-    ASSERT(payload[0] == expected && payload[1] == expected && payload[2] == expected);
+    TEST_ASSERT(raw.PopBytes(payload) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(payload[0] == expected && payload[1] == expected &&
+                payload[2] == expected);
   }
 }
 
@@ -272,7 +278,7 @@ void TestConcurrentPrefixes()
           const size_t prefix = std::min<size_t>(n1 + n2, 1U + expected % 5U);
           for (size_t i = 0U; i < prefix; ++i)
           {
-            ASSERT((i < n1 ? first[i] : second[i - n1]) == expected + i);
+            TEST_ASSERT((i < n1 ? first[i] : second[i - n1]) == expected + i);
           }
           return prefix;
         });
@@ -283,7 +289,7 @@ void TestConcurrentPrefixes()
     }
   }
   producer.join();
-  ASSERT(queue.Size() == 0U);
+  TEST_ASSERT(queue.Size() == 0U);
 }
 }  // namespace
 

--- a/test/base/structure/test_spsc_queue.cpp
+++ b/test/base/structure/test_spsc_queue.cpp
@@ -6,6 +6,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -50,8 +51,8 @@ void ResetProducerTask(ResetProducerArg arg)
       1U,
       [&](uint32_t* first, size_t first_size, uint32_t*, size_t second_size)
       {
-        ASSERT(first_size == 1U);
-        ASSERT(second_size == 0U);
+        TEST_ASSERT(first_size == 1U);
+        TEST_ASSERT(second_size == 0U);
         first[0] = 99U;
         arg.ready->store(true, std::memory_order_release);
         while (!arg.resume->load(std::memory_order_acquire))
@@ -60,7 +61,7 @@ void ResetProducerTask(ResetProducerArg arg)
         }
         return 1U;
       });
-  ASSERT(produced == 1U);
+  TEST_ASSERT(produced == 1U);
 }
 }  // namespace
 
@@ -74,20 +75,20 @@ void test_spsc_queue()
     Queue queue(4);
     uint32_t value = 0;
 
-    ASSERT(queue.MaxSize() == 4);
-    ASSERT(queue.Size() == 0);
-    ASSERT(queue.EmptySize() == 4);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.MaxSize() == 4);
+    TEST_ASSERT(queue.Size() == 0);
+    TEST_ASSERT(queue.EmptySize() == 4);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
 
-    ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(22) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Peek(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 11);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 11);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 22);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(22) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Peek(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 11);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 11);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 22);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
   // Capacity 1 is valid and zero-length batches are no-ops.
@@ -96,21 +97,21 @@ void test_spsc_queue()
     uint32_t value = 0;
     uint32_t batch[1] = {33};
 
-    ASSERT(queue.PushBatch(nullptr, 0) == LibXR::ErrorCode::OK);
-    ASSERT(queue.PopBatch(nullptr, 0) == LibXR::ErrorCode::OK);
-    ASSERT(queue.PeekBatch(nullptr, 0) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PushBatch(nullptr, 0) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PopBatch(nullptr, 0) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PeekBatch(nullptr, 0) == LibXR::ErrorCode::OK);
 
-    ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(22) == LibXR::ErrorCode::FULL);
-    ASSERT(queue.Peek(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 11);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 11);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(22) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(queue.Peek(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 11);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 11);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
 
-    ASSERT(queue.PushBatch(batch, 1) == LibXR::ErrorCode::OK);
-    ASSERT(queue.PopBatch(&value, 1) == LibXR::ErrorCode::OK);
-    ASSERT(value == 33);
+    TEST_ASSERT(queue.PushBatch(batch, 1) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PopBatch(&value, 1) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 33);
   }
 
   // Batch APIs, wraparound, writer callback, and reset behavior.
@@ -119,56 +120,56 @@ void test_spsc_queue()
     uint32_t initial[5] = {1, 2, 3, 4, 5};
     uint32_t readback[5] = {};
 
-    ASSERT(queue.PushBatch(initial, 5) == LibXR::ErrorCode::OK);
-    ASSERT(queue.PushBatch(initial, 1) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(queue.PushBatch(initial, 5) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PushBatch(initial, 1) == LibXR::ErrorCode::FULL);
 
-    ASSERT(queue.PeekBatch(readback, 5) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PeekBatch(readback, 5) == LibXR::ErrorCode::OK);
     for (size_t index = 0; index < 5; ++index)
     {
-      ASSERT(readback[index] == initial[index]);
+      TEST_ASSERT(readback[index] == initial[index]);
     }
 
-    ASSERT(queue.PopBatch(readback, 2) == LibXR::ErrorCode::OK);
-    ASSERT(readback[0] == 1);
-    ASSERT(readback[1] == 2);
+    TEST_ASSERT(queue.PopBatch(readback, 2) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(readback[0] == 1);
+    TEST_ASSERT(readback[1] == 2);
 
     uint32_t wrap[2] = {6, 7};
-    ASSERT(queue.PushBatch(wrap, 2) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PushBatch(wrap, 2) == LibXR::ErrorCode::OK);
 
     uint32_t expected[5] = {3, 4, 5, 6, 7};
-    ASSERT(queue.PeekBatch(readback, 5) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PeekBatch(readback, 5) == LibXR::ErrorCode::OK);
     for (size_t index = 0; index < 5; ++index)
     {
-      ASSERT(readback[index] == expected[index]);
+      TEST_ASSERT(readback[index] == expected[index]);
     }
 
     size_t write_cursor = 100;
     queue.Reset();
-    ASSERT(queue.Size() == 0);
+    TEST_ASSERT(queue.Size() == 0);
     for (size_t index = 0; index < 3; ++index)
     {
-      ASSERT(queue.PushWithWriter(
-                 [&](uint32_t* slot, size_t count)
-                 {
-                   ASSERT(count == 1);
-                   slot[0] = static_cast<uint32_t>(write_cursor++);
-                   return LibXR::ErrorCode::OK;
-                 }) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(queue.PushWithWriter(
+                      [&](uint32_t* slot, size_t count)
+                      {
+                        TEST_ASSERT(count == 1);
+                        slot[0] = static_cast<uint32_t>(write_cursor++);
+                        return LibXR::ErrorCode::OK;
+                      }) == LibXR::ErrorCode::OK);
     }
 
     uint32_t expected_value = 100;
     for (size_t index = 0; index < 3; ++index)
     {
-      ASSERT(queue.PopWithReader(
-                 [&](const uint32_t* slot, size_t count)
-                 {
-                   ASSERT(count == 1);
-                   ASSERT(slot[0] == expected_value++);
-                   return LibXR::ErrorCode::OK;
-                 }) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(queue.PopWithReader(
+                      [&](const uint32_t* slot, size_t count)
+                      {
+                        TEST_ASSERT(count == 1);
+                        TEST_ASSERT(slot[0] == expected_value++);
+                        return LibXR::ErrorCode::OK;
+                      }) == LibXR::ErrorCode::OK);
     }
     uint32_t value = 0;
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
   // Normal Push/Pop remain byte-payload operations and do not require Data{}.
@@ -177,20 +178,20 @@ void test_spsc_queue()
     NoDefaultPayload pushed(88);
     NoDefaultPayload popped(0);
 
-    ASSERT(queue.Push(pushed) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Pop(popped) == LibXR::ErrorCode::OK);
-    ASSERT(popped.value == 88);
+    TEST_ASSERT(queue.Push(pushed) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Pop(popped) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(popped.value == 88);
   }
 
   // Hold a producer after it writes an uncommitted slot, then reset from the consumer.
   {
     Queue queue(4);
-    ASSERT(queue.Push(10U) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(11U) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(10U) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(11U) == LibXR::ErrorCode::OK);
 
     uint32_t value = 0U;
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 10U);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 10U);
 
     std::atomic<bool> producer_ready = false;
     std::atomic<bool> resume_producer = false;
@@ -206,11 +207,11 @@ void test_spsc_queue()
     queue.Reset();
     resume_producer.store(true, std::memory_order_release);
 
-    ASSERT(producer.Join() == LibXR::ErrorCode::OK);
-    ASSERT(queue.Size() == 1U);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 99U);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Size() == 1U);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 99U);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
   // Callback failures must not commit partially produced or consumed elements.
@@ -219,39 +220,39 @@ void test_spsc_queue()
     uint32_t value = 0;
     bool writer_called = false;
 
-    ASSERT(queue.PushWithWriter(
-               [](uint32_t* slot, size_t count)
-               {
-                 ASSERT(count == 1);
-                 slot[0] = 42;
-                 return LibXR::ErrorCode::FAILED;
-               }) == LibXR::ErrorCode::FAILED);
-    ASSERT(queue.Size() == 0);
+    TEST_ASSERT(queue.PushWithWriter(
+                    [](uint32_t* slot, size_t count)
+                    {
+                      TEST_ASSERT(count == 1);
+                      slot[0] = 42;
+                      return LibXR::ErrorCode::FAILED;
+                    }) == LibXR::ErrorCode::FAILED);
+    TEST_ASSERT(queue.Size() == 0);
 
-    ASSERT(queue.Push(1) == LibXR::ErrorCode::OK);
-    ASSERT(queue.Push(2) == LibXR::ErrorCode::OK);
-    ASSERT(queue.PushWithWriter(
-               [&](uint32_t* slot, size_t count)
-               {
-                 UNUSED(slot);
-                 UNUSED(count);
-                 writer_called = true;
-                 return LibXR::ErrorCode::OK;
-               }) == LibXR::ErrorCode::FULL);
-    ASSERT(!writer_called);
-    ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
-    ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(1) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Push(2) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PushWithWriter(
+                    [&](uint32_t* slot, size_t count)
+                    {
+                      UNUSED(slot);
+                      UNUSED(count);
+                      writer_called = true;
+                      return LibXR::ErrorCode::OK;
+                    }) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(!writer_called);
+    TEST_ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.Pop() == LibXR::ErrorCode::OK);
 
-    ASSERT(queue.Push(55) == LibXR::ErrorCode::OK);
-    ASSERT(queue.PopWithReader(
-               [](const uint32_t* slot, size_t count)
-               {
-                 ASSERT(count == 1);
-                 ASSERT(slot[0] == 55);
-                 return LibXR::ErrorCode::FAILED;
-               }) == LibXR::ErrorCode::FAILED);
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 55);
+    TEST_ASSERT(queue.Push(55) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(queue.PopWithReader(
+                    [](const uint32_t* slot, size_t count)
+                    {
+                      TEST_ASSERT(count == 1);
+                      TEST_ASSERT(slot[0] == 55);
+                      return LibXR::ErrorCode::FAILED;
+                    }) == LibXR::ErrorCode::FAILED);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 55);
   }
 
   // Batched byte callbacks receive contiguous chunks even when the ring wraps.
@@ -260,67 +261,67 @@ void test_spsc_queue()
     uint8_t value = 0;
     const uint8_t initial[5] = {10, 11, 12, 13, 14};
 
-    ASSERT(byte_queue.PushBatch(initial, 5) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(byte_queue.PushBatch(initial, 5) == LibXR::ErrorCode::OK);
     for (uint8_t expected = 10; expected < 13; ++expected)
     {
-      ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
-      ASSERT(value == expected);
+      TEST_ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(value == expected);
     }
 
     uint8_t write_next = 20;
     size_t write_chunks = 0;
-    ASSERT(byte_queue.PushWithWriter(4,
-                                     [&](uint8_t* chunk, size_t count)
-                                     {
-                                       ASSERT(count == 2);
-                                       ++write_chunks;
-                                       for (size_t index = 0; index < count; ++index)
-                                       {
-                                         chunk[index] = write_next++;
-                                       }
-                                       return LibXR::ErrorCode::OK;
-                                     }) == LibXR::ErrorCode::OK);
-    ASSERT(write_chunks == 2);
+    TEST_ASSERT(byte_queue.PushWithWriter(4,
+                                          [&](uint8_t* chunk, size_t count)
+                                          {
+                                            TEST_ASSERT(count == 2);
+                                            ++write_chunks;
+                                            for (size_t index = 0; index < count; ++index)
+                                            {
+                                              chunk[index] = write_next++;
+                                            }
+                                            return LibXR::ErrorCode::OK;
+                                          }) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(write_chunks == 2);
 
     const uint8_t expected_after_write[6] = {13, 14, 20, 21, 22, 23};
     uint8_t readback[6] = {};
-    ASSERT(byte_queue.PopBatch(readback, 6) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(byte_queue.PopBatch(readback, 6) == LibXR::ErrorCode::OK);
     for (size_t index = 0; index < 6; ++index)
     {
-      ASSERT(readback[index] == expected_after_write[index]);
+      TEST_ASSERT(readback[index] == expected_after_write[index]);
     }
 
     const uint8_t full[6] = {1, 2, 3, 4, 5, 6};
     const uint8_t wrap[4] = {7, 8, 9, 10};
-    ASSERT(byte_queue.PushBatch(full, 6) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(byte_queue.PushBatch(full, 6) == LibXR::ErrorCode::OK);
     for (size_t index = 0; index < 4; ++index)
     {
-      ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
-      ASSERT(value == static_cast<uint8_t>(index + 1));
+      TEST_ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(value == static_cast<uint8_t>(index + 1));
     }
-    ASSERT(byte_queue.PushBatch(wrap, 4) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(byte_queue.PushBatch(wrap, 4) == LibXR::ErrorCode::OK);
 
     const uint8_t expected_read_chunks[5] = {5, 6, 7, 8, 9};
     size_t read_cursor = 0;
     size_t read_chunks = 0;
-    ASSERT(byte_queue.PopWithReader(5,
-                                    [&](const uint8_t* chunk, size_t count)
-                                    {
-                                      ASSERT((read_chunks == 0 && count == 1) ||
-                                             (read_chunks == 1 && count == 4));
-                                      for (size_t index = 0; index < count; ++index)
-                                      {
-                                        ASSERT(chunk[index] ==
-                                               expected_read_chunks[read_cursor++]);
-                                      }
-                                      ++read_chunks;
-                                      return LibXR::ErrorCode::OK;
-                                    }) == LibXR::ErrorCode::OK);
-    ASSERT(read_chunks == 2);
-    ASSERT(read_cursor == 5);
-    ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
-    ASSERT(value == 10);
-    ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(byte_queue.PopWithReader(
+                    5,
+                    [&](const uint8_t* chunk, size_t count)
+                    {
+                      TEST_ASSERT((read_chunks == 0 && count == 1) ||
+                                  (read_chunks == 1 && count == 4));
+                      for (size_t index = 0; index < count; ++index)
+                      {
+                        TEST_ASSERT(chunk[index] == expected_read_chunks[read_cursor++]);
+                      }
+                      ++read_chunks;
+                      return LibXR::ErrorCode::OK;
+                    }) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(read_chunks == 2);
+    TEST_ASSERT(read_cursor == 5);
+    TEST_ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(value == 10);
+    TEST_ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
   // End-to-end producer/consumer handoff under sustained contention.
@@ -341,16 +342,16 @@ void test_spsc_queue()
       {
         LibXR::Thread::Yield();
       }
-      ASSERT(value == expected);
+      TEST_ASSERT(value == expected);
     }
 
     while (!producer_done.load(std::memory_order_acquire))
     {
       LibXR::Thread::Yield();
     }
-    ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+    TEST_ASSERT(producer.Join() == LibXR::ErrorCode::OK);
     uint32_t value = 0;
-    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
-    ASSERT(queue.Size() == 0);
+    TEST_ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(queue.Size() == 0);
   }
 }

--- a/test/base/structure/test_stack.cpp
+++ b/test/base/structure/test_stack.cpp
@@ -16,6 +16,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_stack`。 Test entry function `test_stack`.
@@ -33,16 +34,16 @@ void test_stack()
     stack.Push(i);
   }
 
-  ASSERT(stack.Push(1) == LibXR::ErrorCode::FULL);
+  TEST_ASSERT(stack.Push(1) == LibXR::ErrorCode::FULL);
 
   for (int i = 0; i <= 9; i++)
   {
     int tmp = -1;
     stack.Pop(tmp);
-    ASSERT(tmp == 9 - i);
+    TEST_ASSERT(tmp == 9 - i);
   }
 
-  ASSERT(stack.Pop() == LibXR::ErrorCode::EMPTY);
+  TEST_ASSERT(stack.Pop() == LibXR::ErrorCode::EMPTY);
 
   for (int i = 0; i <= 5; i++)
   {
@@ -50,11 +51,11 @@ void test_stack()
   }
 
   stack.Insert(10, 2);
-  ASSERT(stack[2] == 10);
-  ASSERT(stack[3] == 2);
-  ASSERT(stack.Size() == 7);
+  TEST_ASSERT(stack[2] == 10);
+  TEST_ASSERT(stack[3] == 2);
+  TEST_ASSERT(stack.Size() == 7);
   stack.Delete(2);
-  ASSERT(stack[2] == 2);
-  ASSERT(stack[3] == 3);
-  ASSERT(stack.Size() == 6);
+  TEST_ASSERT(stack[2] == 2);
+  TEST_ASSERT(stack[3] == 3);
+  TEST_ASSERT(stack.Size() == 6);
 }

--- a/test/base/test_assert.cpp
+++ b/test/base/test_assert.cpp
@@ -18,6 +18,8 @@
  * side effects after a real dispatch to confirm both registration and parameter
  * forwarding paths.
  */
+#include "test_assert.hpp"
+
 #include <cstdint>
 #include <string_view>
 
@@ -68,7 +70,7 @@ void test_assert()
   // Test item: register the probe callback and verify the public getter reports a
   // non-empty fatal callback.
   LibXR::Assert::RegisterFatalErrorCallback(callback);
-  ASSERT(!LibXR::Assert::FatalErrorCallback().Empty());
+  TEST_ASSERT(!LibXR::Assert::FatalErrorCallback().Empty());
 
   // 测试项：通过封装后的执行入口触发 fatal 回调，而不是直接访问全局存储。
   // Test item: dispatch through the wrapped run entry instead of reaching into global
@@ -78,10 +80,10 @@ void test_assert()
   // 测试项：确认回调只执行一次，并且 ISR 标志、文件名、行号都原样透传。
   // Test item: verify one callback hit and exact propagation of ISR flag, file name, and
   // line number.
-  ASSERT(probe.hit_count == 1);
-  ASSERT(!probe.in_isr);
-  ASSERT(probe.file == "test_assert.cpp");
-  ASSERT(probe.line == 42);
+  TEST_ASSERT(probe.hit_count == 1);
+  TEST_ASSERT(!probe.in_isr);
+  TEST_ASSERT(probe.file == "test_assert.cpp");
+  TEST_ASSERT(probe.line == 42);
 
   // 测试项：恢复进入本测试前的 fatal 回调，保持测试入口的全局状态契约。
   // Test item: restore the fatal callback that was active before this test to preserve

--- a/test/base/test_color.cpp
+++ b/test/base/test_color.cpp
@@ -25,6 +25,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_color`。 Test entry function `test_color`.
@@ -47,32 +48,37 @@ void test_color()
   static_assert(std::size(LibXR::LIBXR_PRESET_STR) ==
                 static_cast<size_t>(LibXR::Preset::COUNT));
 
-  ASSERT(std::string_view(
-             LibXR::LIBXR_TEXT_STYLE_STR[static_cast<size_t>(LibXR::TextStyle::NONE)]) ==
-         "");
-  ASSERT(std::string_view(
-             LibXR::LIBXR_TEXT_STYLE_STR[static_cast<size_t>(LibXR::TextStyle::BOLD)]) ==
-         "\033[1m");
-  ASSERT(std::string_view(LibXR::LIBXR_TEXT_STYLE_STR[static_cast<size_t>(
-             LibXR::TextStyle::UNDERLINE)]) == "\033[4m");
+  TEST_ASSERT(
+      std::string_view(
+          LibXR::LIBXR_TEXT_STYLE_STR[static_cast<size_t>(LibXR::TextStyle::NONE)]) ==
+      "");
+  TEST_ASSERT(
+      std::string_view(
+          LibXR::LIBXR_TEXT_STYLE_STR[static_cast<size_t>(LibXR::TextStyle::BOLD)]) ==
+      "\033[1m");
+  TEST_ASSERT(std::string_view(LibXR::LIBXR_TEXT_STYLE_STR[static_cast<size_t>(
+                  LibXR::TextStyle::UNDERLINE)]) == "\033[4m");
 
-  ASSERT(std::string_view(LibXR::LIBXR_TERMINAL_CONTROL_STR[static_cast<size_t>(
-             LibXR::TerminalControl::RESET)]) == "\033[m");
-  ASSERT(std::string_view(LibXR::LIBXR_TERMINAL_CONTROL_STR[static_cast<size_t>(
-             LibXR::TerminalControl::ERASE_LINE)]) == "\033[K");
+  TEST_ASSERT(std::string_view(LibXR::LIBXR_TERMINAL_CONTROL_STR[static_cast<size_t>(
+                  LibXR::TerminalControl::RESET)]) == "\033[m");
+  TEST_ASSERT(std::string_view(LibXR::LIBXR_TERMINAL_CONTROL_STR[static_cast<size_t>(
+                  LibXR::TerminalControl::ERASE_LINE)]) == "\033[K");
 
-  ASSERT(
+  TEST_ASSERT(
       std::string_view(
           LibXR::LIBXR_FOREGROUND_STR[static_cast<size_t>(LibXR::Foreground::GREEN)]) ==
       "\033[32m");
-  ASSERT(std::string_view(
-             LibXR::LIBXR_BACKGROUND_STR[static_cast<size_t>(LibXR::Background::BLUE)]) ==
-         "\033[44m");
+  TEST_ASSERT(
+      std::string_view(
+          LibXR::LIBXR_BACKGROUND_STR[static_cast<size_t>(LibXR::Background::BLUE)]) ==
+      "\033[44m");
 
-  ASSERT(std::string_view(
-             LibXR::LIBXR_PRESET_STR[static_cast<size_t>(LibXR::Preset::YELLOW_BOLD)]) ==
-         "\033[33m\033[1m");
-  ASSERT(std::string_view(
-             LibXR::LIBXR_PRESET_STR[static_cast<size_t>(LibXR::Preset::BOLD_ON_RED)]) ==
-         "\033[1m\033[41m");
+  TEST_ASSERT(
+      std::string_view(
+          LibXR::LIBXR_PRESET_STR[static_cast<size_t>(LibXR::Preset::YELLOW_BOLD)]) ==
+      "\033[33m\033[1m");
+  TEST_ASSERT(
+      std::string_view(
+          LibXR::LIBXR_PRESET_STR[static_cast<size_t>(LibXR::Preset::BOLD_ON_RED)]) ==
+      "\033[1m\033[41m");
 }

--- a/test/base/test_def.cpp
+++ b/test/base/test_def.cpp
@@ -28,6 +28,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -54,28 +55,29 @@ void test_def()
 {
   // 测试内容：按文件头列出的测试项目顺序执行当前测试入口。
   // Test coverage: execute the test items listed in this file header in sequence.
-  ASSERT(equal(LibXR::TWO_PI, LibXR::PI * 2.0));
-  ASSERT(equal(LibXR::STANDARD_GRAVITY, 9.80665));
-  ASSERT(LibXR::ALIGN_SIZE == sizeof(void*));
-  ASSERT(LibXR::CACHE_LINE_SIZE == (sizeof(void*) == 8 ? 64u : 32u));
-  ASSERT(std::string_view(DEF2STR(LIBXR_TEST_TOKEN)) == "LIBXR_TEST_TOKEN");
+  TEST_ASSERT(equal(LibXR::TWO_PI, LibXR::PI * 2.0));
+  TEST_ASSERT(equal(LibXR::STANDARD_GRAVITY, 9.80665));
+  TEST_ASSERT(LibXR::ALIGN_SIZE == sizeof(void*));
+  TEST_ASSERT(LibXR::CACHE_LINE_SIZE == (sizeof(void*) == 8 ? 64u : 32u));
+  TEST_ASSERT(std::string_view(DEF2STR(LIBXR_TEST_TOKEN)) == "LIBXR_TEST_TOKEN");
 
   LayoutProbe probe{0x1234u, 12.5, 0x7Fu};
   const auto expected_offset =
       static_cast<size_t>(reinterpret_cast<const uint8_t*>(&probe.value) -
                           reinterpret_cast<const uint8_t*>(&probe));
-  ASSERT(LibXR::OffsetOf(&LayoutProbe::value) == expected_offset);
-  ASSERT(LibXR::ContainerOf(&probe.value, &LayoutProbe::value) == &probe);
-  ASSERT(LibXR::ContainerOf(&std::as_const(probe).value, &LayoutProbe::value) == &probe);
+  TEST_ASSERT(LibXR::OffsetOf(&LayoutProbe::value) == expected_offset);
+  TEST_ASSERT(LibXR::ContainerOf(&probe.value, &LayoutProbe::value) == &probe);
+  TEST_ASSERT(LibXR::ContainerOf(&std::as_const(probe).value, &LayoutProbe::value) ==
+              &probe);
 
-  ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::EQUAL, 8, 8));
-  ASSERT(!LibXR::SizeLimitCheck(LibXR::SizeLimitMode::EQUAL, 8, 7));
-  ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::LESS, 8, 7));
-  ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::LESS, 8, 8));
-  ASSERT(!LibXR::SizeLimitCheck(LibXR::SizeLimitMode::LESS, 8, 9));
-  ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::MORE, 8, 8));
-  ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::MORE, 8, 9));
-  ASSERT(!LibXR::SizeLimitCheck(LibXR::SizeLimitMode::MORE, 8, 7));
-  ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::NONE, 8, 0));
-  ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::NONE, 8, 99));
+  TEST_ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::EQUAL, 8, 8));
+  TEST_ASSERT(!LibXR::SizeLimitCheck(LibXR::SizeLimitMode::EQUAL, 8, 7));
+  TEST_ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::LESS, 8, 7));
+  TEST_ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::LESS, 8, 8));
+  TEST_ASSERT(!LibXR::SizeLimitCheck(LibXR::SizeLimitMode::LESS, 8, 9));
+  TEST_ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::MORE, 8, 8));
+  TEST_ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::MORE, 8, 9));
+  TEST_ASSERT(!LibXR::SizeLimitCheck(LibXR::SizeLimitMode::MORE, 8, 7));
+  TEST_ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::NONE, 8, 0));
+  TEST_ASSERT(LibXR::SizeLimitCheck(LibXR::SizeLimitMode::NONE, 8, 99));
 }

--- a/test/base/test_mem.cpp
+++ b/test/base/test_mem.cpp
@@ -28,6 +28,7 @@
 #include "libxr_def.hpp"
 #include "libxr_mem.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 static int sign(int v) { return (v > 0) - (v < 0); }
 
@@ -49,13 +50,13 @@ void test_memory()
     LibXR::Memory::FastSet(buf, 0xAA, sizeof(buf));
     for (size_t i = 0; i < sizeof(buf); ++i)
     {
-      ASSERT(buf[i] == 0xAA);
+      TEST_ASSERT(buf[i] == 0xAA);
     }
 
     // size = 0: 不应修改
     uint8_t guard = 0x5A;
     LibXR::Memory::FastSet(&guard, 0x00, 0);
-    ASSERT(guard == 0x5A);
+    TEST_ASSERT(guard == 0x5A);
   }
 
   // --------------------------
@@ -73,18 +74,18 @@ void test_memory()
 
     // 基础整段拷贝
     LibXR::Memory::FastCopy(dst, src, sizeof(src));
-    ASSERT(std::memcmp(dst, src, sizeof(src)) == 0);
+    TEST_ASSERT(std::memcmp(dst, src, sizeof(src)) == 0);
 
     // size = 0: 不应修改 dst
     dst[17] = 0x11;
     LibXR::Memory::FastCopy(dst, src, 0);
-    ASSERT(dst[17] == 0x11);
+    TEST_ASSERT(dst[17] == 0x11);
 
     // dst == src: 自拷贝不应破坏数据
     uint8_t backup[128];
     std::memcpy(backup, src, sizeof(src));
     LibXR::Memory::FastCopy(src, src, sizeof(src));
-    ASSERT(std::memcmp(src, backup, sizeof(src)) == 0);
+    TEST_ASSERT(std::memcmp(src, backup, sizeof(src)) == 0);
 
     // 非对齐地址拷贝：dst+1 <- src+3
     uint8_t src2[200];
@@ -99,7 +100,7 @@ void test_memory()
     const size_t OFF_SRC = 3;
     const size_t LEN = 73;  // 非 4/8 对齐长度
     LibXR::Memory::FastCopy(dst2 + OFF_DST, src2 + OFF_SRC, LEN);
-    ASSERT(std::memcmp(dst2 + OFF_DST, src2 + OFF_SRC, LEN) == 0);
+    TEST_ASSERT(std::memcmp(dst2 + OFF_DST, src2 + OFF_SRC, LEN) == 0);
 
     // 小尺寸/多种长度覆盖（包含 1..65）
     for (size_t n = 1; n <= 65; ++n)
@@ -110,10 +111,10 @@ void test_memory()
         dst[i] = 0xEE;
       }
       LibXR::Memory::FastCopy(dst + 7, src + 5, n);  // 故意偏移
-      ASSERT(std::memcmp(dst + 7, src + 5, n) == 0);
+      TEST_ASSERT(std::memcmp(dst + 7, src + 5, n) == 0);
       // 确保范围外不被写（简单哨兵检查）
-      ASSERT(dst[6] == 0xEE);
-      ASSERT(dst[7 + n] == 0xEE);
+      TEST_ASSERT(dst[6] == 0xEE);
+      TEST_ASSERT(dst[7 + n] == 0xEE);
     }
   }
 
@@ -131,31 +132,31 @@ void test_memory()
     }
 
     // 完全相等
-    ASSERT(LibXR::Memory::FastCmp(a, b, sizeof(a)) == 0);
+    TEST_ASSERT(LibXR::Memory::FastCmp(a, b, sizeof(a)) == 0);
 
     // 首字节差异
     b[0] = static_cast<uint8_t>(b[0] + 1);
     int r1 = LibXR::Memory::FastCmp(a, b, sizeof(a));
     int m1 = std::memcmp(a, b, sizeof(a));
-    ASSERT(sign(r1) == sign(m1));
+    TEST_ASSERT(sign(r1) == sign(m1));
     b[0] = a[0];
 
     // 中间差异
     b[37] = static_cast<uint8_t>(b[37] - 1);
     int r2 = LibXR::Memory::FastCmp(a, b, sizeof(a));
     int m2 = std::memcmp(a, b, sizeof(a));
-    ASSERT(sign(r2) == sign(m2));
+    TEST_ASSERT(sign(r2) == sign(m2));
     b[37] = a[37];
 
     // 末尾差异
     b[95] = static_cast<uint8_t>(b[95] + 5);
     int r3 = LibXR::Memory::FastCmp(a, b, sizeof(a));
     int m3 = std::memcmp(a, b, sizeof(a));
-    ASSERT(sign(r3) == sign(m3));
+    TEST_ASSERT(sign(r3) == sign(m3));
     b[95] = a[95];
 
     // size = 0：应视为相等（对齐 memcmp 语义）
-    ASSERT(LibXR::Memory::FastCmp(a, b, 0) == 0);
+    TEST_ASSERT(LibXR::Memory::FastCmp(a, b, 0) == 0);
 
     // 非对齐指针比较
     uint8_t c[128];
@@ -173,6 +174,6 @@ void test_memory()
     const size_t N = 64;
     int r4 = LibXR::Memory::FastCmp(c + OFF1, d + OFF2, N);
     int m4 = std::memcmp(c + OFF1, d + OFF2, N);
-    ASSERT(sign(r4) == sign(m4));
+    TEST_ASSERT(sign(r4) == sign(m4));
   }
 }

--- a/test/base/test_time.cpp
+++ b/test/base/test_time.cpp
@@ -21,6 +21,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -49,29 +50,29 @@ void test_time()
 
   const auto us_elapsed =
       LibXR::MicrosecondTimestamp(1250) - LibXR::MicrosecondTimestamp(1000);
-  ASSERT(static_cast<uint64_t>(us_elapsed) == 250);
-  ASSERT(us_elapsed.ToMicrosecond() == 250);
-  ASSERT(us_elapsed.ToMillisecond() == 0);
-  ASSERT(equal(us_elapsed.ToSecond(), 0.00025));
-  ASSERT(equal(us_elapsed.ToSecondf(), 0.00025f));
+  TEST_ASSERT(static_cast<uint64_t>(us_elapsed) == 250);
+  TEST_ASSERT(us_elapsed.ToMicrosecond() == 250);
+  TEST_ASSERT(us_elapsed.ToMillisecond() == 0);
+  TEST_ASSERT(equal(us_elapsed.ToSecond(), 0.00025));
+  TEST_ASSERT(equal(us_elapsed.ToSecondf(), 0.00025f));
 
   LibXR::Detail::ConfigureTimebaseWrapRange(999, 999);
   const auto us_wrap = LibXR::MicrosecondTimestamp(3) - LibXR::MicrosecondTimestamp(998);
-  ASSERT(static_cast<uint64_t>(us_wrap) == 5);
-  ASSERT(us_wrap.ToMicrosecond() == 5);
+  TEST_ASSERT(static_cast<uint64_t>(us_wrap) == 5);
+  TEST_ASSERT(us_wrap.ToMicrosecond() == 5);
 
   LibXR::Detail::ConfigureTimebaseWrapRange(UINT64_MAX, UINT32_MAX);
   const auto ms_elapsed =
       LibXR::MillisecondTimestamp(2500) - LibXR::MillisecondTimestamp(1000);
-  ASSERT(static_cast<uint32_t>(ms_elapsed) == 1500);
-  ASSERT(ms_elapsed.ToMillisecond() == 1500);
-  ASSERT(ms_elapsed.ToMicrosecond() == 1500000);
-  ASSERT(equal(ms_elapsed.ToSecond(), 1.5));
-  ASSERT(equal(ms_elapsed.ToSecondf(), 1.5f));
+  TEST_ASSERT(static_cast<uint32_t>(ms_elapsed) == 1500);
+  TEST_ASSERT(ms_elapsed.ToMillisecond() == 1500);
+  TEST_ASSERT(ms_elapsed.ToMicrosecond() == 1500000);
+  TEST_ASSERT(equal(ms_elapsed.ToSecond(), 1.5));
+  TEST_ASSERT(equal(ms_elapsed.ToSecondf(), 1.5f));
 
   LibXR::Detail::ConfigureTimebaseWrapRange(UINT64_MAX, 99);
   const auto ms_wrap = LibXR::MillisecondTimestamp(2) - LibXR::MillisecondTimestamp(98);
-  ASSERT(static_cast<uint32_t>(ms_wrap) == 4);
-  ASSERT(ms_wrap.ToMillisecond() == 4);
-  ASSERT(ms_wrap.ToMicrosecond() == 4000);
+  TEST_ASSERT(static_cast<uint32_t>(ms_wrap) == 4);
+  TEST_ASSERT(ms_wrap.ToMillisecond() == 4);
+  TEST_ASSERT(ms_wrap.ToMicrosecond() == 4000);
 }

--- a/test/base/test_type.cpp
+++ b/test/base/test_type.cpp
@@ -23,6 +23,7 @@
 #include "libxr_def.hpp"
 #include "libxr_type.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_type`。 Test entry function `test_type`.
@@ -36,30 +37,30 @@ void test_type()
   // Test coverage: execute the test items listed in this file header in sequence.
   char mutable_text[] = "abc";
   LibXR::RawData mutable_text_view(mutable_text);
-  ASSERT(mutable_text_view.addr_ == mutable_text);
-  ASSERT(mutable_text_view.size_ == 3);
+  TEST_ASSERT(mutable_text_view.addr_ == mutable_text);
+  TEST_ASSERT(mutable_text_view.size_ == 3);
 
   char mutable_payload[3] = {'i', 'm', 'u'};
   LibXR::RawData mutable_payload_view(mutable_payload);
-  ASSERT(mutable_payload_view.addr_ == mutable_payload);
-  ASSERT(mutable_payload_view.size_ == 3);
+  TEST_ASSERT(mutable_payload_view.addr_ == mutable_payload);
+  TEST_ASSERT(mutable_payload_view.size_ == 3);
 
   const char literal_text[] = "abc";
   LibXR::ConstRawData literal_text_view(literal_text);
-  ASSERT(literal_text_view.addr_ == literal_text);
-  ASSERT(literal_text_view.size_ == 3);
+  TEST_ASSERT(literal_text_view.addr_ == literal_text);
+  TEST_ASSERT(literal_text_view.size_ == 3);
 
   const char embedded_text[] = "ab\0cd";
   LibXR::ConstRawData embedded_text_view(embedded_text);
-  ASSERT(embedded_text_view.size_ == 5);
+  TEST_ASSERT(embedded_text_view.size_ == 5);
 
   const char bounded_payload[3] = {'g', 'p', 'u'};
   LibXR::ConstRawData bounded_payload_view(bounded_payload);
-  ASSERT(bounded_payload_view.addr_ == bounded_payload);
-  ASSERT(bounded_payload_view.size_ == 3);
+  TEST_ASSERT(bounded_payload_view.addr_ == bounded_payload);
+  TEST_ASSERT(bounded_payload_view.size_ == 3);
 
   const std::string_view explicit_view("ab\0cd", 5);
   LibXR::ConstRawData explicit_view_data(explicit_view);
-  ASSERT(explicit_view_data.addr_ == explicit_view.data());
-  ASSERT(explicit_view_data.size_ == explicit_view.size());
+  TEST_ASSERT(explicit_view_data.addr_ == explicit_view.data());
+  TEST_ASSERT(explicit_view_data.size_ == explicit_view.size());
 }

--- a/test/base/utils/test_crc.cpp
+++ b/test/base/utils/test_crc.cpp
@@ -18,6 +18,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_crc`。 Test entry function `test_crc`.
@@ -56,7 +57,7 @@ void test_crc()
   test_crc32.crc =
       LibXR::CRC32::Calculate(&test_crc32, sizeof(test_crc32) - sizeof(uint32_t));
 
-  ASSERT(LibXR::CRC8::Verify(&test_crc8, sizeof(test_crc8)));
-  ASSERT(LibXR::CRC16::Verify(&test_crc16, sizeof(test_crc16)));
-  ASSERT(LibXR::CRC32::Verify(&test_crc32, sizeof(test_crc32)));
+  TEST_ASSERT(LibXR::CRC8::Verify(&test_crc8, sizeof(test_crc8)));
+  TEST_ASSERT(LibXR::CRC16::Verify(&test_crc16, sizeof(test_crc16)));
+  TEST_ASSERT(LibXR::CRC32::Verify(&test_crc32, sizeof(test_crc32)));
 }

--- a/test/base/utils/test_cycle_value.cpp
+++ b/test/base/utils/test_cycle_value.cpp
@@ -16,6 +16,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_cycle_value`。 Test entry function `test_cycle_value`.
@@ -29,17 +30,17 @@ void test_cycle_value()
   // Test coverage: execute the test items listed in this file header in sequence.
   using LibXR::CycleValue;
   CycleValue<> val(4 * LibXR::PI + LibXR::PI / 2);
-  ASSERT(equal(static_cast<double>(val), LibXR::PI / 2));
+  TEST_ASSERT(equal(static_cast<double>(val), LibXR::PI / 2));
 
   val += LibXR::PI;
-  ASSERT(equal(static_cast<double>(val), 3 * LibXR::PI / 2));
+  TEST_ASSERT(equal(static_cast<double>(val), 3 * LibXR::PI / 2));
 
-  ASSERT(equal(static_cast<double>(CycleValue<>(val - 0.0)), 3 * LibXR::PI / 2));
+  TEST_ASSERT(equal(static_cast<double>(CycleValue<>(val - 0.0)), 3 * LibXR::PI / 2));
 
   val -= LibXR::PI;
-  ASSERT(equal(static_cast<double>(val), LibXR::PI / 2));
+  TEST_ASSERT(equal(static_cast<double>(val), LibXR::PI / 2));
 
   auto neg = -val;
-  ASSERT(equal(static_cast<double>(neg), LibXR::TWO_PI - LibXR::PI / 2));
+  TEST_ASSERT(equal(static_cast<double>(neg), LibXR::TWO_PI - LibXR::PI / 2));
   UNUSED(neg);
 }

--- a/test/base/utils/test_encoder.cpp
+++ b/test/base/utils/test_encoder.cpp
@@ -21,6 +21,7 @@
 #include "float_encoder.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_float_encoder`。 Test entry function `test_float_encoder`.
@@ -55,7 +56,7 @@ void test_float_encoder()
 
     UNUSED(error);
 
-    ASSERT(error < 0.001f);  // Allowable error: ±0.001 deg/s
+    TEST_ASSERT(error < 0.001f);  // Allowable error: ±0.001 deg/s
   }
 
   // 2. Accelerometer test: ±24g
@@ -77,7 +78,7 @@ void test_float_encoder()
 
     UNUSED(error);
 
-    ASSERT(error < 0.001f);  // Higher precision required (±0.001g)
+    TEST_ASSERT(error < 0.001f);  // Higher precision required (±0.001g)
   }
 
   // 3. Euler angle test: [-π, π]
@@ -99,7 +100,7 @@ void test_float_encoder()
 
     UNUSED(error);
 
-    ASSERT(error < 0.001f);  // Require high angular accuracy (±0.001 rad)
+    TEST_ASSERT(error < 0.001f);  // Require high angular accuracy (±0.001 rad)
   }
 
   // 4. Out-of-range test: values exceeding min/max should be clamped
@@ -109,8 +110,8 @@ void test_float_encoder()
     float min_val = encoder.Decode(encoder.Encode(-150.0f));  // below range
     float max_val = encoder.Decode(encoder.Encode(150.0f));   // above range
 
-    ASSERT(std::abs(min_val + 100.0f) < 1e-3f);
-    ASSERT(std::abs(max_val - 100.0f) < 1e-3f);
+    TEST_ASSERT(std::abs(min_val + 100.0f) < 1e-3f);
+    TEST_ASSERT(std::abs(max_val - 100.0f) < 1e-3f);
 
     UNUSED(min_val && max_val);
   }
@@ -121,8 +122,8 @@ void test_float_encoder()
     float min_decoded = encoder.Decode(encoder.Encode(-100.0f));
     float max_decoded = encoder.Decode(encoder.Encode(100.0f));
 
-    ASSERT(std::abs(min_decoded + 100.0f) < 1e-5f);
-    ASSERT(std::abs(max_decoded - 100.0f) < 1e-5f);
+    TEST_ASSERT(std::abs(min_decoded + 100.0f) < 1e-5f);
+    TEST_ASSERT(std::abs(max_decoded - 100.0f) < 1e-5f);
 
     UNUSED(min_decoded && max_decoded);
   }
@@ -131,7 +132,7 @@ void test_float_encoder()
   {
     FloatEncoder<BITS> encoder(-50.0f, 50.0f);
     float decoded = encoder.Decode(encoder.Encode(0.0f));
-    ASSERT(std::abs(decoded - 0.0f) < 1e-4f);
+    TEST_ASSERT(std::abs(decoded - 0.0f) < 1e-4f);
 
     UNUSED(decoded);
   }
@@ -141,13 +142,13 @@ void test_float_encoder()
     FloatEncoder<1> encoder(-1.0f, 1.0f);
     uint32_t code0 = encoder.Encode(-1.0f);
     uint32_t code1 = encoder.Encode(1.0f);
-    ASSERT(code0 == 0);
-    ASSERT(code1 == 1);
+    TEST_ASSERT(code0 == 0);
+    TEST_ASSERT(code1 == 1);
 
     float decoded0 = encoder.Decode(code0);
     float decoded1 = encoder.Decode(code1);
-    ASSERT(decoded0 <= -0.5f);
-    ASSERT(decoded1 >= 0.5f);
+    TEST_ASSERT(decoded0 <= -0.5f);
+    TEST_ASSERT(decoded1 >= 0.5f);
 
     UNUSED(decoded0 && decoded1);
   }
@@ -160,8 +161,8 @@ void test_float_encoder()
     float decoded_inf = encoder.Decode(encoder.Encode(INFINITY));
     float decoded_ninf = encoder.Decode(encoder.Encode(-INFINITY));
 
-    ASSERT(std::abs(decoded_inf - 100.0f) < 1e-3f);
-    ASSERT(std::abs(decoded_ninf + 100.0f) < 1e-3f);
+    TEST_ASSERT(std::abs(decoded_inf - 100.0f) < 1e-3f);
+    TEST_ASSERT(std::abs(decoded_ninf + 100.0f) < 1e-3f);
     // Behavior of NaN is undefined; main goal is to ensure no crash
 
     UNUSED(decoded_nan && decoded_inf && decoded_ninf);

--- a/test/base/utils/test_flag.cpp
+++ b/test/base/utils/test_flag.cpp
@@ -19,6 +19,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_flag`。 Test entry function `test_flag`.
@@ -31,44 +32,44 @@ void test_flag()
   // 测试内容：按文件头列出的测试项目顺序执行当前测试入口。
   // Test coverage: execute the test items listed in this file header in sequence.
   LibXR::Flag::Plain plain;
-  ASSERT(!plain.IsSet());
-  ASSERT(!plain.TestAndSet());
-  ASSERT(plain.IsSet());
-  ASSERT(plain.TestAndSet());
-  ASSERT(plain.TestAndClear());
-  ASSERT(!plain.IsSet());
-  ASSERT(!plain.TestAndClear());
-  ASSERT(!plain.Exchange(true));
-  ASSERT(plain.IsSet());
-  ASSERT(plain.Exchange(false));
-  ASSERT(!plain.IsSet());
+  TEST_ASSERT(!plain.IsSet());
+  TEST_ASSERT(!plain.TestAndSet());
+  TEST_ASSERT(plain.IsSet());
+  TEST_ASSERT(plain.TestAndSet());
+  TEST_ASSERT(plain.TestAndClear());
+  TEST_ASSERT(!plain.IsSet());
+  TEST_ASSERT(!plain.TestAndClear());
+  TEST_ASSERT(!plain.Exchange(true));
+  TEST_ASSERT(plain.IsSet());
+  TEST_ASSERT(plain.Exchange(false));
+  TEST_ASSERT(!plain.IsSet());
 
   {
     LibXR::Flag::ScopedRestore restore_outer(plain, true);
-    ASSERT(plain.IsSet());
+    TEST_ASSERT(plain.IsSet());
     {
       LibXR::Flag::ScopedRestore restore_inner(plain, false);
-      ASSERT(!plain.IsSet());
+      TEST_ASSERT(!plain.IsSet());
     }
-    ASSERT(plain.IsSet());
+    TEST_ASSERT(plain.IsSet());
   }
-  ASSERT(!plain.IsSet());
+  TEST_ASSERT(!plain.IsSet());
 
   LibXR::Flag::Atomic atomic;
-  ASSERT(!atomic.IsSet());
-  ASSERT(!atomic.TestAndSet());
-  ASSERT(atomic.IsSet());
-  ASSERT(atomic.TestAndSet());
-  ASSERT(atomic.Exchange(false));
-  ASSERT(!atomic.IsSet());
-  ASSERT(!atomic.Exchange(true));
-  ASSERT(atomic.IsSet());
+  TEST_ASSERT(!atomic.IsSet());
+  TEST_ASSERT(!atomic.TestAndSet());
+  TEST_ASSERT(atomic.IsSet());
+  TEST_ASSERT(atomic.TestAndSet());
+  TEST_ASSERT(atomic.Exchange(false));
+  TEST_ASSERT(!atomic.IsSet());
+  TEST_ASSERT(!atomic.Exchange(true));
+  TEST_ASSERT(atomic.IsSet());
   atomic.Clear();
-  ASSERT(!atomic.IsSet());
+  TEST_ASSERT(!atomic.IsSet());
 
   {
     LibXR::Flag::ScopedRestore restore(atomic, true);
-    ASSERT(atomic.IsSet());
+    TEST_ASSERT(atomic.IsSet());
   }
-  ASSERT(!atomic.IsSet());
+  TEST_ASSERT(!atomic.IsSet());
 }

--- a/test/base/utils/test_inertia.cpp
+++ b/test/base/utils/test_inertia.cpp
@@ -19,6 +19,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_inertia`。 Test entry function `test_inertia`.
@@ -50,33 +51,33 @@ void test_inertia()
   {
     for (int j = 0; j < 3; ++j)
     {
-      ASSERT(equal(from_arr9(i, j), from_mat(i, j)));
+      TEST_ASSERT(equal(from_arr9(i, j), from_mat(i, j)));
     }
   }
 
-  ASSERT(equal(from_sym(0, 0), 1.) && equal(from_sym(1, 1), 2.) &&
-         equal(from_sym(2, 2), 3.) && equal(from_sym(0, 1), -4.) &&
-         equal(from_sym(1, 0), -4.) && equal(from_sym(0, 2), -6.) &&
-         equal(from_sym(2, 0), -6.) && equal(from_sym(1, 2), -5.) &&
-         equal(from_sym(2, 1), -5.));
+  TEST_ASSERT(equal(from_sym(0, 0), 1.) && equal(from_sym(1, 1), 2.) &&
+              equal(from_sym(2, 2), 3.) && equal(from_sym(0, 1), -4.) &&
+              equal(from_sym(1, 0), -4.) && equal(from_sym(0, 2), -6.) &&
+              equal(from_sym(2, 0), -6.) && equal(from_sym(1, 2), -5.) &&
+              equal(from_sym(2, 1), -5.));
 
   for (int i = 0; i < 9; ++i)
   {
-    ASSERT(equal(from_arr9.data[i], from_vals.data[i]));
+    TEST_ASSERT(equal(from_arr9.data[i], from_vals.data[i]));
   }
 
   /* Translation and rotation checks */
   Position pos(std::sqrt(0.5), std::sqrt(0.5), 0.);
   auto translated = from_vals.Translate(pos);
-  ASSERT(equal(translated.data[0], 1.05));
-  ASSERT(equal(translated.data[1], -4.05));
-  ASSERT(equal(translated.data[2], -6.0));
-  ASSERT(equal(translated.data[3], -4.05));
-  ASSERT(equal(translated.data[4], 2.05));
-  ASSERT(equal(translated.data[5], -5.0));
-  ASSERT(equal(translated.data[6], -6.0));
-  ASSERT(equal(translated.data[7], -5.0));
-  ASSERT(equal(translated.data[8], 3.1));
+  TEST_ASSERT(equal(translated.data[0], 1.05));
+  TEST_ASSERT(equal(translated.data[1], -4.05));
+  TEST_ASSERT(equal(translated.data[2], -6.0));
+  TEST_ASSERT(equal(translated.data[3], -4.05));
+  TEST_ASSERT(equal(translated.data[4], 2.05));
+  TEST_ASSERT(equal(translated.data[5], -5.0));
+  TEST_ASSERT(equal(translated.data[6], -6.0));
+  TEST_ASSERT(equal(translated.data[7], -5.0));
+  TEST_ASSERT(equal(translated.data[8], 3.1));
 
   auto rotated_q = translated.Rotate(Quaternion<>(0.9238795, 0., 0., 0.3826834));
   auto rotated_m =
@@ -86,7 +87,7 @@ void test_inertia()
   {
     for (int j = 0; j < 3; ++j)
     {
-      ASSERT(equal(rotated_q(i, j), rotated_m(i, j)));
+      TEST_ASSERT(equal(rotated_q(i, j), rotated_m(i, j)));
     }
   }
 
@@ -94,9 +95,9 @@ void test_inertia()
   Eigen::Matrix<double, 3, 3> m_add;
   m_add << 1., 2., 3., 4., 5., 6., 7., 8., 9.;
   auto m_sum = from_vals + m_add;
-  ASSERT(equal(m_sum(0, 0), from_vals(0, 0) + 1.) &&
-         equal(m_sum(1, 1), from_vals(1, 1) + 5.) &&
-         equal(m_sum(2, 2), from_vals(2, 2) + 9.));
+  TEST_ASSERT(equal(m_sum(0, 0), from_vals(0, 0) + 1.) &&
+              equal(m_sum(1, 1), from_vals(1, 1) + 5.) &&
+              equal(m_sum(2, 2), from_vals(2, 2) + 9.));
 
   /* Center of mass combination */
   Transform t1(Quaternion<>(), Position(1., 0., 0.));
@@ -104,28 +105,28 @@ void test_inertia()
   CenterOfMass<> c1(from_vals, t1);
   CenterOfMass<> c2(from_arr9, t2);
   auto c = c1 + c2;
-  ASSERT(equal(c.mass, 0.2));
-  ASSERT(equal(c.position(0), 0.5) && equal(c.position(1), 0.5) &&
-         equal(c.position(2), 0.));
+  TEST_ASSERT(equal(c.mass, 0.2));
+  TEST_ASSERT(equal(c.position(0), 0.5) && equal(c.position(1), 0.5) &&
+              equal(c.position(2), 0.));
 
   /* Original behaviour check */
   auto inertia_new = Inertia(0.1, 1., 1., 1., 0., 0., 0.)
                          .Translate(pos)
                          .Rotate(LibXR::EulerAngle(0., 0., LibXR::PI / 4).ToQuaternion());
 
-  ASSERT(equal(inertia_new(0, 0), 1.1) && equal(inertia_new(0, 1), 0.) &&
-         equal(inertia_new(0, 2), 0.) && equal(inertia_new(1, 0), 0.) &&
-         equal(inertia_new(1, 1), 1.) && equal(inertia_new(1, 2), 0.) &&
-         equal(inertia_new(2, 0), 0.) && equal(inertia_new(2, 1), 0.) &&
-         equal(inertia_new(2, 2), 1.1));
+  TEST_ASSERT(equal(inertia_new(0, 0), 1.1) && equal(inertia_new(0, 1), 0.) &&
+              equal(inertia_new(0, 2), 0.) && equal(inertia_new(1, 0), 0.) &&
+              equal(inertia_new(1, 1), 1.) && equal(inertia_new(1, 2), 0.) &&
+              equal(inertia_new(2, 0), 0.) && equal(inertia_new(2, 1), 0.) &&
+              equal(inertia_new(2, 2), 1.1));
 
   inertia_new = Inertia(0.1, 1., 1., 1., 0., 0., 0.)
                     .Translate(pos)
                     .Rotate(LibXR::EulerAngle(0., 0., LibXR::PI / 4).ToRotationMatrix());
 
-  ASSERT(equal(inertia_new(0, 0), 1.1) && equal(inertia_new(0, 1), 0.) &&
-         equal(inertia_new(0, 2), 0.) && equal(inertia_new(1, 0), 0.) &&
-         equal(inertia_new(1, 1), 1.) && equal(inertia_new(1, 2), 0.) &&
-         equal(inertia_new(2, 0), 0.) && equal(inertia_new(2, 1), 0.) &&
-         equal(inertia_new(2, 2), 1.1));
+  TEST_ASSERT(equal(inertia_new(0, 0), 1.1) && equal(inertia_new(0, 1), 0.) &&
+              equal(inertia_new(0, 2), 0.) && equal(inertia_new(1, 0), 0.) &&
+              equal(inertia_new(1, 1), 1.) && equal(inertia_new(1, 2), 0.) &&
+              equal(inertia_new(2, 0), 0.) && equal(inertia_new(2, 1), 0.) &&
+              equal(inertia_new(2, 2), 1.1));
 }

--- a/test/base/utils/test_kinematic.cpp
+++ b/test/base/utils/test_kinematic.cpp
@@ -19,6 +19,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_kinematic`。 Test entry function `test_kinematic`.
@@ -84,7 +85,7 @@ void test_kinematic()
   auto error_pos = object_endpoint.GetPositionError();
   auto error_quat = object_endpoint.GetQuaternionError();
 
-  ASSERT(error_pos.norm() < 1e-3);
-  ASSERT(std::abs(error_quat.x()) < 1e-2 && std::abs(error_quat.y()) < 1e-2 &&
-         std::abs(error_quat.z()) < 1e-2 && std::abs(error_quat.w() - 1.0) < 1e-2);
+  TEST_ASSERT(error_pos.norm() < 1e-3);
+  TEST_ASSERT(std::abs(error_quat.x()) < 1e-2 && std::abs(error_quat.y()) < 1e-2 &&
+              std::abs(error_quat.z()) < 1e-2 && std::abs(error_quat.w() - 1.0) < 1e-2);
 }

--- a/test/base/utils/test_pid_cycle.cpp
+++ b/test/base/utils/test_pid_cycle.cpp
@@ -3,6 +3,7 @@
  * @brief PID 周期误差语义子测试。 Split test unit for PID cyclic-error semantics.
  */
 #include "pid_test_common.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试项函数 `RunPidCycleTests`。 Test-item function `RunPidCycleTests`.
@@ -41,8 +42,8 @@ void RunPidCycleTests()
       const double OUT = pid.Calculate(SP, FB, DT);
       const double EXPECT = static_cast<double>(SP - FB);
 
-      ASSERT(near(OUT, EXPECT, 1e-6));
-      ASSERT(near(pid.LastError(), EXPECT, 1e-6));
+      TEST_ASSERT(near(OUT, EXPECT, 1e-6));
+      TEST_ASSERT(near(pid.LastError(), EXPECT, 1e-6));
     }
 
     // cycle = true: err = CycleValue(sp) - fb
@@ -53,12 +54,12 @@ void RunPidCycleTests()
       const double EXPECT_CYCLE = static_cast<double>(LibXR::CycleValue<S>(SP) - FB);
       const double EXPECT_LINEAR = static_cast<double>(SP - FB);
 
-      ASSERT(std::isfinite(EXPECT_CYCLE));
-      ASSERT(std::abs(EXPECT_CYCLE - EXPECT_LINEAR) > 1.0);
+      TEST_ASSERT(std::isfinite(EXPECT_CYCLE));
+      TEST_ASSERT(std::abs(EXPECT_CYCLE - EXPECT_LINEAR) > 1.0);
 
       const double OUT = pid.Calculate(SP, FB, DT);
-      ASSERT(near(OUT, EXPECT_CYCLE, 1e-6));
-      ASSERT(near(pid.LastError(), EXPECT_CYCLE, 1e-6));
+      TEST_ASSERT(near(OUT, EXPECT_CYCLE, 1e-6));
+      TEST_ASSERT(near(pid.LastError(), EXPECT_CYCLE, 1e-6));
     }
   }
 }

--- a/test/base/utils/test_pid_response.cpp
+++ b/test/base/utils/test_pid_response.cpp
@@ -4,6 +4,7 @@
  * behavior.
  */
 #include "pid_test_common.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试项函数 `RunPidResponseTests`。 Test-item function `RunPidResponseTests`.
@@ -30,17 +31,17 @@ void RunPidResponseTests()
     LibXR::PID<> pid(param);
 
     const double OUT1 = pid.Calculate(1.0, 0.0, 0.1);
-    ASSERT(equal(OUT1, 2.05));
+    TEST_ASSERT(equal(OUT1, 2.05));
 
     const double OUT2 = pid.Calculate(1.0, 0.0, 0.1);
-    ASSERT(equal(OUT2, 2.1));
+    TEST_ASSERT(equal(OUT2, 2.1));
 
     for (int i = 0; i < 50; ++i)
     {
       (void)pid.Calculate(1.0, 0.0, 0.1);
     }
-    ASSERT(std::abs(pid.GetIntegralError()) <= param.i_limit + 1e-6);
-    ASSERT(std::abs(pid.LastOutput()) <= param.out_limit + 1e-6);
+    TEST_ASSERT(std::abs(pid.GetIntegralError()) <= param.i_limit + 1e-6);
+    TEST_ASSERT(std::abs(pid.LastOutput()) <= param.out_limit + 1e-6);
   }
 
   // -----------------------
@@ -58,9 +59,9 @@ void RunPidResponseTests()
     LibXR::PID<> pid(param);
 
     const double OUT = pid.Calculate(1.0, 0.0, 0.1);
-    ASSERT(std::abs(OUT) <= param.out_limit + 1e-6);
-    ASSERT(near(OUT, 1.0, 1e-6));
-    ASSERT(near(pid.LastOutput(), 1.0, 1e-6));
+    TEST_ASSERT(std::abs(OUT) <= param.out_limit + 1e-6);
+    TEST_ASSERT(near(OUT, 1.0, 1e-6));
+    TEST_ASSERT(near(pid.LastOutput(), 1.0, 1e-6));
   }
 
   // ---------------------------------------------------
@@ -84,8 +85,8 @@ void RunPidResponseTests()
 
     // When already saturated, integral update is rejected if it increases saturation
     // magnitude.
-    ASSERT(std::abs(pid.GetIntegralError()) <= 1e-6);
-    ASSERT(std::abs(pid.LastOutput()) <= param.out_limit + 1e-6);
+    TEST_ASSERT(std::abs(pid.GetIntegralError()) <= 1e-6);
+    TEST_ASSERT(std::abs(pid.LastOutput()) <= param.out_limit + 1e-6);
   }
 
   // ---------------------------------------------------
@@ -104,7 +105,7 @@ void RunPidResponseTests()
     pid.SetIntegralError(1.0);  // start saturated from I term
 
     const double OUT0 = pid.Calculate(0.0, 0.0, 0.1);
-    ASSERT(std::abs(OUT0) <= param.out_limit + 1e-6);
+    TEST_ASSERT(std::abs(OUT0) <= param.out_limit + 1e-6);
 
     // Apply negative error to drive integral down (unwind).
     for (int i = 0; i < 10; ++i)
@@ -112,8 +113,8 @@ void RunPidResponseTests()
       (void)pid.Calculate(-1.0, 0.0, 0.1);
     }
 
-    ASSERT(pid.GetIntegralError() < 1.0);
-    ASSERT(std::abs(pid.LastOutput()) <= param.out_limit + 1e-6);
+    TEST_ASSERT(pid.GetIntegralError() < 1.0);
+    TEST_ASSERT(std::abs(pid.LastOutput()) <= param.out_limit + 1e-6);
   }
 
   // -----------------------------------------
@@ -135,7 +136,7 @@ void RunPidResponseTests()
     // D: fb_dot=10 => fb_d_k=10 => d_out = 10*0.1 = 1.0
     // out = p*e_k + i_out - d_out = 2 + 0.05 - 1.0 = 1.05
     const double OUT = pid.Calculate(1.0, 0.0, 10.0, 0.1);
-    ASSERT(near(OUT, 1.05, 1e-6));
+    TEST_ASSERT(near(OUT, 1.05, 1e-6));
   }
 
   // -------------------------------------------------

--- a/test/base/utils/test_pid_state.cpp
+++ b/test/base/utils/test_pid_state.cpp
@@ -4,6 +4,7 @@
  * behavior.
  */
 #include "pid_test_common.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试项函数 `RunPidStateTests`。 Test-item function `RunPidStateTests`.
@@ -30,7 +31,7 @@ void RunPidStateTests()
 
     (void)pid.Calculate(0.0, 0.3, 0.1);
     // eps 放宽：兼容默认 Scalar 为 float 的实现
-    ASSERT(near(pid.LastFeedback(), 0.3, 1e-6));
+    TEST_ASSERT(near(pid.LastFeedback(), 0.3, 1e-6));
   }
 
   // ---------------------------------------------------------
@@ -50,7 +51,7 @@ void RunPidStateTests()
     (void)pid.Calculate(0.0, 0.0, 0.1);  // establishes last_fb = 0
     (void)pid.Calculate(0.0, 1.0, 0.1);  // fb_dot = 10, scaled by k => 20
 
-    ASSERT(near(pid.LastDerivative(), 20.0, 1e-6));
+    TEST_ASSERT(near(pid.LastDerivative(), 20.0, 1e-6));
   }
 
   // -------------------------------------------------
@@ -68,14 +69,14 @@ void RunPidStateTests()
     LibXR::PID<> pid(param);
 
     const double OUT1 = pid.Calculate(1.0, 0.0, 0.1);
-    ASSERT(std::isfinite(OUT1));
+    TEST_ASSERT(std::isfinite(OUT1));
 
     const double OUT_DT0 = pid.Calculate(1.0, 0.0, 0.0);
-    ASSERT(near(OUT_DT0, OUT1, 1e-12));
+    TEST_ASSERT(near(OUT_DT0, OUT1, 1e-12));
 
     const double STD_NAN = std::numeric_limits<double>::quiet_NaN();
     const double OUT_NAN = pid.Calculate(STD_NAN, 0.0, 0.1);
-    ASSERT(near(OUT_NAN, OUT1, 1e-12));
+    TEST_ASSERT(near(OUT_NAN, OUT1, 1e-12));
   }
 
   // -----------------------
@@ -95,11 +96,11 @@ void RunPidStateTests()
     (void)pid.Calculate(1.0, 0.0, 0.1);
     pid.Reset();
 
-    ASSERT(near(pid.GetIntegralError(), 0.0, 1e-12));
-    ASSERT(near(pid.LastError(), 0.0, 1e-12));
-    ASSERT(near(pid.LastFeedback(), 0.0, 1e-12));
-    ASSERT(near(pid.LastOutput(), 0.0, 1e-12));
-    ASSERT(near(pid.LastDerivative(), 0.0, 1e-12));
+    TEST_ASSERT(near(pid.GetIntegralError(), 0.0, 1e-12));
+    TEST_ASSERT(near(pid.LastError(), 0.0, 1e-12));
+    TEST_ASSERT(near(pid.LastFeedback(), 0.0, 1e-12));
+    TEST_ASSERT(near(pid.LastOutput(), 0.0, 1e-12));
+    TEST_ASSERT(near(pid.LastDerivative(), 0.0, 1e-12));
   }
 
   // -------------------------------------------------------
@@ -119,8 +120,8 @@ void RunPidStateTests()
     pid.SetIntegralError(1.0);  // even if preset, Calculate() should clear it
     (void)pid.Calculate(1.0, 0.0, 0.1);
 
-    ASSERT(near(pid.GetIntegralError(), 0.0, 1e-12));
-    ASSERT(near(pid.LastOutput(), 0.0, 1e-12));
+    TEST_ASSERT(near(pid.GetIntegralError(), 0.0, 1e-12));
+    TEST_ASSERT(near(pid.LastOutput(), 0.0, 1e-12));
   }
 
   // -------------------------------------------------------
@@ -138,8 +139,8 @@ void RunPidStateTests()
     LibXR::PID<> pid(param);
 
     const double OUT = pid.Calculate(1.0, 0.0, 0.1);
-    ASSERT(near(OUT, 100.0, 1e-6));
-    ASSERT(near(pid.LastOutput(), 100.0, 1e-6));
+    TEST_ASSERT(near(OUT, 100.0, 1e-6));
+    TEST_ASSERT(near(pid.LastOutput(), 100.0, 1e-6));
   }
 
   // -------------------------------------------------------

--- a/test/base/utils/test_transform_construction.cpp
+++ b/test/base/utils/test_transform_construction.cpp
@@ -3,6 +3,7 @@
  * @brief transform 构造与基础代数子测试。 Split test unit for transform construction and
  * basic algebra.
  */
+#include "test_assert.hpp"
 #include "transform_test_common.hpp"
 
 /**
@@ -27,31 +28,31 @@ void RunTransformConstructionTests()
   auto& quat = state.quat;
   auto& quat_new = state.quat_new;
   LibXR::Quaternion quat_from_array(state.quat_wxyz);
-  ASSERT(equal(quat_from_array.w(), state.quat_wxyz[0]) &&
-         equal(quat_from_array.x(), state.quat_wxyz[1]) &&
-         equal(quat_from_array.y(), state.quat_wxyz[2]) &&
-         equal(quat_from_array.z(), state.quat_wxyz[3]));
-  ASSERT(equal(quat_from_array(0), state.quat_wxyz[1]) &&
-         equal(quat_from_array(1), state.quat_wxyz[2]) &&
-         equal(quat_from_array(2), state.quat_wxyz[3]) &&
-         equal(quat_from_array(3), state.quat_wxyz[0]));
+  TEST_ASSERT(equal(quat_from_array.w(), state.quat_wxyz[0]) &&
+              equal(quat_from_array.x(), state.quat_wxyz[1]) &&
+              equal(quat_from_array.y(), state.quat_wxyz[2]) &&
+              equal(quat_from_array.z(), state.quat_wxyz[3]));
+  TEST_ASSERT(equal(quat_from_array(0), state.quat_wxyz[1]) &&
+              equal(quat_from_array(1), state.quat_wxyz[2]) &&
+              equal(quat_from_array(2), state.quat_wxyz[3]) &&
+              equal(quat_from_array(3), state.quat_wxyz[0]));
 
   LibXR::RotationMatrix rot_from_array(state.rot_row_major);
   LibXR::RotationMatrix rot_from_2d_array(state.rot_row_major_2d);
-  ASSERT(equal(rot_from_array(0, 0), 1.0) && equal(rot_from_array(0, 1), 0.0) &&
-         equal(rot_from_array(0, 2), 0.0) && equal(rot_from_array(1, 0), 0.0) &&
-         equal(rot_from_array(1, 1), 0.0) && equal(rot_from_array(1, 2), -1.0) &&
-         equal(rot_from_array(2, 0), 0.0) && equal(rot_from_array(2, 1), 1.0) &&
-         equal(rot_from_array(2, 2), 0.0));
-  ASSERT(equal(rot_from_2d_array(0, 0), rot_from_array(0, 0)) &&
-         equal(rot_from_2d_array(0, 1), rot_from_array(0, 1)) &&
-         equal(rot_from_2d_array(0, 2), rot_from_array(0, 2)) &&
-         equal(rot_from_2d_array(1, 0), rot_from_array(1, 0)) &&
-         equal(rot_from_2d_array(1, 1), rot_from_array(1, 1)) &&
-         equal(rot_from_2d_array(1, 2), rot_from_array(1, 2)) &&
-         equal(rot_from_2d_array(2, 0), rot_from_array(2, 0)) &&
-         equal(rot_from_2d_array(2, 1), rot_from_array(2, 1)) &&
-         equal(rot_from_2d_array(2, 2), rot_from_array(2, 2)));
+  TEST_ASSERT(equal(rot_from_array(0, 0), 1.0) && equal(rot_from_array(0, 1), 0.0) &&
+              equal(rot_from_array(0, 2), 0.0) && equal(rot_from_array(1, 0), 0.0) &&
+              equal(rot_from_array(1, 1), 0.0) && equal(rot_from_array(1, 2), -1.0) &&
+              equal(rot_from_array(2, 0), 0.0) && equal(rot_from_array(2, 1), 1.0) &&
+              equal(rot_from_array(2, 2), 0.0));
+  TEST_ASSERT(equal(rot_from_2d_array(0, 0), rot_from_array(0, 0)) &&
+              equal(rot_from_2d_array(0, 1), rot_from_array(0, 1)) &&
+              equal(rot_from_2d_array(0, 2), rot_from_array(0, 2)) &&
+              equal(rot_from_2d_array(1, 0), rot_from_array(1, 0)) &&
+              equal(rot_from_2d_array(1, 1), rot_from_array(1, 1)) &&
+              equal(rot_from_2d_array(1, 2), rot_from_array(1, 2)) &&
+              equal(rot_from_2d_array(2, 0), rot_from_array(2, 0)) &&
+              equal(rot_from_2d_array(2, 1), rot_from_array(2, 1)) &&
+              equal(rot_from_2d_array(2, 2), rot_from_array(2, 2)));
 
   /* Position */
   rot = eulr.ToRotationMatrix();
@@ -61,28 +62,28 @@ void RunTransformConstructionTests()
   quat_new = pos_new / pos;
   rot_new = quat_new.ToRotationMatrix();
   pos_new = pos_new / rot_new;
-  ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
-         equal(pos_new(2), pos(2)));
+  TEST_ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
+              equal(pos_new(2), pos(2)));
 
   pos_new /= quat;
   pos_new *= rot;
-  ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
-         equal(pos_new(2), pos(2)));
+  TEST_ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
+              equal(pos_new(2), pos(2)));
 
   pos_new = (pos - pos_new) * 2.;
   pos_new *= 2;
   pos_new /= 4;
-  ASSERT(equal(pos_new(0), 0.) && equal(pos_new(1), 0.) && equal(pos_new(2), 0.));
+  TEST_ASSERT(equal(pos_new(0), 0.) && equal(pos_new(1), 0.) && equal(pos_new(2), 0.));
 
   pos_new = pos + pos_new;
-  ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
-         equal(pos_new(2), pos(2)));
+  TEST_ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
+              equal(pos_new(2), pos(2)));
 
   pos_new -= pos;
 
-  ASSERT(equal(pos_new(0), 0.) && equal(pos_new(1), 0.) && equal(pos_new(2), 0.));
+  TEST_ASSERT(equal(pos_new(0), 0.) && equal(pos_new(1), 0.) && equal(pos_new(2), 0.));
 
   pos_new += pos;
-  ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
-         equal(pos_new(2), pos(2)));
+  TEST_ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
+              equal(pos_new(2), pos(2)));
 }

--- a/test/base/utils/test_transform_euler_orders.cpp
+++ b/test/base/utils/test_transform_euler_orders.cpp
@@ -3,6 +3,7 @@
  * @brief transform 欧拉顺序 round-trip 子测试。 Split test unit for transform Euler-order
  * round trips.
  */
+#include "test_assert.hpp"
 #include "transform_test_common.hpp"
 
 /**
@@ -26,169 +27,169 @@ void RunTransformEulerOrderTests()
 
   /* ZYX Order */
   rot = eulr.ToRotationMatrixZYX();
-  ASSERT(equal(rot(0, 0), 0.6123725) && equal(rot(0, 1), -0.5915064) &&
-         equal(rot(0, 2), 0.5245190) && equal(rot(1, 0), 0.6123725) &&
-         equal(rot(1, 1), 0.7745190) && equal(rot(1, 2), 0.1584937) &&
-         equal(rot(2, 0), -0.5000000) && equal(rot(2, 1), 0.2241439) &&
-         equal(rot(2, 2), 0.8365163));
+  TEST_ASSERT(equal(rot(0, 0), 0.6123725) && equal(rot(0, 1), -0.5915064) &&
+              equal(rot(0, 2), 0.5245190) && equal(rot(1, 0), 0.6123725) &&
+              equal(rot(1, 1), 0.7745190) && equal(rot(1, 2), 0.1584937) &&
+              equal(rot(2, 0), -0.5000000) && equal(rot(2, 1), 0.2241439) &&
+              equal(rot(2, 2), 0.8365163));
 
   eulr_new = rot.ToEulerAngleZYX();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   quat = LibXR::Quaternion(rot);
   quat_new = eulr.ToQuaternionZYX();
-  ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
-         equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
+  TEST_ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
+              equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
 
   rot_new = quat.ToRotationMatrix();
-  ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
-         equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
-         equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
-         equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
-         equal(rot_new(2, 2), rot(2, 2)));
+  TEST_ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
+              equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
+              equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
+              equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
+              equal(rot_new(2, 2), rot(2, 2)));
 
   eulr_new = quat.ToEulerAngleZYX();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   /* ZXY Order */
   rot = eulr.ToRotationMatrixZXY();
-  ASSERT(equal(rot(0, 0), 0.5208661) && equal(rot(0, 1), -0.6830127) &&
-         equal(rot(0, 2), 0.5120471) && equal(rot(1, 0), 0.7038788) &&
-         equal(rot(1, 1), 0.6830127) && equal(rot(1, 2), 0.1950597) &&
-         equal(rot(2, 0), -0.4829629) && equal(rot(2, 1), 0.2588190) &&
-         equal(rot(2, 2), 0.8365163));
+  TEST_ASSERT(equal(rot(0, 0), 0.5208661) && equal(rot(0, 1), -0.6830127) &&
+              equal(rot(0, 2), 0.5120471) && equal(rot(1, 0), 0.7038788) &&
+              equal(rot(1, 1), 0.6830127) && equal(rot(1, 2), 0.1950597) &&
+              equal(rot(2, 0), -0.4829629) && equal(rot(2, 1), 0.2588190) &&
+              equal(rot(2, 2), 0.8365163));
 
   eulr_new = rot.ToEulerAngleZXY();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   quat = LibXR::Quaternion(rot);
   quat_new = eulr.ToQuaternionZXY();
-  ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
-         equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
+  TEST_ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
+              equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
 
   rot_new = quat.ToRotationMatrix();
-  ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
-         equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
-         equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
-         equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
-         equal(rot_new(2, 2), rot(2, 2)));
+  TEST_ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
+              equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
+              equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
+              equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
+              equal(rot_new(2, 2), rot(2, 2)));
 
   eulr_new = quat.ToEulerAngleZXY();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   /* YXZ Order */
   rot = eulr.ToRotationMatrixYXZ();
-  ASSERT(equal(rot(0, 0), 0.7038788) && equal(rot(0, 1), -0.5208661) &&
-         equal(rot(0, 2), 0.4829629) && equal(rot(1, 0), 0.6830127) &&
-         equal(rot(1, 1), 0.6830127) && equal(rot(1, 2), -0.2588190) &&
-         equal(rot(2, 0), -0.1950597) && equal(rot(2, 1), 0.5120471) &&
-         equal(rot(2, 2), 0.8365163));
+  TEST_ASSERT(equal(rot(0, 0), 0.7038788) && equal(rot(0, 1), -0.5208661) &&
+              equal(rot(0, 2), 0.4829629) && equal(rot(1, 0), 0.6830127) &&
+              equal(rot(1, 1), 0.6830127) && equal(rot(1, 2), -0.2588190) &&
+              equal(rot(2, 0), -0.1950597) && equal(rot(2, 1), 0.5120471) &&
+              equal(rot(2, 2), 0.8365163));
 
   eulr_new = rot.ToEulerAngleYXZ();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   quat = LibXR::Quaternion(rot);
   quat_new = eulr.ToQuaternionYXZ();
-  ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
-         equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
+  TEST_ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
+              equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
 
   rot_new = quat.ToRotationMatrix();
-  ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
-         equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
-         equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
-         equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
-         equal(rot_new(2, 2), rot(2, 2)));
+  TEST_ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
+              equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
+              equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
+              equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
+              equal(rot_new(2, 2), rot(2, 2)));
 
   eulr_new = quat.ToEulerAngleYXZ();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   /* XYZ Order */
   rot = eulr.ToRotationMatrixXYZ();
-  ASSERT(equal(rot(0, 0), 0.6123725) && equal(rot(0, 1), -0.6123725) &&
-         equal(rot(0, 2), 0.5000000) && equal(rot(1, 0), 0.7745190) &&
-         equal(rot(1, 1), 0.5915064) && equal(rot(1, 2), -0.2241439) &&
-         equal(rot(2, 0), -0.1584937) && equal(rot(2, 1), 0.5245190) &&
-         equal(rot(2, 2), 0.8365163));
+  TEST_ASSERT(equal(rot(0, 0), 0.6123725) && equal(rot(0, 1), -0.6123725) &&
+              equal(rot(0, 2), 0.5000000) && equal(rot(1, 0), 0.7745190) &&
+              equal(rot(1, 1), 0.5915064) && equal(rot(1, 2), -0.2241439) &&
+              equal(rot(2, 0), -0.1584937) && equal(rot(2, 1), 0.5245190) &&
+              equal(rot(2, 2), 0.8365163));
 
   eulr_new = rot.ToEulerAngleXYZ();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   quat = LibXR::Quaternion(rot);
   quat_new = eulr.ToQuaternionXYZ();
-  ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
-         equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
+  TEST_ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
+              equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
 
   rot_new = quat.ToRotationMatrix();
-  ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
-         equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
-         equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
-         equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
-         equal(rot_new(2, 2), rot(2, 2)));
+  TEST_ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
+              equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
+              equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
+              equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
+              equal(rot_new(2, 2), rot(2, 2)));
 
   eulr_new = quat.ToEulerAngleXYZ();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   /* XZY Order */
   rot = eulr.ToRotationMatrixXZY();
-  ASSERT(equal(rot(0, 0), 0.6123725) && equal(rot(0, 1), -0.7071068) &&
-         equal(rot(0, 2), 0.3535534) && equal(rot(1, 0), 0.7209159) &&
-         equal(rot(1, 1), 0.6830127) && equal(rot(1, 2), 0.1173625) &&
-         equal(rot(2, 0), -0.3244693) && equal(rot(2, 1), 0.1830127) &&
-         equal(rot(2, 2), 0.9280227));
+  TEST_ASSERT(equal(rot(0, 0), 0.6123725) && equal(rot(0, 1), -0.7071068) &&
+              equal(rot(0, 2), 0.3535534) && equal(rot(1, 0), 0.7209159) &&
+              equal(rot(1, 1), 0.6830127) && equal(rot(1, 2), 0.1173625) &&
+              equal(rot(2, 0), -0.3244693) && equal(rot(2, 1), 0.1830127) &&
+              equal(rot(2, 2), 0.9280227));
 
   eulr_new = rot.ToEulerAngleXZY();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   quat = LibXR::Quaternion(rot);
   quat_new = eulr.ToQuaternionXZY();
-  ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
-         equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
+  TEST_ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
+              equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
 
   rot_new = quat.ToRotationMatrix();
-  ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
-         equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
-         equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
-         equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
-         equal(rot_new(2, 2), rot(2, 2)));
+  TEST_ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
+              equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
+              equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
+              equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
+              equal(rot_new(2, 2), rot(2, 2)));
 
   eulr_new = quat.ToEulerAngleXZY();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   /* YZX Order */
   rot = eulr.ToRotationMatrixYZX();
-  ASSERT(equal(rot(0, 0), 0.6123725) && equal(rot(0, 1), -0.4620968) &&
-         equal(rot(0, 2), 0.6414565) && equal(rot(1, 0), 0.7071068) &&
-         equal(rot(1, 1), 0.6830127) && equal(rot(1, 2), -0.1830127) &&
-         equal(rot(2, 0), -0.3535534) && equal(rot(2, 1), 0.5656502) &&
-         equal(rot(2, 2), 0.7450100));
+  TEST_ASSERT(equal(rot(0, 0), 0.6123725) && equal(rot(0, 1), -0.4620968) &&
+              equal(rot(0, 2), 0.6414565) && equal(rot(1, 0), 0.7071068) &&
+              equal(rot(1, 1), 0.6830127) && equal(rot(1, 2), -0.1830127) &&
+              equal(rot(2, 0), -0.3535534) && equal(rot(2, 1), 0.5656502) &&
+              equal(rot(2, 2), 0.7450100));
 
   eulr_new = rot.ToEulerAngleYZX();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 
   quat = LibXR::Quaternion(rot);
   quat_new = eulr.ToQuaternionYZX();
-  ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
-         equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
+  TEST_ASSERT(equal(quat_new.w(), quat.w()) && equal(quat_new.x(), quat.x()) &&
+              equal(quat_new.y(), quat.y()) && equal(quat_new.z(), quat.z()));
 
   rot_new = quat.ToRotationMatrix();
-  ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
-         equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
-         equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
-         equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
-         equal(rot_new(2, 2), rot(2, 2)));
+  TEST_ASSERT(equal(rot_new(0, 0), rot(0, 0)) && equal(rot_new(0, 1), rot(0, 1)) &&
+              equal(rot_new(0, 2), rot(0, 2)) && equal(rot_new(1, 0), rot(1, 0)) &&
+              equal(rot_new(1, 1), rot(1, 1)) && equal(rot_new(1, 2), rot(1, 2)) &&
+              equal(rot_new(2, 0), rot(2, 0)) && equal(rot_new(2, 1), rot(2, 1)) &&
+              equal(rot_new(2, 2), rot(2, 2)));
 
   eulr_new = quat.ToEulerAngleYZX();
-  ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
-         equal(eulr_new(2), eulr(2)));
+  TEST_ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
+              equal(eulr_new(2), eulr(2)));
 }

--- a/test/base/utils/test_transform_rotation.cpp
+++ b/test/base/utils/test_transform_rotation.cpp
@@ -3,6 +3,7 @@
  * @brief transform 旋转互操作子测试。 Split test unit for transform rotation
  * interoperability.
  */
+#include "test_assert.hpp"
 #include "transform_test_common.hpp"
 
 /**
@@ -26,8 +27,8 @@ void RunTransformRotationInteropTests()
   quat_new = quat;
   quat_new = quat - quat_new;
   quat_new = quat + quat_new;
-  ASSERT(equal(quat_new(0), quat(0)) && equal(quat_new(1), quat(1)) &&
-         equal(quat_new(2), quat(2)) && equal(quat_new(3), quat(3)));
+  TEST_ASSERT(equal(quat_new(0), quat(0)) && equal(quat_new(1), quat(1)) &&
+              equal(quat_new(2), quat(2)) && equal(quat_new(3), quat(3)));
 
   Eigen::Quaternion<double> eigen_quat =
       LibXR::EulerAngle<double>(LibXR::PI / 8, -LibXR::PI / 9, LibXR::PI / 7)
@@ -35,23 +36,24 @@ void RunTransformRotationInteropTests()
   LibXR::RotationMatrix rot_from_eigen_quat(eigen_quat);
   rot_new = eigen_quat;
   const Eigen::Matrix3d eigen_rot = eigen_quat.toRotationMatrix();
-  ASSERT(equal(rot_from_eigen_quat(0, 0), eigen_rot(0, 0)) &&
-         equal(rot_from_eigen_quat(0, 1), eigen_rot(0, 1)) &&
-         equal(rot_from_eigen_quat(0, 2), eigen_rot(0, 2)) &&
-         equal(rot_from_eigen_quat(1, 0), eigen_rot(1, 0)) &&
-         equal(rot_from_eigen_quat(1, 1), eigen_rot(1, 1)) &&
-         equal(rot_from_eigen_quat(1, 2), eigen_rot(1, 2)) &&
-         equal(rot_from_eigen_quat(2, 0), eigen_rot(2, 0)) &&
-         equal(rot_from_eigen_quat(2, 1), eigen_rot(2, 1)) &&
-         equal(rot_from_eigen_quat(2, 2), eigen_rot(2, 2)));
-  ASSERT(equal(rot_new(0, 0), eigen_rot(0, 0)) && equal(rot_new(0, 1), eigen_rot(0, 1)) &&
-         equal(rot_new(0, 2), eigen_rot(0, 2)) && equal(rot_new(1, 0), eigen_rot(1, 0)) &&
-         equal(rot_new(1, 1), eigen_rot(1, 1)) && equal(rot_new(1, 2), eigen_rot(1, 2)) &&
-         equal(rot_new(2, 0), eigen_rot(2, 0)) && equal(rot_new(2, 1), eigen_rot(2, 1)) &&
-         equal(rot_new(2, 2), eigen_rot(2, 2)));
+  TEST_ASSERT(equal(rot_from_eigen_quat(0, 0), eigen_rot(0, 0)) &&
+              equal(rot_from_eigen_quat(0, 1), eigen_rot(0, 1)) &&
+              equal(rot_from_eigen_quat(0, 2), eigen_rot(0, 2)) &&
+              equal(rot_from_eigen_quat(1, 0), eigen_rot(1, 0)) &&
+              equal(rot_from_eigen_quat(1, 1), eigen_rot(1, 1)) &&
+              equal(rot_from_eigen_quat(1, 2), eigen_rot(1, 2)) &&
+              equal(rot_from_eigen_quat(2, 0), eigen_rot(2, 0)) &&
+              equal(rot_from_eigen_quat(2, 1), eigen_rot(2, 1)) &&
+              equal(rot_from_eigen_quat(2, 2), eigen_rot(2, 2)));
+  TEST_ASSERT(
+      equal(rot_new(0, 0), eigen_rot(0, 0)) && equal(rot_new(0, 1), eigen_rot(0, 1)) &&
+      equal(rot_new(0, 2), eigen_rot(0, 2)) && equal(rot_new(1, 0), eigen_rot(1, 0)) &&
+      equal(rot_new(1, 1), eigen_rot(1, 1)) && equal(rot_new(1, 2), eigen_rot(1, 2)) &&
+      equal(rot_new(2, 0), eigen_rot(2, 0)) && equal(rot_new(2, 1), eigen_rot(2, 1)) &&
+      equal(rot_new(2, 2), eigen_rot(2, 2)));
   quat_new = quat / eigen_quat;
   Eigen::Quaternion<double> eigen_div =
       Eigen::Quaternion<double>(quat) * eigen_quat.conjugate();
-  ASSERT(equal(quat_new.w(), eigen_div.w()) && equal(quat_new.x(), eigen_div.x()) &&
-         equal(quat_new.y(), eigen_div.y()) && equal(quat_new.z(), eigen_div.z()));
+  TEST_ASSERT(equal(quat_new.w(), eigen_div.w()) && equal(quat_new.x(), eigen_div.x()) &&
+              equal(quat_new.y(), eigen_div.y()) && equal(quat_new.z(), eigen_div.z()));
 }

--- a/test/common/rw/pipe_stream_test_common.hpp
+++ b/test/common/rw/pipe_stream_test_common.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "pipe_transfer_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -38,13 +39,13 @@ void VerifyStreamBlockPendingCompletion(LibXR::ErrorCode finish_result,
     if (submit_mode == StreamSubmitMode::COMMIT)
     {
       auto ec = ws.Commit();
-      ASSERT(ec == expected_result);
+      TEST_ASSERT(ec == expected_result);
     }
   }
 
   ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(sem.Value() == 0);
 }
 
 /**
@@ -65,17 +66,17 @@ void VerifyStreamBlockTimeout()
   ws << ConstRawData{TX, sizeof(TX)};
 
   auto ec = ws.Commit();
-  ASSERT(ec == ErrorCode::TIMEOUT);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(ec == ErrorCode::TIMEOUT);
+  TEST_ASSERT(sem.Value() == 0);
 
   {
     auto queue = w.GetWriteQueue(false);
-    ASSERT(!queue.Empty());
+    TEST_ASSERT(!queue.Empty());
     static uint8_t sink[16];
     queue.PopAll(sink);
   }
 
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(sem.Value() == 0);
 }
 
 }  // namespace

--- a/test/common/rw/pipe_transfer_test_common.hpp
+++ b/test/common/rw/pipe_transfer_test_common.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "rw_port_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -63,11 +64,11 @@ void ExpectCallResult(Harness& harness, LibXR::ErrorCode call_result,
 {
   if (harness.mode == TestMode::BLOCK)
   {
-    ASSERT(call_result == final_result);
+    TEST_ASSERT(call_result == final_result);
   }
   else
   {
-    ASSERT(call_result == LibXR::ErrorCode::OK);
+    TEST_ASSERT(call_result == LibXR::ErrorCode::OK);
     harness.ExpectFinal(final_result);
   }
 }
@@ -97,7 +98,7 @@ void VerifyPendingReadThenWrite(TestMode read_mode, TestMode write_mode, size_t 
     StartDelayedPipeWriter(writer, ctx, "pipe_write_async");
 
     auto read_result = r(RawData{rx.data(), rx.size()}, read.op);
-    ASSERT(read_result == ErrorCode::OK);
+    TEST_ASSERT(read_result == ErrorCode::OK);
     ExpectWaitOk(write_done);
     JoinThreadIfNeeded(writer);
     ExpectCallResult(write, ctx.result, ErrorCode::OK);
@@ -105,7 +106,7 @@ void VerifyPendingReadThenWrite(TestMode read_mode, TestMode write_mode, size_t 
   else
   {
     auto read_result = r(RawData{rx.data(), rx.size()}, read.op);
-    ASSERT(read_result == ErrorCode::OK);
+    TEST_ASSERT(read_result == ErrorCode::OK);
     read.ExpectPendingSubmitted();
 
     auto write_result = w(ConstRawData{tx.data(), tx.size()}, write.op);
@@ -113,7 +114,7 @@ void VerifyPendingReadThenWrite(TestMode read_mode, TestMode write_mode, size_t 
     read.ExpectFinal(ErrorCode::OK);
   }
 
-  ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
+  TEST_ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
 }
 
 void VerifyWriteThenRead(TestMode write_mode, TestMode read_mode, size_t size,
@@ -138,8 +139,8 @@ void VerifyWriteThenRead(TestMode write_mode, TestMode read_mode, size_t size,
   auto read_result = r(RawData{rx.data(), rx.size()}, read.op);
   ExpectCallResult(read, read_result, ErrorCode::OK);
 
-  ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
-  ASSERT(r.Size() == 0);
+  TEST_ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
+  TEST_ASSERT(r.Size() == 0);
 }
 
 }  // namespace

--- a/test/common/rw/pipe_zero_test_common.hpp
+++ b/test/common/rw/pipe_zero_test_common.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "pipe_transfer_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -28,22 +29,22 @@ void VerifyZeroWriteMode(TestMode mode)
   auto write_result = w(ConstRawData{nullptr, 0}, write.op);
   if (mode == TestMode::BLOCK)
   {
-    ASSERT(write_result == ErrorCode::OK);
+    TEST_ASSERT(write_result == ErrorCode::OK);
   }
   else
   {
-    ASSERT(write_result == ErrorCode::OK);
+    TEST_ASSERT(write_result == ErrorCode::OK);
     write.ExpectFinal(ErrorCode::OK);
   }
-  ASSERT(w.Size() == 0);
+  TEST_ASSERT(w.Size() == 0);
 
   uint8_t tx = 0x5A;
   uint8_t rx = 0;
   WriteOperation plain_write;
   ReadOperation plain_read;
-  ASSERT(w(ConstRawData{&tx, 1}, plain_write) == ErrorCode::OK);
-  ASSERT(r(RawData{&rx, 1}, plain_read) == ErrorCode::OK);
-  ASSERT(rx == tx);
+  TEST_ASSERT(w(ConstRawData{&tx, 1}, plain_write) == ErrorCode::OK);
+  TEST_ASSERT(r(RawData{&rx, 1}, plain_read) == ErrorCode::OK);
+  TEST_ASSERT(rx == tx);
 }
 
 void VerifyZeroReadMode(TestMode mode)
@@ -56,25 +57,25 @@ void VerifyZeroReadMode(TestMode mode)
 
   uint8_t tx = 0xA7;
   WriteOperation write_op;
-  ASSERT(w(ConstRawData{&tx, 1}, write_op) == ErrorCode::OK);
+  TEST_ASSERT(w(ConstRawData{&tx, 1}, write_op) == ErrorCode::OK);
 
   uint8_t dummy = 0x11;
   ReadHarness read(mode);
   auto zero_result = r(RawData{&dummy, 0}, read.op);
   if (mode == TestMode::BLOCK)
   {
-    ASSERT(zero_result == ErrorCode::OK);
+    TEST_ASSERT(zero_result == ErrorCode::OK);
   }
   else
   {
-    ASSERT(zero_result == ErrorCode::OK);
+    TEST_ASSERT(zero_result == ErrorCode::OK);
     read.ExpectFinal(ErrorCode::OK);
   }
 
   uint8_t rx = 0;
   ReadOperation plain_read;
-  ASSERT(r(RawData{&rx, 1}, plain_read) == ErrorCode::OK);
-  ASSERT(rx == tx);
+  TEST_ASSERT(r(RawData{&rx, 1}, plain_read) == ErrorCode::OK);
+  TEST_ASSERT(rx == tx);
 }
 
 }  // namespace

--- a/test/common/rw/rw_mode_test_common.hpp
+++ b/test/common/rw/rw_mode_test_common.hpp
@@ -11,6 +11,7 @@
 #include "libxr_pipe.hpp"
 #include "libxr_rw.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace LibXRTest
 {
@@ -82,11 +83,12 @@ struct ModeHarness
   {
     if (mode == TestMode::POLLING)
     {
-      ASSERT(polling_status.load(std::memory_order_acquire) == PollingStatus::RUNNING);
+      TEST_ASSERT(polling_status.load(std::memory_order_acquire) ==
+                  PollingStatus::RUNNING);
     }
     else if (mode == TestMode::CALLBACK)
     {
-      ASSERT(probe.count.load(std::memory_order_acquire) == 0);
+      TEST_ASSERT(probe.count.load(std::memory_order_acquire) == 0);
     }
   }
 
@@ -100,15 +102,15 @@ struct ModeHarness
       case TestMode::NONE:
         return;
       case TestMode::POLLING:
-        ASSERT(polling_status.load(std::memory_order_acquire) ==
-               ((expected == LibXR::ErrorCode::OK) ? PollingStatus::DONE
-                                                   : PollingStatus::ERROR));
+        TEST_ASSERT(polling_status.load(std::memory_order_acquire) ==
+                    ((expected == LibXR::ErrorCode::OK) ? PollingStatus::DONE
+                                                        : PollingStatus::ERROR));
         return;
       case TestMode::CALLBACK:
-        ASSERT(probe.sem.Wait(ASYNC_TIMEOUT_MS) == LibXR::ErrorCode::OK);
-        ASSERT(probe.count.load(std::memory_order_acquire) == 1);
-        ASSERT(static_cast<LibXR::ErrorCode>(
-                   probe.last.load(std::memory_order_acquire)) == expected);
+        TEST_ASSERT(probe.sem.Wait(ASYNC_TIMEOUT_MS) == LibXR::ErrorCode::OK);
+        TEST_ASSERT(probe.count.load(std::memory_order_acquire) == 1);
+        TEST_ASSERT(static_cast<LibXR::ErrorCode>(
+                        probe.last.load(std::memory_order_acquire)) == expected);
         return;
       case TestMode::BLOCK:
         return;

--- a/test/common/rw/rw_port_test_common.hpp
+++ b/test/common/rw/rw_port_test_common.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "rw_thread_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -41,28 +42,28 @@ void VerifyPendingReadMode(TestMode mode)
     StartReadQueueCompleter(finisher, r, done, tx.data(), tx.size(), "rd_queue");
 
     auto block_result = r(RawData{rx.data(), rx.size()}, read.op);
-    ASSERT(block_result == ErrorCode::OK);
+    TEST_ASSERT(block_result == ErrorCode::OK);
 
     ExpectWaitOk(done);
     JoinThreadIfNeeded(finisher);
-    ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
+    TEST_ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
     return;
   }
 
   auto call_result = r(RawData{rx.data(), rx.size()}, read.op);
-  ASSERT(call_result == ErrorCode::OK);
+  TEST_ASSERT(call_result == ErrorCode::OK);
   read.ExpectPendingSubmitted();
 
   {
     auto queue = r.GetReadQueue(false);
-    ASSERT(queue.PushBatch(tx.data(), tx.size()) == ErrorCode::OK);
+    TEST_ASSERT(queue.PushBatch(tx.data(), tx.size()) == ErrorCode::OK);
     queue.Publish();
   }
   if (mode != TestMode::NONE)
   {
     read.ExpectFinal(ErrorCode::OK);
   }
-  ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
+  TEST_ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
 }
 
 /**
@@ -85,24 +86,24 @@ void VerifyPendingWriteMode(TestMode mode, LibXR::ErrorCode result)
     StartWriteFinisher(finisher, w, done, result, "wr_finish");
 
     auto block_result = w(ConstRawData{tx.data(), tx.size()}, write.op);
-    ASSERT(block_result == result);
+    TEST_ASSERT(block_result == result);
 
     ExpectWaitOk(done);
     JoinThreadIfNeeded(finisher);
-    ASSERT(w.Size() == 0);
+    TEST_ASSERT(w.Size() == 0);
     return;
   }
 
   auto call_result = w(ConstRawData{tx.data(), tx.size()}, write.op);
-  ASSERT(call_result == ErrorCode::OK);
+  TEST_ASSERT(call_result == ErrorCode::OK);
 
   {
     auto queue = w.GetWriteQueue(false);
-    ASSERT(!queue.Empty());
+    TEST_ASSERT(!queue.Empty());
     if (result == ErrorCode::OK)
     {
       static uint8_t sink[16];
-      ASSERT(queue.AvailableSize() <= sizeof(sink));
+      TEST_ASSERT(queue.AvailableSize() <= sizeof(sink));
       queue.PopAll(sink);
     }
     else
@@ -114,7 +115,7 @@ void VerifyPendingWriteMode(TestMode mode, LibXR::ErrorCode result)
   {
     write.ExpectFinal(result);
   }
-  ASSERT(w.Size() == 0);
+  TEST_ASSERT(w.Size() == 0);
 }
 
 }  // namespace

--- a/test/common/rw/rw_thread_test_common.hpp
+++ b/test/common/rw/rw_thread_test_common.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "rw_mode_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -21,7 +22,7 @@ using LibXRTest::WriteHarness;
  */
 inline void JoinThreadIfNeeded(LibXR::Thread& thread)
 {
-  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 }
 
 /**
@@ -29,7 +30,7 @@ inline void JoinThreadIfNeeded(LibXR::Thread& thread)
  */
 inline void ExpectWaitOk(LibXR::Semaphore& sem, uint32_t timeout = ASYNC_TIMEOUT_MS)
 {
-  ASSERT(sem.Wait(timeout) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(sem.Wait(timeout) == LibXR::ErrorCode::OK);
 }
 
 struct ReadQueueCompletionContext
@@ -47,7 +48,7 @@ void CompletePendingReadFromQueue(ReadQueueCompletionContext ctx)
 {
   auto queue = ctx.port->GetReadQueue(false);
   auto ans = queue.PushBatch(ctx.data, ctx.size);
-  ASSERT(ans == LibXR::ErrorCode::OK);
+  TEST_ASSERT(ans == LibXR::ErrorCode::OK);
   queue.Publish();
   ctx.done->Post();
 }
@@ -77,7 +78,7 @@ void FinishPendingWrite(WriteFinishContext ctx)
 
     if (ctx.result == LibXR::ErrorCode::OK)
     {
-      ASSERT(queue.AvailableSize() <= sizeof(sink));
+      TEST_ASSERT(queue.AvailableSize() <= sizeof(sink));
       queue.PopAll(sink);
     }
     else

--- a/test/framework/assert_disabled_headers.cpp
+++ b/test/framework/assert_disabled_headers.cpp
@@ -1,0 +1,25 @@
+#include "cdc_to_uart.hpp"
+#include "linux_shared_topic.hpp"
+#include "object_pool.hpp"
+
+#if defined(LIBXR_DEV_ASSERT_BUILD) || defined(LIBXR_DEBUG_BUILD)
+#error "This target checks public headers with product assertions disabled."
+#endif
+
+template <typename Pool>
+void ExercisePool()
+{
+  Pool pool(4);
+  typename Pool::Handle handle;
+  (void)pool.Acquire(handle);
+  handle.Reset();
+}
+
+void TestAssertDisabledHeaders()
+{
+  ExercisePool<LibXR::ObjectPool<uint32_t>>();
+  ExercisePool<LibXR::SPSCObjectPool<uint32_t>>();
+  ExercisePool<LibXR::MPMCObjectPool<uint32_t>>();
+}
+
+template class LibXR::LinuxSharedTopic<uint32_t>;

--- a/test/framework/assert_modes.cpp
+++ b/test/framework/assert_modes.cpp
@@ -1,0 +1,87 @@
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <csignal>
+#include <cstring>
+
+#include "libxr_def.hpp"
+#include "test_assert.hpp"
+
+namespace
+{
+int fatal_count = 0;
+bool fatal_in_isr = false;
+const char* fatal_file = nullptr;
+uint32_t fatal_line = 0;
+}  // namespace
+
+// 仅记录宏的分发，不调用平台致命错误处理 / Record dispatch without platform shutdown.
+extern "C" void libxr_fatal_error(const char* file, uint32_t line, bool in_isr)
+{
+  ++fatal_count;
+  fatal_file = file;
+  fatal_line = line;
+  fatal_in_isr = in_isr;
+}
+
+int main()
+{
+  int evaluations = 0;
+  ASSERT(++evaluations == 1);
+  TEST_ASSERT(evaluations == 1);
+  ASSERT(false);
+#ifdef LIBXR_DEBUG_BUILD
+  TEST_ASSERT(fatal_count == 1);
+#else
+  TEST_ASSERT(fatal_count == 0);
+#endif
+
+  fatal_count = 0;
+  evaluations = 0;
+  DEV_ASSERT(++evaluations == 1);
+  DEV_ASSERT(false);
+#ifdef LIBXR_DEV_ASSERT_BUILD
+  TEST_ASSERT(evaluations == 1 && fatal_count == 1);
+#else
+  TEST_ASSERT(evaluations == 0 && fatal_count == 0);
+  DEV_ASSERT(no_such_identifier);
+  DEV_ASSERT_FROM_CALLBACK(no_such_condition, no_such_context);
+#endif
+
+  fatal_count = 0;
+  evaluations = 0;
+  REQUIRE(++evaluations == 1);
+  const uint32_t line = __LINE__ + 1;
+  REQUIRE_FROM_CALLBACK(false, true);
+  TEST_ASSERT(evaluations == 1 && fatal_count == 1);
+  TEST_ASSERT(fatal_in_isr && fatal_line == line);
+  TEST_ASSERT(std::strcmp(fatal_file, __FILE__) == 0);
+
+  fatal_count = 0;
+  ASSERT_FROM_CALLBACK(false, true);
+#ifdef LIBXR_DEBUG_BUILD
+  TEST_ASSERT(fatal_count == 1 && fatal_in_isr);
+#else
+  TEST_ASSERT(fatal_count == 0);
+#endif
+  fatal_count = 0;
+  DEV_ASSERT_FROM_CALLBACK(false, true);
+#ifdef LIBXR_DEV_ASSERT_BUILD
+  TEST_ASSERT(fatal_count == 1 && fatal_in_isr);
+#else
+  TEST_ASSERT(fatal_count == 0);
+#endif
+
+  // 测试检查自身在所有开关组合下都必须失败 / Test checks must fail in every mode.
+  const pid_t child = fork();
+  TEST_ASSERT(child >= 0);
+  if (child == 0)
+  {
+    TEST_ASSERT(false);
+    _exit(0);
+  }
+  int status = 0;
+  TEST_ASSERT(waitpid(child, &status, 0) == child);
+  TEST_ASSERT(WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT);
+  return 0;
+}

--- a/test/framework/main.cpp
+++ b/test/framework/main.cpp
@@ -34,14 +34,10 @@ int main()
       {
         UNUSED(in_isr);
         UNUSED(arg);
-        UNUSED(file);
-        UNUSED(line);
-
-        std::fprintf(stderr, "Error: Union test failed at step [%s].\r\n", test_name);
+        std::fprintf(stderr, "%s:%u: product assertion failed in [%s].\n", file,
+                     static_cast<unsigned>(line), test_name ? test_name : "startup");
         std::fflush(stderr);
-        // NOLINTNEXTLINE
-        *(volatile long long*)(nullptr) = 0;
-        exit(-1);
+        std::abort();
       },
       reinterpret_cast<void*>(0));
 

--- a/test/framework/test_assert.hpp
+++ b/test/framework/test_assert.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+
+/// 测试结果检查，不受产品断言开关影响 / Test check independent of product assertions.
+#define TEST_ASSERT(condition)                                                          \
+  do                                                                                    \
+  {                                                                                     \
+    if (!(condition))                                                                   \
+    {                                                                                   \
+      std::fprintf(stderr, "%s:%d: test failed: %s\n", __FILE__, __LINE__, #condition); \
+      std::abort();                                                                     \
+    }                                                                                   \
+  } while (0)

--- a/test/framework/test_case_runner.hpp
+++ b/test/framework/test_case_runner.hpp
@@ -16,6 +16,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "test_assert.hpp"
+
 #if defined(LIBXR_SYSTEM_POSIX_HOST)
 #include <sys/wait.h>
 #include <unistd.h>
@@ -66,13 +68,13 @@ inline void run_test_case(const TestCase& test_case)
 
   if (!test_case.isolated)
   {
-    ASSERT(test_case.function() == 0);
+    TEST_ASSERT(test_case.function() == 0);
     return;
   }
 
 #if defined(LIBXR_SYSTEM_POSIX_HOST)
   pid_t child = fork();
-  ASSERT(child >= 0);
+  TEST_ASSERT(child >= 0);
 
   if (child == 0)
   {
@@ -81,10 +83,10 @@ inline void run_test_case(const TestCase& test_case)
   }
 
   int status = 0;
-  ASSERT(waitpid(child, &status, 0) == child);
-  ASSERT(WIFEXITED(status));
-  ASSERT(WEXITSTATUS(status) == 0);
+  TEST_ASSERT(waitpid(child, &status, 0) == child);
+  TEST_ASSERT(WIFEXITED(status));
+  TEST_ASSERT(WEXITSTATUS(status) == 0);
 #else
-  ASSERT(false);
+  TEST_ASSERT(false);
 #endif
 }

--- a/test/linux_database/linux_database_flash_test_common.hpp
+++ b/test/linux_database/linux_database_flash_test_common.hpp
@@ -26,6 +26,7 @@
 #include "libxr_def.hpp"
 #include "linux_flash.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxDatabaseTestCommon
 {
@@ -92,7 +93,7 @@ class FailingFlash : public Flash
     {
       return ErrorCode::FAILED;
     }
-    ASSERT(offset + size <= flash_area_.size());
+    TEST_ASSERT(offset + size <= flash_area_.size());
     std::memset(flash_area_.data() + offset, 0xFF, size);
     return ErrorCode::OK;
   }
@@ -103,7 +104,7 @@ class FailingFlash : public Flash
     {
       return ErrorCode::FAILED;
     }
-    ASSERT(offset + data.size_ <= flash_area_.size());
+    TEST_ASSERT(offset + data.size_ <= flash_area_.size());
     std::memcpy(flash_area_.data() + offset, data.addr_, data.size_);
     return ErrorCode::OK;
   }
@@ -157,7 +158,7 @@ void ExpectFatalExit(int exit_code, Func&& func)
   // 辅助内容：验证当前失败或退出预期。
   // Helper coverage: validate the current expected failure or exit condition.
   pid_t child = fork();
-  ASSERT(child >= 0);
+  TEST_ASSERT(child >= 0);
 
   if (child == 0)
   {
@@ -174,9 +175,9 @@ void ExpectFatalExit(int exit_code, Func&& func)
   }
 
   int status = 0;
-  ASSERT(waitpid(child, &status, 0) == child);
-  ASSERT(WIFEXITED(status));
-  ASSERT(WEXITSTATUS(status) == exit_code);
+  TEST_ASSERT(waitpid(child, &status, 0) == child);
+  TEST_ASSERT(WIFEXITED(status));
+  TEST_ASSERT(WEXITSTATUS(status) == exit_code);
 }
 
 }  // namespace LinuxDatabaseTestCommon

--- a/test/linux_database/linux_database_image_test_common.hpp
+++ b/test/linux_database/linux_database_image_test_common.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "linux_database_flash_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxDatabaseTestCommon
 {
@@ -50,12 +51,12 @@ inline void WriteLe32(std::vector<uint8_t>& bytes, size_t offset, uint32_t value
 [[nodiscard]] inline std::vector<uint8_t> ReadAllBytes(const char* path)
 {
   std::ifstream file(path, std::ios::binary);
-  ASSERT(static_cast<bool>(file));
+  TEST_ASSERT(static_cast<bool>(file));
 
   std::vector<uint8_t> bytes(XR_DB_FLASH_SIZE, 0);
   file.read(reinterpret_cast<char*>(bytes.data()),
             static_cast<std::streamsize>(bytes.size()));
-  ASSERT(file.gcount() == static_cast<std::streamsize>(bytes.size()));
+  TEST_ASSERT(file.gcount() == static_cast<std::streamsize>(bytes.size()));
   return bytes;
 }
 
@@ -72,17 +73,17 @@ inline void WriteAllBytes(const char* path, const std::vector<uint8_t>& bytes)
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
   std::ofstream file(path, std::ios::binary | std::ios::trunc);
-  ASSERT(static_cast<bool>(file));
+  TEST_ASSERT(static_cast<bool>(file));
   file.write(reinterpret_cast<const char*>(bytes.data()),
              static_cast<std::streamsize>(bytes.size()));
-  ASSERT(static_cast<bool>(file));
+  TEST_ASSERT(static_cast<bool>(file));
 }
 
 inline void CraftPartialBackup(std::vector<uint8_t>& bytes, size_t partial_len)
 {
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
-  ASSERT(partial_len < XR_DB_BLOCK_SIZE);
+  TEST_ASSERT(partial_len < XR_DB_BLOCK_SIZE);
 
   const size_t backup_offset = XR_DB_BLOCK_SIZE;
   for (size_t i = 0; i < partial_len; ++i)
@@ -138,7 +139,7 @@ inline void CreateSeedDatabase(const char* path)
   DatabaseRaw<16> db(flash, 5);
   db.Restore();
   DatabaseRaw<16>::Key<uint32_t> key(db, "key", 1234);
-  ASSERT(key.data_ == 1234);
+  TEST_ASSERT(key.data_ == 1234);
 }
 
 inline void CreateTwoKeyDatabase(const char* path)
@@ -149,8 +150,8 @@ inline void CreateTwoKeyDatabase(const char* path)
   db.Restore();
   DatabaseRaw<16>::Key<uint32_t> key1(db, "key1", 1111);
   DatabaseRaw<16>::Key<uint32_t> key2(db, "key2", 2222);
-  ASSERT(key1.data_ == 1111);
-  ASSERT(key2.data_ == 2222);
+  TEST_ASSERT(key1.data_ == 1111);
+  TEST_ASSERT(key2.data_ == 2222);
 }
 
 }  // namespace LinuxDatabaseTestCommon

--- a/test/linux_database/linux_database_reopen_test_common.hpp
+++ b/test/linux_database/linux_database_reopen_test_common.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "linux_database_image_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxDatabaseTestCommon
 {
@@ -54,9 +55,10 @@ inline void AssertMainValidBackupInvalid(const char* path)
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
   auto bytes = ReadAllBytes(path);
-  ASSERT(ReadLe32(bytes, 0) == XR_DB_FLASH_HEADER);
-  ASSERT(ReadLe32(bytes, XR_DB_CHECKSUM_OFFSET) == XR_DB_CHECKSUM);
-  ASSERT(ReadLe32(bytes, XR_DB_BLOCK_SIZE + XR_DB_CHECKSUM_OFFSET) != XR_DB_CHECKSUM);
+  TEST_ASSERT(ReadLe32(bytes, 0) == XR_DB_FLASH_HEADER);
+  TEST_ASSERT(ReadLe32(bytes, XR_DB_CHECKSUM_OFFSET) == XR_DB_CHECKSUM);
+  TEST_ASSERT(ReadLe32(bytes, XR_DB_BLOCK_SIZE + XR_DB_CHECKSUM_OFFSET) !=
+              XR_DB_CHECKSUM);
 }
 
 inline void RunPartialBackupCase(const char* path, MainChecksum main_checksum,
@@ -74,7 +76,7 @@ inline void RunPartialBackupCase(const char* path, MainChecksum main_checksum,
   }
   WriteAllBytes(path, bytes);
 
-  ASSERT(ReopenDatabaseValue(path, default_value) == expected_value);
+  TEST_ASSERT(ReopenDatabaseValue(path, default_value) == expected_value);
   AssertMainValidBackupInvalid(path);
 }
 

--- a/test/linux_database/test_database_raw_recovery.cpp
+++ b/test/linux_database/test_database_raw_recovery.cpp
@@ -5,6 +5,7 @@
  */
 #include "linux_database_test_common.hpp"
 #include "raw_database_test_groups.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -31,10 +32,10 @@ void TestDatabaseRawInvalidMainKeyMetadataReinitializes()
   MarkMainFirstKeyAsUninitialized(bytes);
   WriteAllBytes(path, bytes);
 
-  ASSERT(ReopenDatabaseValue(path, 77) == 77);
+  TEST_ASSERT(ReopenDatabaseValue(path, 77) == 77);
   auto repaired = ReadAllBytes(path);
-  ASSERT(ReadLe32(repaired, 0) == XR_DB_FLASH_HEADER);
-  ASSERT(ReadLe32(repaired, XR_DB_CHECKSUM_OFFSET) == XR_DB_CHECKSUM);
+  TEST_ASSERT(ReadLe32(repaired, 0) == XR_DB_FLASH_HEADER);
+  TEST_ASSERT(ReadLe32(repaired, XR_DB_CHECKSUM_OFFSET) == XR_DB_CHECKSUM);
 }
 
 /**
@@ -59,7 +60,7 @@ void TestDatabaseRawInvalidBackupMetadataDoesNotRestore()
   InvalidateMainChecksum(bytes);
   WriteAllBytes(path, bytes);
 
-  ASSERT(ReopenDatabaseValue(path, 55) == 55);
+  TEST_ASSERT(ReopenDatabaseValue(path, 55) == 55);
   AssertMainValidBackupInvalid(path);
 }
 
@@ -84,7 +85,7 @@ void TestDatabaseRawRestoresFromValidBackup()
   InvalidateMainChecksum(bytes);
   WriteAllBytes(path, bytes);
 
-  ASSERT(ReopenDatabaseValue(path, 55) == 1234);
+  TEST_ASSERT(ReopenDatabaseValue(path, 55) == 1234);
   AssertMainValidBackupInvalid(path);
 }
 
@@ -108,11 +109,11 @@ void TestDatabaseRawCorruptFirstKeySizeInMultiKeyDatabaseReinitializes()
   CorruptMainFirstKeyRawInfo(bytes, 0x7FFFFFFFU);
   WriteAllBytes(path, bytes);
 
-  ASSERT(ReopenDatabaseValue(path, 77, "key1") == 77);
-  ASSERT(ReopenDatabaseValue(path, 88, "key2") == 88);
+  TEST_ASSERT(ReopenDatabaseValue(path, 77, "key1") == 77);
+  TEST_ASSERT(ReopenDatabaseValue(path, 88, "key2") == 88);
   auto repaired = ReadAllBytes(path);
-  ASSERT(ReadLe32(repaired, 0) == XR_DB_FLASH_HEADER);
-  ASSERT(ReadLe32(repaired, XR_DB_CHECKSUM_OFFSET) == XR_DB_CHECKSUM);
+  TEST_ASSERT(ReadLe32(repaired, 0) == XR_DB_FLASH_HEADER);
+  TEST_ASSERT(ReadLe32(repaired, XR_DB_CHECKSUM_OFFSET) == XR_DB_CHECKSUM);
 }
 
 }  // namespace

--- a/test/linux_database/test_database_raw_smoke.cpp
+++ b/test/linux_database/test_database_raw_smoke.cpp
@@ -5,6 +5,7 @@
  */
 #include "linux_database_test_common.hpp"
 #include "raw_database_test_groups.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -51,10 +52,10 @@ void TestLinuxDatabaseRawSmoke()
   k3_2.Load();
   k4_2.Load();
 
-  ASSERT(std::memcmp(&data_k1[0], &k1_2.data_[0], sizeof(data_k1)) == 0);
-  ASSERT(std::memcmp(&data_k2[0], &k2_2.data_[0], sizeof(data_k2)) == 0);
-  ASSERT(std::memcmp(&data_k3[0], &k3_2.data_[0], sizeof(data_k3)) == 0);
-  ASSERT(std::memcmp(&data_k4[0], &k4_2.data_[0], sizeof(data_k4)) == 0);
+  TEST_ASSERT(std::memcmp(&data_k1[0], &k1_2.data_[0], sizeof(data_k1)) == 0);
+  TEST_ASSERT(std::memcmp(&data_k2[0], &k2_2.data_[0], sizeof(data_k2)) == 0);
+  TEST_ASSERT(std::memcmp(&data_k3[0], &k3_2.data_[0], sizeof(data_k3)) == 0);
+  TEST_ASSERT(std::memcmp(&data_k4[0], &k4_2.data_[0], sizeof(data_k4)) == 0);
 
   for (size_t i = 0; i < 1000; i++)
   {
@@ -83,10 +84,10 @@ void TestLinuxDatabaseRawSmoke()
     k2_2.Load();
     k3_2.Load();
     k4_2.Load();
-    ASSERT(std::memcmp(&data_k1[0], &k1_2.data_[0], sizeof(data_k1)) == 0);
-    ASSERT(std::memcmp(&data_k2[0], &k2_2.data_[0], sizeof(data_k2)) == 0);
-    ASSERT(std::memcmp(&data_k3[0], &k3_2.data_[0], sizeof(data_k3)) == 0);
-    ASSERT(std::memcmp(&data_k4[0], &k4_2.data_[0], sizeof(data_k4)) == 0);
+    TEST_ASSERT(std::memcmp(&data_k1[0], &k1_2.data_[0], sizeof(data_k1)) == 0);
+    TEST_ASSERT(std::memcmp(&data_k2[0], &k2_2.data_[0], sizeof(data_k2)) == 0);
+    TEST_ASSERT(std::memcmp(&data_k3[0], &k3_2.data_[0], sizeof(data_k3)) == 0);
+    TEST_ASSERT(std::memcmp(&data_k4[0], &k4_2.data_[0], sizeof(data_k4)) == 0);
   }
 }
 
@@ -130,8 +131,8 @@ void TestDatabaseRawSaveCurrentValue()
 
   DatabaseRaw<16>::Key<uint32_t> key(db, "raw", 1);
   key.data_ = 2;
-  ASSERT(key.Save() == ErrorCode::OK);
-  ASSERT(ReopenDatabaseValue(path, 0, "raw") == 2);
+  TEST_ASSERT(key.Save() == ErrorCode::OK);
+  TEST_ASSERT(ReopenDatabaseValue(path, 0, "raw") == 2);
 }
 
 /**
@@ -154,7 +155,7 @@ void TestDatabaseRawRequiresExactStoredSize()
     DatabaseRaw<16> db(flash, 5);
     db.Restore();
     DatabaseRaw<16>::Key<uint32_t> key(db, "shape", 0x11223344U);
-    ASSERT(key.data_ == 0x11223344U);
+    TEST_ASSERT(key.data_ == 0x11223344U);
   }
 
   {
@@ -162,11 +163,11 @@ void TestDatabaseRawRequiresExactStoredSize()
                                                  XR_DB_MIN_WRITE_SIZE, false, true);
     DatabaseRaw<16> db(flash, 5);
     DatabaseRaw<16>::Key<uint64_t> wider_key(db, "shape", 0ULL);
-    ASSERT(wider_key.data_ == 0ULL);
-    ASSERT(wider_key.Load() == ErrorCode::FAILED);
+    TEST_ASSERT(wider_key.data_ == 0ULL);
+    TEST_ASSERT(wider_key.Load() == ErrorCode::FAILED);
   }
 
-  ASSERT(ReopenDatabaseValue(path, 0, "shape") == 0x11223344U);
+  TEST_ASSERT(ReopenDatabaseValue(path, 0, "shape") == 0x11223344U);
 }
 
 }  // namespace

--- a/test/linux_database/test_database_sequential_smoke.cpp
+++ b/test/linux_database/test_database_sequential_smoke.cpp
@@ -10,6 +10,7 @@
  *          2. `Save()` persists the key object's current value.
  */
 #include "linux_database_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -48,17 +49,17 @@ void TestLinuxDatabaseSequentialSmoke()
     k3.Load();
     k4.Load();
 
-    ASSERT(std::memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
-    ASSERT(std::memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
-    ASSERT(std::memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
-    ASSERT(std::memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
+    TEST_ASSERT(std::memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
+    TEST_ASSERT(std::memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
+    TEST_ASSERT(std::memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
+    TEST_ASSERT(std::memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
 
     for (int j = 0; j < Thread::GetTime() % 100; j++)
     {
       data_k4[1] = Thread::GetTime() + j;
       k4 = data_k4;
       k4.Load();
-      ASSERT(std::memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
+      TEST_ASSERT(std::memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
     }
 
     for (int j = 0; j < Thread::GetTime() % 100; j++)
@@ -66,7 +67,7 @@ void TestLinuxDatabaseSequentialSmoke()
       data_k1[0] = Thread::GetTime() + j;
       k1 = data_k1;
       k1.Load();
-      ASSERT(std::memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
+      TEST_ASSERT(std::memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
     }
 
     for (int j = 0; j < Thread::GetTime() % 100; ++j)
@@ -75,10 +76,10 @@ void TestLinuxDatabaseSequentialSmoke()
       k2.Load();
       k3.Load();
       k4.Load();
-      ASSERT(std::memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
-      ASSERT(std::memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
-      ASSERT(std::memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
-      ASSERT(std::memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
+      TEST_ASSERT(std::memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
+      TEST_ASSERT(std::memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
+      TEST_ASSERT(std::memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
+      TEST_ASSERT(std::memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
     }
 
     for (int j = 0; j < Thread::GetTime() % 100; j++)
@@ -87,13 +88,13 @@ void TestLinuxDatabaseSequentialSmoke()
       data_k2[1] = LibXR::Timebase::GetMilliseconds();
       k2 = data_k2;
       k2.Load();
-      ASSERT(std::memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
+      TEST_ASSERT(std::memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
     }
 
-    ASSERT(std::memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
-    ASSERT(std::memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
-    ASSERT(std::memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
-    ASSERT(std::memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
+    TEST_ASSERT(std::memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
+    TEST_ASSERT(std::memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
+    TEST_ASSERT(std::memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
+    TEST_ASSERT(std::memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
   }
 }
 
@@ -109,8 +110,8 @@ void TestDatabaseSequentialSaveCurrentValue()
 
   DatabaseRawSequential::Key<uint32_t> key(db, "seq", 1);
   key.data_ = 2;
-  ASSERT(key.Save() == ErrorCode::OK);
-  ASSERT(ReopenSequentialDatabaseValue(path, 0, "seq") == 2);
+  TEST_ASSERT(key.Save() == ErrorCode::OK);
+  TEST_ASSERT(ReopenSequentialDatabaseValue(path, 0, "seq") == 2);
 }
 
 }  // namespace

--- a/test/linux_shm/linux_shm_topic_test_common.hpp
+++ b/test/linux_shm/linux_shm_topic_test_common.hpp
@@ -21,6 +21,7 @@
 
 #include "libxr.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -87,8 +88,8 @@ inline void AssertFrame(const IPCFrame& frame, uint32_t expected_seq)
 {
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
-  ASSERT(frame.seq == expected_seq);
-  ASSERT(frame.checksum == ComputeChecksum(frame));
+  TEST_ASSERT(frame.seq == expected_seq);
+  TEST_ASSERT(frame.checksum == ComputeChecksum(frame));
 }
 
 /**
@@ -122,7 +123,7 @@ inline void WaitForSubscriberNum(SharedTopic& topic, uint32_t expected_num)
   {
     usleep(10000);
   }
-  ASSERT(topic.GetSubscriberNum() == expected_num);
+  TEST_ASSERT(topic.GetSubscriberNum() == expected_num);
 }
 
 /**
@@ -137,9 +138,9 @@ inline void ExpectChildExit(pid_t child, int expected_code = 0)
   // 辅助内容：验证当前失败或退出预期。
   // Helper coverage: validate the current expected failure or exit condition.
   int status = 0;
-  ASSERT(waitpid(child, &status, 0) == child);
-  ASSERT(WIFEXITED(status));
-  ASSERT(WEXITSTATUS(status) == expected_code);
+  TEST_ASSERT(waitpid(child, &status, 0) == child);
+  TEST_ASSERT(WIFEXITED(status));
+  TEST_ASSERT(WEXITSTATUS(status) == expected_code);
 }
 
 void RunAttachQueueScenarios();

--- a/test/linux_shm/test_attach_queue.cpp
+++ b/test/linux_shm/test_attach_queue.cpp
@@ -3,6 +3,8 @@
  * @brief `LinuxSharedTopic` attach/queue 语义子验证。 Split verification unit for
  * `LinuxSharedTopic` attach and queue semantics.
  */
+#include <thread>
+
 #include "linux_shm_topic_test_common.hpp"
 #include "test_assert.hpp"
 
@@ -86,6 +88,25 @@ void RunAttachQueueScenarios()
                 static_cast<uint64_t>(timestamp2));
     TEST_ASSERT(subscriber.GetPendingNum() == 0);
     subscriber.Release();
+
+    // 消费完一批消息后，旧唤醒提示不能被当成仍有消息。
+    // A wake hint left by a drained batch must not report another message.
+    TEST_ASSERT(subscriber.Wait(2) == LibXR::ErrorCode::TIMEOUT);
+    std::thread next_publish(
+        [&publisher]()
+        {
+          LibXR::Thread::Sleep(10);
+          SharedData next;
+          TEST_ASSERT(publisher.CreateData(next) == LibXR::ErrorCode::OK);
+          FillFrame(*next.GetData(), 103);
+          TEST_ASSERT(publisher.Publish(next) == LibXR::ErrorCode::OK);
+        });
+    const auto wait_result = subscriber.Wait(LONG_WAIT_MS);
+    next_publish.join();
+    TEST_ASSERT(wait_result == LibXR::ErrorCode::OK);
+    AssertFrame(*subscriber.GetData(), 103);
+    subscriber.Release();
+    TEST_ASSERT(subscriber.Wait(2) == LibXR::ErrorCode::TIMEOUT);
   }
   // BROADCAST_FULL should fail publish when the subscriber queue is saturated.
   UNUSED(SharedTopic::Remove(topic_name));

--- a/test/linux_shm/test_attach_queue.cpp
+++ b/test/linux_shm/test_attach_queue.cpp
@@ -4,6 +4,7 @@
  * `LinuxSharedTopic` attach and queue semantics.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -30,60 +31,60 @@ void RunAttachQueueScenarios()
     config.queue_num = 4;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber(topic_name);
-    ASSERT(subscriber.Valid());
-    ASSERT(publisher.GetSubscriberNum() == 1);
+    TEST_ASSERT(subscriber.Valid());
+    TEST_ASSERT(publisher.GetSubscriberNum() == 1);
 
     SharedTopic attach_only(topic_name);
-    ASSERT(attach_only.Valid());
+    TEST_ASSERT(attach_only.Valid());
     SharedData attach_data;
-    ASSERT(attach_only.CreateData(attach_data) == LibXR::ErrorCode::STATE_ERR);
+    TEST_ASSERT(attach_only.CreateData(attach_data) == LibXR::ErrorCode::STATE_ERR);
 
     SharedData data0;
     const LibXR::MicrosecondTimestamp timestamp0(101000);
-    ASSERT(publisher.CreateData(data0) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.CreateData(data0) == LibXR::ErrorCode::OK);
     FillFrame(*data0.GetData(), 100);
-    ASSERT(publisher.Publish(data0, timestamp0) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(data0, timestamp0) == LibXR::ErrorCode::OK);
 
     SharedData data1;
     const LibXR::MicrosecondTimestamp timestamp1(102000);
-    ASSERT(publisher.CreateData(data1) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.CreateData(data1) == LibXR::ErrorCode::OK);
     FillFrame(*data1.GetData(), 101);
-    ASSERT(publisher.Publish(data1, timestamp1) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(data1, timestamp1) == LibXR::ErrorCode::OK);
 
     SharedData data2;
-    ASSERT(publisher.CreateData(data2) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(publisher.CreateData(data2) == LibXR::ErrorCode::FULL);
 
-    ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber.GetData() != nullptr);
+    TEST_ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 100);
-    ASSERT(static_cast<uint64_t>(subscriber.GetTimestamp()) ==
-           static_cast<uint64_t>(timestamp0));
+    TEST_ASSERT(static_cast<uint64_t>(subscriber.GetTimestamp()) ==
+                static_cast<uint64_t>(timestamp0));
     subscriber.GetData()->seq = 1000;
-    ASSERT(subscriber.GetData()->seq == 1000);
-    ASSERT(subscriber.GetPendingNum() == 1);
+    TEST_ASSERT(subscriber.GetData()->seq == 1000);
+    TEST_ASSERT(subscriber.GetPendingNum() == 1);
     subscriber.Release();
 
     const LibXR::MicrosecondTimestamp timestamp2(103000);
-    ASSERT(publisher.CreateData(data2) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.CreateData(data2) == LibXR::ErrorCode::OK);
     FillFrame(*data2.GetData(), 102);
-    ASSERT(publisher.Publish(data2, timestamp2) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(data2, timestamp2) == LibXR::ErrorCode::OK);
 
-    ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber.GetData() != nullptr);
+    TEST_ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 101);
-    ASSERT(static_cast<uint64_t>(subscriber.GetTimestamp()) ==
-           static_cast<uint64_t>(timestamp1));
+    TEST_ASSERT(static_cast<uint64_t>(subscriber.GetTimestamp()) ==
+                static_cast<uint64_t>(timestamp1));
     subscriber.Release();
 
-    ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber.GetData() != nullptr);
+    TEST_ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 102);
-    ASSERT(static_cast<uint64_t>(subscriber.GetTimestamp()) ==
-           static_cast<uint64_t>(timestamp2));
-    ASSERT(subscriber.GetPendingNum() == 0);
+    TEST_ASSERT(static_cast<uint64_t>(subscriber.GetTimestamp()) ==
+                static_cast<uint64_t>(timestamp2));
+    TEST_ASSERT(subscriber.GetPendingNum() == 0);
     subscriber.Release();
   }
   // BROADCAST_FULL should fail publish when the subscriber queue is saturated.
@@ -98,34 +99,34 @@ void RunAttachQueueScenarios()
     config.queue_num = 3;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber(topic_name);
-    ASSERT(subscriber.Valid());
+    TEST_ASSERT(subscriber.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 201);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 202);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 203);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::FULL);
 
-    ASSERT(subscriber.GetPendingNum() == 2);
-    ASSERT(subscriber.GetDropNum() == 1);
-    ASSERT(publisher.GetPublishFailedNum() == 1);
+    TEST_ASSERT(subscriber.GetPendingNum() == 2);
+    TEST_ASSERT(subscriber.GetDropNum() == 1);
+    TEST_ASSERT(publisher.GetPublishFailedNum() == 1);
 
     SharedData recv_data;
-    ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(recv_data.GetSequence() == 1);
+    TEST_ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(recv_data.GetSequence() == 1);
     AssertFrame(*recv_data.GetData(), 201);
     const SharedData& const_recv_data = recv_data;
     const_recv_data.GetData()->seq = 1201;
-    ASSERT(const_recv_data.GetData()->seq == 1201);
+    TEST_ASSERT(const_recv_data.GetData()->seq == 1201);
     recv_data.Reset();
 
-    ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(recv_data.GetSequence() == 2);
+    TEST_ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(recv_data.GetSequence() == 2);
     AssertFrame(*recv_data.GetData(), 202);
     recv_data.Reset();
   }
@@ -142,32 +143,32 @@ void RunAttachQueueScenarios()
     config.queue_num = 3;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber(topic_name,
                                 LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD);
-    ASSERT(subscriber.Valid());
+    TEST_ASSERT(subscriber.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 211);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 212);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 213);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
-    ASSERT(subscriber.GetPendingNum() == 2);
-    ASSERT(subscriber.GetDropNum() == 1);
-    ASSERT(publisher.GetPublishFailedNum() == 0);
+    TEST_ASSERT(subscriber.GetPendingNum() == 2);
+    TEST_ASSERT(subscriber.GetDropNum() == 1);
+    TEST_ASSERT(publisher.GetPublishFailedNum() == 0);
 
     SharedData recv_data;
-    ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(recv_data.GetSequence() == 2);
+    TEST_ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(recv_data.GetSequence() == 2);
     AssertFrame(*recv_data.GetData(), 212);
     recv_data.Reset();
 
-    ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(recv_data.GetSequence() == 3);
+    TEST_ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(recv_data.GetSequence() == 3);
     AssertFrame(*recv_data.GetData(), 213);
     recv_data.Reset();
   }

--- a/test/linux_shm/test_balance_rr_dead.cpp
+++ b/test/linux_shm/test_balance_rr_dead.cpp
@@ -8,6 +8,7 @@
  *          1. The group keeps working after a dead balanced subscriber is reclaimed.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -26,15 +27,15 @@ void RunBalanceRoundRobinDeadMemberScenario()
     config.queue_num = 4;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     int ack_pipe[2] = {-1, -1};
     int cmd_pipe[2] = {-1, -1};
-    ASSERT(pipe(ack_pipe) == 0);
-    ASSERT(pipe(cmd_pipe) == 0);
+    TEST_ASSERT(pipe(ack_pipe) == 0);
+    TEST_ASSERT(pipe(cmd_pipe) == 0);
 
     pid_t child = fork();
-    ASSERT(child >= 0);
+    TEST_ASSERT(child >= 0);
 
     if (child == 0)
     {
@@ -76,34 +77,35 @@ void RunBalanceRoundRobinDeadMemberScenario()
 
     IPCFrame frame = {};
     FillFrame(frame, 361);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     uint32_t first_seq = 0;
-    ASSERT(read(ack_pipe[0], &first_seq, sizeof(first_seq)) ==
-           static_cast<ssize_t>(sizeof(first_seq)));
-    ASSERT(first_seq == 361);
+    TEST_ASSERT(read(ack_pipe[0], &first_seq, sizeof(first_seq)) ==
+                static_cast<ssize_t>(sizeof(first_seq)));
+    TEST_ASSERT(first_seq == 361);
 
     SharedSubscriber subscriber_alive(topic_name,
                                       LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    ASSERT(subscriber_alive.Valid());
+    TEST_ASSERT(subscriber_alive.Valid());
     WaitForSubscriberNum(publisher, 2);
 
     uint8_t cmd = 0xA5;
-    ASSERT(write(cmd_pipe[1], &cmd, sizeof(cmd)) == static_cast<ssize_t>(sizeof(cmd)));
+    TEST_ASSERT(write(cmd_pipe[1], &cmd, sizeof(cmd)) ==
+                static_cast<ssize_t>(sizeof(cmd)));
 
     ExpectChildExit(child);
 
     FillFrame(frame, 362);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 363);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     SharedData recv_alive1;
     SharedData recv_alive2;
-    ASSERT(subscriber_alive.Wait(recv_alive1, LONG_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_alive.Wait(recv_alive2, LONG_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(recv_alive1.GetData()->seq == 362);
-    ASSERT(recv_alive2.GetData()->seq == 363);
+    TEST_ASSERT(subscriber_alive.Wait(recv_alive1, LONG_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_alive.Wait(recv_alive2, LONG_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(recv_alive1.GetData()->seq == 362);
+    TEST_ASSERT(recv_alive2.GetData()->seq == 363);
 
     close(ack_pipe[0]);
     close(cmd_pipe[1]);

--- a/test/linux_shm/test_balance_rr_rotate.cpp
+++ b/test/linux_shm/test_balance_rr_rotate.cpp
@@ -8,6 +8,7 @@
  *          1. Delivery rotates in order among active balanced subscribers.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -26,39 +27,39 @@ void RunBalanceRoundRobinRotateScenario()
     config.queue_num = 4;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber_a(topic_name,
                                   LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
     SharedSubscriber subscriber_b(topic_name,
                                   LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    ASSERT(subscriber_a.Valid());
-    ASSERT(subscriber_b.Valid());
+    TEST_ASSERT(subscriber_a.Valid());
+    TEST_ASSERT(subscriber_b.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 351);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 352);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 353);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 354);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     SharedData recv_a1;
     SharedData recv_a2;
     SharedData recv_b1;
     SharedData recv_b2;
 
-    ASSERT(subscriber_a.Wait(recv_a1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_a.Wait(recv_a2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_a.Wait(recv_a1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_b.Wait(recv_b1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_a.Wait(recv_a2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_b.Wait(recv_b2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
 
-    ASSERT(recv_a1.GetData()->seq == 351);
-    ASSERT(recv_b1.GetData()->seq == 352);
-    ASSERT(recv_a2.GetData()->seq == 353);
-    ASSERT(recv_b2.GetData()->seq == 354);
+    TEST_ASSERT(recv_a1.GetData()->seq == 351);
+    TEST_ASSERT(recv_b1.GetData()->seq == 352);
+    TEST_ASSERT(recv_a2.GetData()->seq == 353);
+    TEST_ASSERT(recv_b2.GetData()->seq == 354);
   }
 
   UNUSED(SharedTopic::Remove(topic_name));

--- a/test/linux_shm/test_balance_rr_skip.cpp
+++ b/test/linux_shm/test_balance_rr_skip.cpp
@@ -8,6 +8,7 @@
  *          1. When one balanced subscriber is full, delivery skips it and goes to others.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -26,7 +27,7 @@ void RunBalanceRoundRobinSkipFullScenario()
     config.queue_num = 2;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber_a(topic_name,
                                   LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
@@ -34,36 +35,36 @@ void RunBalanceRoundRobinSkipFullScenario()
                                   LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
     SharedSubscriber subscriber_c(topic_name,
                                   LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    ASSERT(subscriber_a.Valid());
-    ASSERT(subscriber_b.Valid());
-    ASSERT(subscriber_c.Valid());
+    TEST_ASSERT(subscriber_a.Valid());
+    TEST_ASSERT(subscriber_b.Valid());
+    TEST_ASSERT(subscriber_c.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 371);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 372);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 373);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     SharedData recv_b0;
-    ASSERT(subscriber_b.Wait(recv_b0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(recv_b0.GetData()->seq == 372);
+    TEST_ASSERT(subscriber_b.Wait(recv_b0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(recv_b0.GetData()->seq == 372);
     recv_b0.Reset();
 
     FillFrame(frame, 374);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     SharedData recv_a;
     SharedData recv_b1;
     SharedData recv_c;
-    ASSERT(subscriber_a.Wait(recv_a, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_c.Wait(recv_c, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_a.Wait(recv_a, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_b.Wait(recv_b1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_c.Wait(recv_c, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
 
-    ASSERT(recv_a.GetData()->seq == 371);
-    ASSERT(recv_b1.GetData()->seq == 374);
-    ASSERT(recv_c.GetData()->seq == 373);
+    TEST_ASSERT(recv_a.GetData()->seq == 371);
+    TEST_ASSERT(recv_b1.GetData()->seq == 374);
+    TEST_ASSERT(recv_c.GetData()->seq == 373);
   }
 
   UNUSED(SharedTopic::Remove(topic_name));

--- a/test/linux_shm/test_cross_process.cpp
+++ b/test/linux_shm/test_cross_process.cpp
@@ -4,6 +4,7 @@
  * cross-process ordering semantics.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -30,10 +31,10 @@ void RunCrossProcessScenarios()
     config.queue_num = 64;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     pid_t child = fork();
-    ASSERT(child >= 0);
+    TEST_ASSERT(child >= 0);
 
     if (child == 0)
     {
@@ -72,9 +73,9 @@ void RunCrossProcessScenarios()
     for (uint32_t seq = 1; seq <= 32; ++seq)
     {
       SharedData data;
-      ASSERT(publisher.CreateData(data) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(publisher.CreateData(data) == LibXR::ErrorCode::OK);
       FillFrame(*data.GetData(), seq);
-      ASSERT(publisher.Publish(data) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(publisher.Publish(data) == LibXR::ErrorCode::OK);
     }
 
     ExpectChildExit(child);

--- a/test/linux_shm/test_lifecycle_dead_sub.cpp
+++ b/test/linux_shm/test_lifecycle_dead_sub.cpp
@@ -11,6 +11,7 @@
  * recover.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -29,15 +30,15 @@ void RunLifecycleDeadSubscriberScenario()
     config.queue_num = 4;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     int ack_pipe[2] = {-1, -1};
     int cmd_pipe[2] = {-1, -1};
-    ASSERT(pipe(ack_pipe) == 0);
-    ASSERT(pipe(cmd_pipe) == 0);
+    TEST_ASSERT(pipe(ack_pipe) == 0);
+    TEST_ASSERT(pipe(cmd_pipe) == 0);
 
     pid_t child = fork();
-    ASSERT(child >= 0);
+    TEST_ASSERT(child >= 0);
 
     if (child == 0)
     {
@@ -78,27 +79,29 @@ void RunLifecycleDeadSubscriberScenario()
 
     IPCFrame frame = {};
     FillFrame(frame, 401);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     uint8_t ack = 0;
-    ASSERT(read(ack_pipe[0], &ack, sizeof(ack)) == static_cast<ssize_t>(sizeof(ack)));
+    TEST_ASSERT(read(ack_pipe[0], &ack, sizeof(ack)) ==
+                static_cast<ssize_t>(sizeof(ack)));
 
     FillFrame(frame, 402);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     uint8_t cmd = 0x5A;
-    ASSERT(write(cmd_pipe[1], &cmd, sizeof(cmd)) == static_cast<ssize_t>(sizeof(cmd)));
+    TEST_ASSERT(write(cmd_pipe[1], &cmd, sizeof(cmd)) ==
+                static_cast<ssize_t>(sizeof(cmd)));
 
     ExpectChildExit(child);
-    ASSERT(publisher.GetSubscriberNum() == 1);
+    TEST_ASSERT(publisher.GetSubscriberNum() == 1);
 
     SharedData data0;
     SharedData data1;
     SharedData data2;
-    ASSERT(publisher.CreateData(data0) == LibXR::ErrorCode::OK);
-    ASSERT(publisher.GetSubscriberNum() == 0);
-    ASSERT(publisher.CreateData(data1) == LibXR::ErrorCode::OK);
-    ASSERT(publisher.CreateData(data2) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(publisher.CreateData(data0) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.GetSubscriberNum() == 0);
+    TEST_ASSERT(publisher.CreateData(data1) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.CreateData(data2) == LibXR::ErrorCode::FULL);
 
     close(ack_pipe[0]);
     close(cmd_pipe[1]);

--- a/test/linux_shm/test_lifecycle_slot_ref.cpp
+++ b/test/linux_shm/test_lifecycle_slot_ref.cpp
@@ -10,6 +10,7 @@
  *          2. After the last release, the publisher can create new data again.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -29,34 +30,34 @@ void RunLifecycleSlotReferenceScenario()
     config.queue_num = 4;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber_a(topic_name);
     SharedSubscriber subscriber_b(topic_name);
-    ASSERT(subscriber_a.Valid());
-    ASSERT(subscriber_b.Valid());
+    TEST_ASSERT(subscriber_a.Valid());
+    TEST_ASSERT(subscriber_b.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 301);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
-    ASSERT(subscriber_a.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_a.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_b.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     AssertFrame(*subscriber_a.GetData(), 301);
     AssertFrame(*subscriber_b.GetData(), 301);
 
     subscriber_a.Release();
 
     SharedData blocked_data;
-    ASSERT(publisher.CreateData(blocked_data) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(publisher.CreateData(blocked_data) == LibXR::ErrorCode::FULL);
 
     subscriber_b.Release();
-    ASSERT(publisher.CreateData(blocked_data) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.CreateData(blocked_data) == LibXR::ErrorCode::OK);
     FillFrame(*blocked_data.GetData(), 302);
-    ASSERT(publisher.Publish(blocked_data) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(blocked_data) == LibXR::ErrorCode::OK);
 
-    ASSERT(subscriber_a.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_a.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_b.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     AssertFrame(*subscriber_a.GetData(), 302);
     AssertFrame(*subscriber_b.GetData(), 302);
     subscriber_a.Release();

--- a/test/linux_shm/test_lifecycle_takeover.cpp
+++ b/test/linux_shm/test_lifecycle_takeover.cpp
@@ -9,6 +9,7 @@
  * exits.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -28,7 +29,7 @@ void RunLifecycleTakeoverScenario()
     config.queue_num = 4;
 
     pid_t child = fork();
-    ASSERT(child >= 0);
+    TEST_ASSERT(child >= 0);
 
     if (child == 0)
     {
@@ -51,11 +52,11 @@ void RunLifecycleTakeoverScenario()
     ExpectChildExit(child);
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 151);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
   }
 }
 

--- a/test/linux_shm/test_mixed_modes.cpp
+++ b/test/linux_shm/test_mixed_modes.cpp
@@ -4,6 +4,7 @@
  * `LinuxSharedTopic` domain and mixed-mode semantics.
  */
 #include "linux_shm_topic_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace LinuxShmTopicTest
 {
@@ -36,26 +37,26 @@ void RunMixedModeScenarios()
 
     SharedTopic publisher_a(topic_name, domain_a, config);
     SharedTopic publisher_b(topic_name, "linux_shm_domain_b", config);
-    ASSERT(publisher_a.Valid());
-    ASSERT(publisher_b.Valid());
+    TEST_ASSERT(publisher_a.Valid());
+    TEST_ASSERT(publisher_b.Valid());
 
     SharedSubscriber subscriber_a(topic_name, "linux_shm_domain_a");
     SharedSubscriber subscriber_b(topic_name, domain_b);
-    ASSERT(subscriber_a.Valid());
-    ASSERT(subscriber_b.Valid());
+    TEST_ASSERT(subscriber_a.Valid());
+    TEST_ASSERT(subscriber_b.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 331);
-    ASSERT(publisher_a.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher_a.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 441);
-    ASSERT(publisher_b.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher_b.Publish(frame) == LibXR::ErrorCode::OK);
 
     SharedData recv_a;
     SharedData recv_b;
-    ASSERT(subscriber_a.Wait(recv_a, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(recv_a.GetData()->seq == 331);
-    ASSERT(recv_b.GetData()->seq == 441);
+    TEST_ASSERT(subscriber_a.Wait(recv_a, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_b.Wait(recv_b, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(recv_a.GetData()->seq == 331);
+    TEST_ASSERT(recv_b.GetData()->seq == 441);
     recv_a.Reset();
     recv_b.Reset();
 
@@ -73,44 +74,44 @@ void RunMixedModeScenarios()
     config.queue_num = 4;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber_broadcast(topic_name);
     SharedSubscriber subscriber_rr_a(topic_name,
                                      LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
     SharedSubscriber subscriber_rr_b(topic_name,
                                      LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    ASSERT(subscriber_broadcast.Valid());
-    ASSERT(subscriber_rr_a.Valid());
-    ASSERT(subscriber_rr_b.Valid());
+    TEST_ASSERT(subscriber_broadcast.Valid());
+    TEST_ASSERT(subscriber_rr_a.Valid());
+    TEST_ASSERT(subscriber_rr_b.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 381);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 382);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
     FillFrame(frame, 383);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     SharedData bc0;
     SharedData bc1;
     SharedData bc2;
-    ASSERT(subscriber_broadcast.Wait(bc0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_broadcast.Wait(bc1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_broadcast.Wait(bc2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(bc0.GetData()->seq == 381);
-    ASSERT(bc1.GetData()->seq == 382);
-    ASSERT(bc2.GetData()->seq == 383);
+    TEST_ASSERT(subscriber_broadcast.Wait(bc0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_broadcast.Wait(bc1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_broadcast.Wait(bc2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(bc0.GetData()->seq == 381);
+    TEST_ASSERT(bc1.GetData()->seq == 382);
+    TEST_ASSERT(bc2.GetData()->seq == 383);
 
     SharedData rr_a0;
     SharedData rr_b0;
     SharedData rr_a1;
-    ASSERT(subscriber_rr_a.Wait(rr_a0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_rr_b.Wait(rr_b0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_rr_a.Wait(rr_a1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(rr_a0.GetData()->seq == 381);
-    ASSERT(rr_b0.GetData()->seq == 382);
-    ASSERT(rr_a1.GetData()->seq == 383);
+    TEST_ASSERT(subscriber_rr_a.Wait(rr_a0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_rr_b.Wait(rr_b0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(subscriber_rr_a.Wait(rr_a1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(rr_a0.GetData()->seq == 381);
+    TEST_ASSERT(rr_b0.GetData()->seq == 382);
+    TEST_ASSERT(rr_a1.GetData()->seq == 383);
   }
 
   UNUSED(SharedTopic::Remove(topic_name));
@@ -126,28 +127,28 @@ void RunMixedModeScenarios()
     config.queue_num = 2;
 
     SharedTopic publisher(topic_name, config);
-    ASSERT(publisher.Valid());
+    TEST_ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber_broadcast(topic_name);
     SharedSubscriber subscriber_rr(topic_name,
                                    LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    ASSERT(subscriber_broadcast.Valid());
-    ASSERT(subscriber_rr.Valid());
+    TEST_ASSERT(subscriber_broadcast.Valid());
+    TEST_ASSERT(subscriber_rr.Valid());
 
     IPCFrame frame = {};
     FillFrame(frame, 391);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     FillFrame(frame, 392);
-    ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::FULL);
+    TEST_ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::FULL);
 
     SharedData bc0;
-    ASSERT(subscriber_broadcast.Wait(bc0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(bc0.GetData()->seq == 391);
+    TEST_ASSERT(subscriber_broadcast.Wait(bc0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(bc0.GetData()->seq == 391);
 
     SharedData rr0;
-    ASSERT(subscriber_rr.Wait(rr0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
-    ASSERT(rr0.GetData()->seq == 391);
+    TEST_ASSERT(subscriber_rr.Wait(rr0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(rr0.GetData()->seq == 391);
   }
 }
 }  // namespace LinuxShmTopicTest

--- a/test/runtime/driver/test_linux_uart.cpp
+++ b/test/runtime/driver/test_linux_uart.cpp
@@ -16,6 +16,7 @@
 
 #include "linux_uart.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -30,7 +31,7 @@ void WaitUntil(Predicate predicate)
   const auto deadline = Clock::now() + WAIT_LIMIT;
   while (!predicate())
   {
-    ASSERT(Clock::now() < deadline);
+    TEST_ASSERT(Clock::now() < deadline);
     Thread::Sleep(1);
   }
 }
@@ -40,20 +41,20 @@ struct Pty
   Pty()
   {
     master = posix_openpt(O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
-    ASSERT(master >= 0);
-    ASSERT(grantpt(master) == 0);
-    ASSERT(unlockpt(master) == 0);
+    TEST_ASSERT(master >= 0);
+    TEST_ASSERT(grantpt(master) == 0);
+    TEST_ASSERT(unlockpt(master) == 0);
     char* name = ptsname(master);
-    ASSERT(name != nullptr);
+    TEST_ASSERT(name != nullptr);
     path = name;
     observer = open(path.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
-    ASSERT(observer >= 0);
+    TEST_ASSERT(observer >= 0);
   }
 
   uint32_t Baudrate() const
   {
     termios2 config{};
-    ASSERT(ioctl(observer, TCGETS2, &config) == 0);
+    TEST_ASSERT(ioctl(observer, TCGETS2, &config) == 0);
     return config.c_ospeed;
   }
 
@@ -69,8 +70,8 @@ struct Pty
         offset += static_cast<size_t>(count);
         continue;
       }
-      ASSERT(count < 0 && (errno == EINTR || errno == EAGAIN));
-      ASSERT(Clock::now() < deadline);
+      TEST_ASSERT(count < 0 && (errno == EINTR || errno == EAGAIN));
+      TEST_ASSERT(Clock::now() < deadline);
       Thread::Sleep(1);
     }
   }
@@ -88,8 +89,8 @@ struct Pty
         offset += static_cast<size_t>(count);
         continue;
       }
-      ASSERT(count < 0 && (errno == EINTR || errno == EAGAIN));
-      ASSERT(Clock::now() < deadline);
+      TEST_ASSERT(count < 0 && (errno == EINTR || errno == EAGAIN));
+      TEST_ASSERT(Clock::now() < deadline);
       Thread::Sleep(1);
     }
     return data;
@@ -98,7 +99,7 @@ struct Pty
   void ExpectNoOutput()
   {
     pollfd item{master, POLLIN, 0};
-    ASSERT(poll(&item, 1, 20) == 0);
+    TEST_ASSERT(poll(&item, 1, 20) == 0);
   }
 
   int master = -1;
@@ -130,7 +131,7 @@ struct DevicePath
 {
   explicit DevicePath(const Pty* initial = nullptr)
   {
-    ASSERT(mkdtemp(directory) != nullptr);
+    TEST_ASSERT(mkdtemp(directory) != nullptr);
     path = std::string(directory) + "/uart";
     if (initial != nullptr)
     {
@@ -141,25 +142,28 @@ struct DevicePath
       // 普通文件可打开，但无法配置为串口，用于验证首次打开恢复。
       // A regular file opens but rejects TTY configuration, exercising initial recovery.
       const int fd = open(path.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0600);
-      ASSERT(fd >= 0);
-      ASSERT(close(fd) == 0);
+      TEST_ASSERT(fd >= 0);
+      TEST_ASSERT(close(fd) == 0);
     }
   }
 
   ~DevicePath()
   {
     Remove();
-    ASSERT(rmdir(directory) == 0);
+    TEST_ASSERT(rmdir(directory) == 0);
   }
 
-  void Remove() { ASSERT(unlink(path.c_str()) == 0); }
-  void Connect(const Pty& pty) { ASSERT(symlink(pty.path.c_str(), path.c_str()) == 0); }
+  void Remove() { TEST_ASSERT(unlink(path.c_str()) == 0); }
+  void Connect(const Pty& pty)
+  {
+    TEST_ASSERT(symlink(pty.path.c_str(), path.c_str()) == 0);
+  }
 
   void Disconnect(const Pty& pty)
   {
     Remove();
-    ASSERT(close(pty.observer) == 0);
-    ASSERT(close(pty.master) == 0);
+    TEST_ASSERT(close(pty.observer) == 0);
+    TEST_ASSERT(close(pty.master) == 0);
   }
 
   char directory[sizeof("/tmp/libxr-uart-test-XXXXXX")] = "/tmp/libxr-uart-test-XXXXXX";
@@ -184,7 +188,7 @@ struct Fixture
   {
     uart = new LinuxUART(pty.path.c_str(), 115200, UART::Parity::NO_PARITY, 8, 1, 8,
                          capacity);
-    ASSERT(pty.Baudrate() == 115200);
+    TEST_ASSERT(pty.Baudrate() == 115200);
   }
 
   Pty pty;
@@ -209,11 +213,12 @@ void test_linux_uart_rx_backpressure()
     std::array<uint8_t, 64> chunk{};
     Semaphore sem;
     ReadOperation op(sem, 1000);
-    ASSERT(fixture->uart->Read(RawData{chunk.data(), chunk.size()}, op) == ErrorCode::OK);
+    TEST_ASSERT(fixture->uart->Read(RawData{chunk.data(), chunk.size()}, op) ==
+                ErrorCode::OK);
     received.insert(received.end(), chunk.begin(), chunk.end());
   }
-  ASSERT(received == expected);
-  ASSERT(fixture->uart->read_port_->Size() == 0);
+  TEST_ASSERT(received == expected);
+  TEST_ASSERT(fixture->uart->read_port_->Size() == 0);
 }
 
 /**
@@ -224,27 +229,27 @@ void test_linux_uart_tx_backpressure()
   constexpr size_t PAYLOAD_SIZE = 256 * 1024;
   auto* fixture = new Fixture(PAYLOAD_SIZE + 64);
   auto expected = Pattern(PAYLOAD_SIZE);
-  ASSERT(fixture->uart->Write(ConstRawData{expected.data(), expected.size()},
-                              fixture->completion.op) == ErrorCode::OK);
+  TEST_ASSERT(fixture->uart->Write(ConstRawData{expected.data(), expected.size()},
+                                   fixture->completion.op) == ErrorCode::OK);
   WaitUntil(
       [&]
       {
         const auto remaining = fixture->uart->write_port_->Size();
         return remaining > 0 && remaining < PAYLOAD_SIZE;
       });
-  ASSERT(fixture->completion.Is(PollingStatus::RUNNING));
+  TEST_ASSERT(fixture->completion.Is(PollingStatus::RUNNING));
   const UART::Configuration config{57600, UART::Parity::NO_PARITY, 8, 1};
-  ASSERT(fixture->uart->SetConfig(config) == ErrorCode::OK);
-  ASSERT(fixture->pty.Baudrate() == 115200);
+  TEST_ASSERT(fixture->uart->SetConfig(config) == ErrorCode::OK);
+  TEST_ASSERT(fixture->pty.Baudrate() == 115200);
 
   const std::vector<uint8_t> suffix{0, 0xFF, '\r', '\n', 0x11, 0x13};
   auto* suffix_completion = new Completion;
-  ASSERT(fixture->uart->Write(ConstRawData{suffix.data(), suffix.size()},
-                              suffix_completion->op) == ErrorCode::OK);
+  TEST_ASSERT(fixture->uart->Write(ConstRawData{suffix.data(), suffix.size()},
+                                   suffix_completion->op) == ErrorCode::OK);
   expected.insert(expected.end(), suffix.begin(), suffix.end());
-  ASSERT(fixture->pty.Receive(expected.size()) == expected);
+  TEST_ASSERT(fixture->pty.Receive(expected.size()) == expected);
   suffix_completion->Wait();
-  ASSERT(fixture->completion.Is(PollingStatus::DONE));
+  TEST_ASSERT(fixture->completion.Is(PollingStatus::DONE));
   WaitUntil([&] { return fixture->pty.Baudrate() == config.baudrate; });
 }
 
@@ -258,12 +263,12 @@ void test_linux_uart_block_timeout()
   const auto expected = Pattern(256 * 1024);
   auto* sem = new Semaphore;
   WriteOperation op(*sem, 30);
-  ASSERT(fixture->uart->Write(ConstRawData{expected.data(), expected.size()}, op) ==
-         ErrorCode::TIMEOUT);
-  ASSERT(fixture->uart->write_port_->Size() > 0);
-  ASSERT(fixture->pty.Receive(expected.size()) == expected);
+  TEST_ASSERT(fixture->uart->Write(ConstRawData{expected.data(), expected.size()}, op) ==
+              ErrorCode::TIMEOUT);
+  TEST_ASSERT(fixture->uart->write_port_->Size() > 0);
+  TEST_ASSERT(fixture->pty.Receive(expected.size()) == expected);
   WaitUntil([&] { return fixture->uart->write_port_->Size() == 0; });
-  ASSERT(sem->Value() == 0);
+  TEST_ASSERT(sem->Value() == 0);
 }
 
 /**
@@ -282,7 +287,7 @@ void test_linux_uart_callback_write()
   auto* callback = new WriteOperation::Callback(WriteOperation::Callback::Create(
       [](bool in_isr, Context* self, ErrorCode result)
       {
-        ASSERT(!in_isr && result == ErrorCode::OK);
+        TEST_ASSERT(!in_isr && result == ErrorCode::OK);
         self->submit_result = self->fixture.uart->Write(
             ConstRawData{self->second.data(), self->second.size()},
             self->fixture.completion.op);
@@ -291,12 +296,12 @@ void test_linux_uart_callback_write()
       ctx));
   WriteOperation op(*callback);
   const std::array<uint8_t, 3> first{1, 2, 3};
-  ASSERT(ctx->fixture.uart->Write(ConstRawData{first.data(), first.size()}, op) ==
-         ErrorCode::OK);
-  ASSERT(ctx->fixture.pty.Receive(6) == std::vector<uint8_t>({1, 2, 3, 4, 5, 6}));
+  TEST_ASSERT(ctx->fixture.uart->Write(ConstRawData{first.data(), first.size()}, op) ==
+              ErrorCode::OK);
+  TEST_ASSERT(ctx->fixture.pty.Receive(6) == std::vector<uint8_t>({1, 2, 3, 4, 5, 6}));
   ctx->fixture.completion.Wait();
-  ASSERT(ctx->calls.load(std::memory_order_acquire) == 1);
-  ASSERT(ctx->submit_result == ErrorCode::OK);
+  TEST_ASSERT(ctx->calls.load(std::memory_order_acquire) == 1);
+  TEST_ASSERT(ctx->submit_result == ErrorCode::OK);
 }
 
 /**
@@ -309,17 +314,18 @@ void test_linux_uart_stream_config()
   auto* stream =
       new WritePort::Stream(fixture->uart->write_port_, fixture->completion.op);
   const auto expected = Pattern(32);
-  ASSERT(stream->Write(ConstRawData{expected.data(), expected.size()}) == ErrorCode::OK);
+  TEST_ASSERT(stream->Write(ConstRawData{expected.data(), expected.size()}) ==
+              ErrorCode::OK);
   fixture->pty.ExpectNoOutput();
   UART::Configuration config{57600, UART::Parity::NO_PARITY, 8, 1};
-  ASSERT(fixture->uart->SetConfig(config) == ErrorCode::OK);
+  TEST_ASSERT(fixture->uart->SetConfig(config) == ErrorCode::OK);
   WaitUntil([&] { return fixture->pty.Baudrate() == config.baudrate; });
   fixture->pty.ExpectNoOutput();
-  ASSERT(stream->Commit() == ErrorCode::OK);
-  ASSERT(fixture->pty.Receive(expected.size()) == expected);
+  TEST_ASSERT(stream->Commit() == ErrorCode::OK);
+  TEST_ASSERT(fixture->pty.Receive(expected.size()) == expected);
   fixture->completion.Wait();
   config.baudrate = 0;
-  ASSERT(fixture->uart->SetConfig(config) == ErrorCode::ARG_ERR);
+  TEST_ASSERT(fixture->uart->SetConfig(config) == ErrorCode::ARG_ERR);
 }
 
 /**
@@ -332,7 +338,7 @@ void test_linux_uart_reconnect()
   auto* next_pty = new Pty;
   DevicePath device(old_pty);
   auto* uart = new LinuxUART(device.path.c_str());
-  ASSERT(old_pty->Baudrate() == 115200);
+  TEST_ASSERT(old_pty->Baudrate() == 115200);
   device.Disconnect(*old_pty);
 
   // 先确认旧 fd 已关闭，再提交尚未尝试发送的新请求。
@@ -353,23 +359,23 @@ void test_linux_uart_reconnect()
       });
   auto* completion = new Completion;
   const auto expected = Pattern(48);
-  ASSERT(uart->Write(ConstRawData{expected.data(), expected.size()}, completion->op) ==
-         ErrorCode::OK);
+  TEST_ASSERT(uart->Write(ConstRawData{expected.data(), expected.size()},
+                          completion->op) == ErrorCode::OK);
   const UART::Configuration config{38400, UART::Parity::NO_PARITY, 8, 1};
-  ASSERT(uart->SetConfig(config) == ErrorCode::OK);
-  ASSERT(uart->SetConfig(config) == ErrorCode::BUSY);
+  TEST_ASSERT(uart->SetConfig(config) == ErrorCode::OK);
+  TEST_ASSERT(uart->SetConfig(config) == ErrorCode::BUSY);
   auto* received = new std::array<uint8_t, 48>;
   auto* read_completion = new Completion;
-  ASSERT(uart->Read(RawData{received->data(), received->size()}, read_completion->op) ==
-         ErrorCode::OK);
+  TEST_ASSERT(uart->Read(RawData{received->data(), received->size()},
+                         read_completion->op) == ErrorCode::OK);
 
   device.Connect(*next_pty);
-  ASSERT(next_pty->Receive(expected.size()) == expected);
-  ASSERT(next_pty->Baudrate() == config.baudrate);
+  TEST_ASSERT(next_pty->Receive(expected.size()) == expected);
+  TEST_ASSERT(next_pty->Baudrate() == config.baudrate);
   next_pty->Send(expected);
   read_completion->Wait();
-  ASSERT(std::memcmp(received->data(), expected.data(), expected.size()) == 0);
-  ASSERT(completion->Is(PollingStatus::DONE));
+  TEST_ASSERT(std::memcmp(received->data(), expected.data(), expected.size()) == 0);
+  TEST_ASSERT(completion->Is(PollingStatus::DONE));
 }
 
 /**
@@ -385,8 +391,8 @@ void test_linux_uart_partial_disconnect()
                              8, PAYLOAD_SIZE + 64);
   const auto first = Pattern(PAYLOAD_SIZE);
   auto* first_completion = new Completion;
-  ASSERT(uart->Write(ConstRawData{first.data(), first.size()}, first_completion->op) ==
-         ErrorCode::OK);
+  TEST_ASSERT(uart->Write(ConstRawData{first.data(), first.size()},
+                          first_completion->op) == ErrorCode::OK);
   WaitUntil(
       [&]
       {
@@ -395,14 +401,14 @@ void test_linux_uart_partial_disconnect()
       });
   const auto second = Pattern(32);
   auto* second_completion = new Completion;
-  ASSERT(uart->Write(ConstRawData{second.data(), second.size()}, second_completion->op) ==
-         ErrorCode::OK);
+  TEST_ASSERT(uart->Write(ConstRawData{second.data(), second.size()},
+                          second_completion->op) == ErrorCode::OK);
 
   device.Disconnect(*old_pty);
   first_completion->Wait(PollingStatus::ERROR);
-  ASSERT(second_completion->Is(PollingStatus::RUNNING));
+  TEST_ASSERT(second_completion->Is(PollingStatus::RUNNING));
   device.Connect(*next_pty);
-  ASSERT(next_pty->Receive(second.size()) == second);
+  TEST_ASSERT(next_pty->Receive(second.size()) == second);
   second_completion->Wait();
   next_pty->ExpectNoOutput();
 }
@@ -417,10 +423,10 @@ void test_linux_uart_initial_open_recovery()
   auto* uart = new LinuxUART(device.path.c_str());
   auto* completion = new Completion;
   const auto expected = Pattern(32);
-  ASSERT(uart->Write(ConstRawData{expected.data(), expected.size()}, completion->op) ==
-         ErrorCode::OK);
+  TEST_ASSERT(uart->Write(ConstRawData{expected.data(), expected.size()},
+                          completion->op) == ErrorCode::OK);
   device.Remove();
   device.Connect(*pty);
-  ASSERT(pty->Receive(expected.size()) == expected);
+  TEST_ASSERT(pty->Receive(expected.size()) == expected);
   completion->Wait();
 }

--- a/test/runtime/middleware/message/test_runtime.cpp
+++ b/test/runtime/middleware/message/test_runtime.cpp
@@ -22,6 +22,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -59,26 +60,26 @@ void TestASyncSubscriberFreshWait()
 
   int value = 41;
   topic.Publish(value, LibXR::MicrosecondTimestamp(7041));
-  ASSERT(!suber.Available());
+  TEST_ASSERT(!suber.Available());
 
   suber.StartWaiting();
   value = 42;
   topic.Publish(value, LibXR::MicrosecondTimestamp(7042));
-  ASSERT(suber.Available());
+  TEST_ASSERT(suber.Available());
   suber.StartWaiting();
-  ASSERT(suber.Available());
-  ASSERT(suber.GetData() == value);
-  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7042);
-  ASSERT(!suber.Available());
+  TEST_ASSERT(suber.Available());
+  TEST_ASSERT(suber.GetData() == value);
+  TEST_ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7042);
+  TEST_ASSERT(!suber.Available());
 
   suber.StartWaiting();
   UNUSED(suber.GetData());
   value = 43;
   topic.PublishFromCallback(value, LibXR::MicrosecondTimestamp(7043), false);
-  ASSERT(suber.Available());
-  ASSERT(suber.GetData() == value);
-  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7043);
-  ASSERT(!suber.Available());
+  TEST_ASSERT(suber.Available());
+  TEST_ASSERT(suber.GetData() == value);
+  TEST_ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7043);
+  TEST_ASSERT(!suber.Available());
 }
 
 /**
@@ -104,9 +105,9 @@ void TestSyncSubscriberFreshWait()
     auto value = i + 1;
     topic.Publish(value, LibXR::MicrosecondTimestamp(7100 + i));
   }
-  ASSERT(rx == -1);
-  ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
-  ASSERT(suber.Wait(1) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(rx == -1);
+  TEST_ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(suber.Wait(1) == LibXR::ErrorCode::TIMEOUT);
 
   auto wait_and_publish = [&](auto publish)
   {
@@ -123,34 +124,34 @@ void TestSyncSubscriberFreshWait()
       LibXR::Thread::Yield();
     }
 
-    ASSERT(suber.block_->data_.wait_state.load(std::memory_order_acquire) ==
-           LibXR::Topic::SyncBlock::WAITING);
-    ASSERT(suber.Wait(0) == LibXR::ErrorCode::BUSY);
+    TEST_ASSERT(suber.block_->data_.wait_state.load(std::memory_order_acquire) ==
+                LibXR::Topic::SyncBlock::WAITING);
+    TEST_ASSERT(suber.Wait(0) == LibXR::ErrorCode::BUSY);
     publish();
-    ASSERT(wait_thread.Join() == LibXR::ErrorCode::OK);
-    ASSERT(ctx.result == LibXR::ErrorCode::OK);
+    TEST_ASSERT(wait_thread.Join() == LibXR::ErrorCode::OK);
+    TEST_ASSERT(ctx.result == LibXR::ErrorCode::OK);
   };
 
   int value = 6;
   wait_and_publish(
       [&]()
       { topic.PublishFromCallback(value, LibXR::MicrosecondTimestamp(7106), false); });
-  ASSERT(rx == value);
-  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7106);
-  ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(rx == value);
+  TEST_ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7106);
+  TEST_ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
 
-  ASSERT(suber.Wait(1) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(suber.Wait(1) == LibXR::ErrorCode::TIMEOUT);
   value = 7;
   topic.Publish(value, LibXR::MicrosecondTimestamp(7107));
-  ASSERT(rx == 6);
-  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7106);
-  ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(rx == 6);
+  TEST_ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7106);
+  TEST_ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
 
   value = 8;
   wait_and_publish([&]() { topic.Publish(value, LibXR::MicrosecondTimestamp(7108)); });
-  ASSERT(rx == value);
-  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7108);
-  ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(rx == value);
+  TEST_ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7108);
+  TEST_ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
 }
 
 }  // namespace

--- a/test/runtime/rw/test_pipe_runtime_cases.cpp
+++ b/test/runtime/rw/test_pipe_runtime_cases.cpp
@@ -4,6 +4,7 @@
  *        / Pipe blocking submission and repeated transfer tests.
  */
 #include "rw_runtime_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -22,7 +23,7 @@ void test_pipe_stream_block_immediate_path()
 
   uint8_t rx[8] = {0};
   ReadOperation rop;
-  ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
+  TEST_ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
 
   Semaphore sem;
   WriteOperation wop(sem, 100);
@@ -32,11 +33,11 @@ void test_pipe_stream_block_immediate_path()
   ws << ConstRawData{A, sizeof(A)} << ConstRawData{B, sizeof(B)};
 
   auto ec = ws.Commit();
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
   static const uint8_t EXPECT[] = {0x21, 0x22, 0x23, 0x31, 0x32, 0x33, 0x34, 0x35};
-  ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
+  TEST_ASSERT(sem.Value() == 0);
 }
 
 /**
@@ -75,7 +76,7 @@ void test_pipe_block_reuse_stress()
       Thread writer;
       StartDelayedPipeWriter(writer, ctx, "pipe_block_async");
 
-      ASSERT(r(RawData{rx.data(), rx.size()}, read.op) == ErrorCode::OK);
+      TEST_ASSERT(r(RawData{rx.data(), rx.size()}, read.op) == ErrorCode::OK);
       ExpectWaitOk(write_done);
       JoinThreadIfNeeded(writer);
       ExpectCallResult(write, ctx.result, ErrorCode::OK);
@@ -87,9 +88,9 @@ void test_pipe_block_reuse_stress()
       ExpectCallResult(read, r(RawData{rx.data(), rx.size()}, read.op), ErrorCode::OK);
     }
 
-    ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
-    ASSERT(r.Size() == 0);
-    ASSERT(w.Size() == 0);
+    TEST_ASSERT(std::memcmp(rx.data(), tx.data(), tx.size()) == 0);
+    TEST_ASSERT(r.Size() == 0);
+    TEST_ASSERT(w.Size() == 0);
   }
 }
 

--- a/test/runtime/rw/test_rw_block_timeout_cases.cpp
+++ b/test/runtime/rw/test_rw_block_timeout_cases.cpp
@@ -3,6 +3,7 @@
  * @brief RW 超时与后台接收入队测试 / RW timeout and background RX production tests.
  */
 #include "rw_runtime_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -24,24 +25,24 @@ void test_rw_block_read_timeout_detaches_pending()
   ReadOperation block_op(sem, 0);
 
   auto ec = r(RawData{timed_out_rx, sizeof(timed_out_rx)}, block_op);
-  ASSERT(ec == ErrorCode::TIMEOUT);
+  TEST_ASSERT(ec == ErrorCode::TIMEOUT);
 
   static const uint8_t STALE_EXPECT[] = {0xA1, 0xA2, 0xA3, 0xA4};
-  ASSERT(std::memcmp(timed_out_rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
+  TEST_ASSERT(std::memcmp(timed_out_rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
 
   static const uint8_t TX[] = {0x10, 0x20, 0x30, 0x40};
   WriteOperation wop;
   ec = w(ConstRawData{TX, sizeof(TX)}, wop);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
 
-  ASSERT(std::memcmp(timed_out_rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(std::memcmp(timed_out_rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
+  TEST_ASSERT(sem.Value() == 0);
 
   uint8_t fresh_rx[sizeof(TX)] = {0};
   ReadOperation rop;
   ec = r(RawData{fresh_rx, sizeof(fresh_rx)}, rop);
-  ASSERT(ec == ErrorCode::OK);
-  ASSERT(std::memcmp(fresh_rx, TX, sizeof(TX)) == 0);
+  TEST_ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(std::memcmp(fresh_rx, TX, sizeof(TX)) == 0);
 }
 
 /**
@@ -65,7 +66,7 @@ void test_rw_zero_read_pending_notifies_without_dequeue()
     StartReadQueueCompleter(finisher, r, done, TX, sizeof(TX), "rd_zero_ready");
 
     auto ec = r(RawData{&dummy, 0}, read.op);
-    ASSERT(ec == ErrorCode::OK);
+    TEST_ASSERT(ec == ErrorCode::OK);
     ExpectWaitOk(done, SHORT_WAIT_MS);
     JoinThreadIfNeeded(finisher);
 
@@ -74,16 +75,16 @@ void test_rw_zero_read_pending_notifies_without_dequeue()
       read.ExpectFinal(ErrorCode::OK);
     }
 
-    ASSERT(dummy == 0xA0);
-    ASSERT(r.dequeue_count == 0);
-    ASSERT(r.Size() == sizeof(TX));
+    TEST_ASSERT(dummy == 0xA0);
+    TEST_ASSERT(r.dequeue_count == 0);
+    TEST_ASSERT(r.Size() == sizeof(TX));
 
     uint8_t follow_up[sizeof(TX)] = {};
     ReadOperation follow_op;
     ec = r(RawData{follow_up, sizeof(follow_up)}, follow_op);
-    ASSERT(ec == ErrorCode::OK);
-    ASSERT(std::memcmp(follow_up, TX, sizeof(TX)) == 0);
-    ASSERT(r.dequeue_count == 1);
+    TEST_ASSERT(ec == ErrorCode::OK);
+    TEST_ASSERT(std::memcmp(follow_up, TX, sizeof(TX)) == 0);
+    TEST_ASSERT(r.dequeue_count == 1);
   }
 }
 
@@ -104,30 +105,30 @@ void test_rw_block_write_timeout_detaches_waiter()
   Semaphore sem1;
   WriteOperation op1(sem1, 0);
   auto ec = w(ConstRawData{TX1, sizeof(TX1)}, op1);
-  ASSERT(ec == ErrorCode::TIMEOUT);
-  ASSERT(sem1.Value() == 0);
+  TEST_ASSERT(ec == ErrorCode::TIMEOUT);
+  TEST_ASSERT(sem1.Value() == 0);
 
   static uint8_t sink[sizeof(TX1)] = {};
   {
     auto queue = w.GetWriteQueue(false);
-    ASSERT(!queue.Empty());
+    TEST_ASSERT(!queue.Empty());
     queue.PopAll(sink);
   }
 
   Semaphore sem2;
   WriteOperation op2(sem2, 0);
   ec = w(ConstRawData{TX2, sizeof(TX2)}, op2);
-  ASSERT(ec == ErrorCode::TIMEOUT);
-  ASSERT(sem2.Value() == 0);
+  TEST_ASSERT(ec == ErrorCode::TIMEOUT);
+  TEST_ASSERT(sem2.Value() == 0);
 
   static uint8_t sink2[sizeof(TX2)] = {};
   {
     auto queue = w.GetWriteQueue(false);
-    ASSERT(!queue.Empty());
+    TEST_ASSERT(!queue.Empty());
     queue.PopAll(sink2);
   }
-  ASSERT(sem1.Value() == 0);
-  ASSERT(sem2.Value() == 0);
+  TEST_ASSERT(sem1.Value() == 0);
+  TEST_ASSERT(sem2.Value() == 0);
 }
 
 /**
@@ -149,11 +150,11 @@ void test_rw_read_port_block_queue_completion_copies_data()
   StartReadQueueCompleter(finisher, r, done, TX, sizeof(TX), "rd_queue_block");
 
   auto ec = r(RawData{rx, sizeof(rx)}, op);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
   ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
-  ASSERT(std::memcmp(rx, TX, sizeof(TX)) == 0);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(std::memcmp(rx, TX, sizeof(TX)) == 0);
+  TEST_ASSERT(sem.Value() == 0);
 }
 
 }  // namespace

--- a/test/runtime/rw/test_rw_block_waiter_cases.cpp
+++ b/test/runtime/rw/test_rw_block_waiter_cases.cpp
@@ -11,6 +11,7 @@
  * next wait cycle.
  */
 #include "rw_runtime_test_common.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -40,7 +41,7 @@ void test_rw_write_port_block_pending_result_propagates()
   StartWriteFinisher(finisher, w, done, ErrorCode::FAILED, "wr_finish");
 
   auto ec = w(ConstRawData{TX, sizeof(TX)}, op);
-  ASSERT(ec == ErrorCode::FAILED);
+  TEST_ASSERT(ec == ErrorCode::FAILED);
   ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
 }
@@ -71,20 +72,20 @@ void test_rw_write_port_block_reused_waiter_discards_stale_signal()
   StartWriteFinisher(finisher1, w, done1, ErrorCode::FAILED, "wr_stale1");
 
   auto ec = w(ConstRawData{TX1, sizeof(TX1)}, op);
-  ASSERT(ec == ErrorCode::FAILED);
+  TEST_ASSERT(ec == ErrorCode::FAILED);
   ExpectWaitOk(done1, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher1);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(sem.Value() == 0);
 
   Semaphore done2;
   Thread finisher2;
   StartWriteFinisher(finisher2, w, done2, ErrorCode::OK, "wr_stale2");
 
   ec = w(ConstRawData{TX2, sizeof(TX2)}, op);
-  ASSERT(ec == ErrorCode::OK);
+  TEST_ASSERT(ec == ErrorCode::OK);
   ExpectWaitOk(done2, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher2);
-  ASSERT(sem.Value() == 0);
+  TEST_ASSERT(sem.Value() == 0);
 }
 
 }  // namespace

--- a/test/runtime/system/test_async.cpp
+++ b/test/runtime/system/test_async.cpp
@@ -19,6 +19,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_async`。 Test entry function `test_async`.
@@ -48,11 +49,11 @@ void test_async()
       new (async_storage) LibXR::ASync(512, LibXR::Thread::Priority::REALTIME);
   for (int i = 0; i < 10; i++)
   {
-    ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
-    ASSERT(async_arg == i);
+    TEST_ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
+    TEST_ASSERT(async_arg == i);
     async->AssignJob(async_cb);
 
-    ASSERT(async->GetStatus() == LibXR::ASync::Status::BUSY);
+    TEST_ASSERT(async->GetStatus() == LibXR::ASync::Status::BUSY);
     const uint32_t wait_start = LibXR::Thread::GetTime();
     while (async->status_.load(std::memory_order_acquire) != LibXR::ASync::Status::DONE &&
            LibXR::Thread::GetTime() - wait_start < 1000U)
@@ -60,9 +61,10 @@ void test_async()
       LibXR::Thread::Yield();
     }
 
-    ASSERT(async->status_.load(std::memory_order_acquire) == LibXR::ASync::Status::DONE);
-    ASSERT(async_arg == i + 1);
-    ASSERT(async->GetStatus() == LibXR::ASync::Status::DONE);
-    ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
+    TEST_ASSERT(async->status_.load(std::memory_order_acquire) ==
+                LibXR::ASync::Status::DONE);
+    TEST_ASSERT(async_arg == i + 1);
+    TEST_ASSERT(async->GetStatus() == LibXR::ASync::Status::DONE);
+    TEST_ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
   }
 }

--- a/test/runtime/system/test_mutex.cpp
+++ b/test/runtime/system/test_mutex.cpp
@@ -21,6 +21,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -41,7 +42,7 @@ struct MutexAcquireContext
  */
 void AcquireMutex(MutexAcquireContext* ctx)
 {
-  ASSERT(ctx->mutex->Lock() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(ctx->mutex->Lock() == LibXR::ErrorCode::OK);
   ctx->acquired->store(true, std::memory_order_release);
   ctx->mutex->Unlock();
   ctx->done->Post();
@@ -64,22 +65,22 @@ void test_mutex()
   std::atomic<bool> acquired(false);
   LibXR::Thread waiter;
 
-  ASSERT(mutex.Lock() == LibXR::ErrorCode::OK);
-  ASSERT(mutex.TryLock() == LibXR::ErrorCode::BUSY);
+  TEST_ASSERT(mutex.Lock() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(mutex.TryLock() == LibXR::ErrorCode::BUSY);
 
   MutexAcquireContext ctx = {&mutex, &acquired, &done};
   waiter.Create<MutexAcquireContext*>(&ctx, AcquireMutex, "mutex_waiter", 1024,
                                       LibXR::Thread::Priority::MEDIUM);
 
   LibXR::Thread::Sleep(20);
-  ASSERT(!acquired.load(std::memory_order_acquire));
+  TEST_ASSERT(!acquired.load(std::memory_order_acquire));
 
   mutex.Unlock();
 
-  ASSERT(done.Wait(500) == LibXR::ErrorCode::OK);
-  ASSERT(waiter.Join() == LibXR::ErrorCode::OK);
-  ASSERT(acquired.load(std::memory_order_acquire));
+  TEST_ASSERT(done.Wait(500) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(waiter.Join() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(acquired.load(std::memory_order_acquire));
 
-  ASSERT(mutex.TryLock() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(mutex.TryLock() == LibXR::ErrorCode::OK);
   mutex.Unlock();
 }

--- a/test/runtime/system/test_semaphore.cpp
+++ b/test/runtime/system/test_semaphore.cpp
@@ -16,6 +16,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_semaphore`。 Test entry function `test_semaphore`.
@@ -30,13 +31,13 @@ void test_semaphore()
   LibXR::Semaphore sem(0);
   LibXR::Thread thread;
 
-  ASSERT(sem.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(sem.Wait(0) == LibXR::ErrorCode::TIMEOUT);
 
   sem.Post();
   sem.Post();
-  ASSERT(sem.Wait(0) == LibXR::ErrorCode::OK);
-  ASSERT(sem.Wait(0) == LibXR::ErrorCode::OK);
-  ASSERT(sem.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(sem.Wait(0) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(sem.Wait(0) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(sem.Wait(0) == LibXR::ErrorCode::TIMEOUT);
 
   thread.Create<LibXR::Semaphore*>(
       &sem,
@@ -48,6 +49,6 @@ void test_semaphore()
       },
       "semaphore_thread", 512, LibXR::Thread::Priority::REALTIME);
 
-  ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
-  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 }

--- a/test/runtime/system/test_thread.cpp
+++ b/test/runtime/system/test_thread.cpp
@@ -19,6 +19,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 /**
  * @brief 测试入口函数 `test_thread`。 Test entry function `test_thread`.
@@ -33,7 +34,7 @@ void test_thread()
   LibXR::Thread thread;
   LibXR::Semaphore sem(0);
 
-  ASSERT(sem.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+  TEST_ASSERT(sem.Wait(0) == LibXR::ErrorCode::TIMEOUT);
 
   thread.Create<LibXR::Semaphore*>(
       &sem,
@@ -44,13 +45,13 @@ void test_thread()
       },
       "test_task", 512, LibXR::Thread::Priority::REALTIME);
 
-  ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
-  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
+  TEST_ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 
   const uint32_t sleep_start_ms = LibXR::Thread::GetTime();
   LibXR::Thread::Sleep(20);
   const uint32_t sleep_elapsed_ms = LibXR::Thread::GetTime() - sleep_start_ms;
-  ASSERT(sleep_elapsed_ms >= 15);
+  TEST_ASSERT(sleep_elapsed_ms >= 15);
 
   LibXR::MillisecondTimestamp wakeup = LibXR::Thread::GetTime();
   const uint32_t periodic_start_ms = wakeup;
@@ -58,7 +59,7 @@ void test_thread()
   const uint32_t first_wakeup_ms = LibXR::Thread::GetTime();
   LibXR::Thread::SleepUntil(wakeup, 10);
   const uint32_t second_wakeup_ms = LibXR::Thread::GetTime();
-  ASSERT(first_wakeup_ms - periodic_start_ms >= 8);
-  ASSERT(second_wakeup_ms - periodic_start_ms >= 18);
-  ASSERT(second_wakeup_ms >= first_wakeup_ms);
+  TEST_ASSERT(first_wakeup_ms - periodic_start_ms >= 8);
+  TEST_ASSERT(second_wakeup_ms - periodic_start_ms >= 18);
+  TEST_ASSERT(second_wakeup_ms >= first_wakeup_ms);
 }

--- a/test/runtime/system/test_timebase.cpp
+++ b/test/runtime/system/test_timebase.cpp
@@ -17,6 +17,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 
 namespace
 {
@@ -61,16 +62,16 @@ void test_timebase()
   end_us = LibXR::Timebase::GetMicroseconds();
   end_ms = LibXR::Timebase::GetMilliseconds();
 
-  ASSERT(std::fabs((end_ms - start_ms).ToMillisecond() - 100.0f) < 10);
-  ASSERT(std::fabs((end_us - start_us).ToMicrosecond() - 100000.0f) < 10000);
+  TEST_ASSERT(std::fabs((end_ms - start_ms).ToMillisecond() - 100.0f) < 10);
+  TEST_ASSERT(std::fabs((end_us - start_us).ToMicrosecond() - 100000.0f) < 10000);
 
   TimebaseWrapProbe::Set(old_max_valid_us, 999u);
-  ASSERT((LibXR::MillisecondTimestamp(3u) - LibXR::MillisecondTimestamp(998u))
-             .ToMillisecond() == 5u);
+  TEST_ASSERT((LibXR::MillisecondTimestamp(3u) - LibXR::MillisecondTimestamp(998u))
+                  .ToMillisecond() == 5u);
 
   TimebaseWrapProbe::Set(999999u, 999u);
-  ASSERT((LibXR::MicrosecondTimestamp(7u) - LibXR::MicrosecondTimestamp(999995u))
-             .ToMicrosecond() == 12u);
+  TEST_ASSERT((LibXR::MicrosecondTimestamp(7u) - LibXR::MicrosecondTimestamp(999995u))
+                  .ToMicrosecond() == 12u);
 
   TimebaseWrapProbe::Set(old_max_valid_us, old_max_valid_ms);
 }

--- a/test/runtime/system/test_timer.cpp
+++ b/test/runtime/system/test_timer.cpp
@@ -17,6 +17,7 @@
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
+#include "test_assert.hpp"
 #include "timer.hpp"
 
 /**
@@ -51,5 +52,5 @@ void test_timer()
     }
   }
 
-  ASSERT(timer_arg == 20);
+  TEST_ASSERT(timer_arg == 20);
 }


### PR DESCRIPTION
统一配置/调用前提、内部开发检查和致命运行错误的断言用途。ASSERT 保留关闭后求值的行为；DEV_ASSERT 默认不求值，仅显式开启时检查；必需资源创建和初始化失败、显式 OrExit 路径使用 REQUIRE。实际队列、状态认领和 HAL 操作位于检查之外，仅检查用变量与参数标记为 [[maybe_unused]]。

1517 处测试结果判断使用始终生效的 TEST_ASSERT。CI 分别完整构建并运行 Debug/DEV_ASSERT=ON、Release/ON、Release/OFF，保留四组合宏测试；严格对象目标强制关闭可选断言，以 -Wall -Werror -Wunused-parameter 编译实际公共模板和 RW 源文件。

一并包含已独立批准并整合的 [#280](https://github.com/Jiu-xiao/libxr/pull/280)：共享内存通知改为二值提示，消费者在等待前清提示并检查实际队列，避免发布与通知之间的计数下溢及漏唤醒。IPC 协议版本由 2 升为 3，拒绝新旧进程混用，不自动删除不匹配的旧段。

两部分分别保留一个提交，组合源码树为 1a3cc5841c5f6e25a54313207bd02742edecfe54，与获审及受测版本一致。两个审核 head 的三种完整 CI、严格编译及格式检查通过；本地组合 Release/OFF runner 通过61组测试。既有竞态的实际函数反例、修复及错误顺序负例、双向版本拒绝已验证。没有新增实机验收结论。
