### PR TITLE
fix(linux): prevent shared topic notification races

### DIFF
--- a/system/linux/linux_shared_topic_impl.hpp
+++ b/system/linux/linux_shared_topic_impl.hpp
@@ -449,7 +449,7 @@ class LinuxSharedTopic : public Topic
         {
           topic.subscribers_[i].queue_head.store(0, std::memory_order_release);
           topic.subscribers_[i].queue_tail.store(0, std::memory_order_release);
-          topic.subscribers_[i].ready_sem_count.store(0, std::memory_order_release);
+          topic.subscribers_[i].ready_signal.store(0, std::memory_order_release);
           topic.subscribers_[i].dropped_messages.store(0, std::memory_order_release);
           topic.subscribers_[i].owner_pid.store(topic.self_identity_.pid,
                                                 std::memory_order_release);
@@ -949,7 +949,8 @@ class LinuxSharedTopic : public Topic
     std::atomic<uint32_t> mode;
     std::atomic<uint32_t> queue_head;
     std::atomic<uint32_t> queue_tail;
-    std::atomic<uint32_t> ready_sem_count;
+    std::atomic<uint32_t>
+        ready_signal;  ///< 唤醒提示，不表示队列长度 / Wake hint, not size.
     std::atomic<uint64_t> dropped_messages;
     std::atomic<uint32_t> owner_pid;
     std::atomic<uint64_t> owner_starttime;
@@ -968,7 +969,7 @@ class LinuxSharedTopic : public Topic
   };
 
   static constexpr uint64_t MAGIC = 0x4c58524950435348ULL;
-  static constexpr uint32_t VERSION = 2;
+  static constexpr uint32_t VERSION = 3;
   static constexpr uint32_t INIT_READY = 1;
   static constexpr uint32_t INVALID_INDEX = UINT32_MAX;
 
@@ -1261,7 +1262,7 @@ class LinuxSharedTopic : public Topic
           std::memory_order_release);
       subscribers_[i].queue_head.store(0, std::memory_order_release);
       subscribers_[i].queue_tail.store(0, std::memory_order_release);
-      subscribers_[i].ready_sem_count.store(0, std::memory_order_release);
+      subscribers_[i].ready_signal.store(0, std::memory_order_release);
       subscribers_[i].dropped_messages.store(0, std::memory_order_release);
       subscribers_[i].owner_pid.store(0, std::memory_order_release);
       subscribers_[i].owner_starttime.store(0, std::memory_order_release);
@@ -1637,20 +1638,19 @@ class LinuxSharedTopic : public Topic
 
   static void PostReady(SubscriberControl& control)
   {
-    control.ready_sem_count.fetch_add(1, std::memory_order_release);
-    FutexWake(&control.ready_sem_count);
+    control.ready_signal.store(1, std::memory_order_release);
+    FutexWake(&control.ready_signal);
   }
 
-  static void ConsumeReady(SubscriberControl& control)
+  static bool HasQueuedData(const SubscriberControl& control)
   {
-    [[maybe_unused]] const uint32_t prev =
-        control.ready_sem_count.fetch_sub(1, std::memory_order_acq_rel);
-    DEV_ASSERT(prev > 0);
+    return control.queue_head.load(std::memory_order_acquire) !=
+           control.queue_tail.load(std::memory_order_acquire);
   }
 
   static ErrorCode WaitReady(SubscriberControl& control, uint32_t timeout_ms)
   {
-    if (control.ready_sem_count.load(std::memory_order_acquire) != 0)
+    if (HasQueuedData(control))
     {
       return ErrorCode::OK;
     }
@@ -1660,7 +1660,10 @@ class LinuxSharedTopic : public Topic
 
     while (true)
     {
-      if (control.ready_sem_count.load(std::memory_order_acquire) != 0)
+      // 先清提示再检查队列，覆盖检查与进入 futex 等待之间的发布。
+      // Clear the hint before checking the queue so a later publication prevents sleep.
+      control.ready_signal.exchange(0, std::memory_order_acq_rel);
+      if (HasQueuedData(control))
       {
         return ErrorCode::OK;
       }
@@ -1677,7 +1680,7 @@ class LinuxSharedTopic : public Topic
 
       wait_ms = MonotonicTime::WaitSliceMilliseconds(wait_ms);
 
-      const int futex_ans = FutexWait(&control.ready_sem_count, 0, wait_ms);
+      const int futex_ans = FutexWait(&control.ready_signal, 0, wait_ms);
       if (futex_ans == 0 || errno == EAGAIN || errno == EINTR)
       {
         continue;
@@ -1690,7 +1693,7 @@ class LinuxSharedTopic : public Topic
           continue;
         }
         if (MonotonicTime::RemainingMilliseconds(deadline_ms) == 0 &&
-            control.ready_sem_count.load(std::memory_order_acquire) == 0)
+            !HasQueuedData(control))
         {
           return ErrorCode::TIMEOUT;
         }
@@ -1763,7 +1766,6 @@ class LinuxSharedTopic : public Topic
       if (control.queue_head.compare_exchange_weak(
               head, next_head, std::memory_order_acq_rel, std::memory_order_relaxed))
       {
-        ConsumeReady(control);
         return ErrorCode::OK;
       }
     }
@@ -1789,7 +1791,6 @@ class LinuxSharedTopic : public Topic
               head, next_head, std::memory_order_acq_rel, std::memory_order_relaxed))
       {
         control.dropped_messages.fetch_add(1, std::memory_order_relaxed);
-        ConsumeReady(control);
         ReleaseSlot(descriptor.slot_index);
         return ErrorCode::OK;
       }

--- a/test/linux_shm/test_attach_queue.cpp
+++ b/test/linux_shm/test_attach_queue.cpp
@@ -3,6 +3,8 @@
  * @brief `LinuxSharedTopic` attach/queue 语义子验证。 Split verification unit for
  * `LinuxSharedTopic` attach and queue semantics.
  */
+#include <thread>
+
 #include "linux_shm_topic_test_common.hpp"
 #include "test_assert.hpp"
 
@@ -86,6 +88,25 @@ void RunAttachQueueScenarios()
                 static_cast<uint64_t>(timestamp2));
     TEST_ASSERT(subscriber.GetPendingNum() == 0);
     subscriber.Release();
+
+    // 消费完一批消息后，旧唤醒提示不能被当成仍有消息。
+    // A wake hint left by a drained batch must not report another message.
+    TEST_ASSERT(subscriber.Wait(2) == LibXR::ErrorCode::TIMEOUT);
+    std::thread next_publish(
+        [&publisher]()
+        {
+          LibXR::Thread::Sleep(10);
+          SharedData next;
+          TEST_ASSERT(publisher.CreateData(next) == LibXR::ErrorCode::OK);
+          FillFrame(*next.GetData(), 103);
+          TEST_ASSERT(publisher.Publish(next) == LibXR::ErrorCode::OK);
+        });
+    const auto wait_result = subscriber.Wait(LONG_WAIT_MS);
+    next_publish.join();
+    TEST_ASSERT(wait_result == LibXR::ErrorCode::OK);
+    AssertFrame(*subscriber.GetData(), 103);
+    subscriber.Release();
+    TEST_ASSERT(subscriber.Wait(2) == LibXR::ErrorCode::TIMEOUT);
   }
   // BROADCAST_FULL should fail publish when the subscriber queue is saturated.
   UNUSED(SharedTopic::Remove(topic_name));


### PR DESCRIPTION
消费者可能在队列描述符已经发布、通知计数尚未增加时取走消息，把通知计数从零减成 UINT32_MAX。将通知改为二值提示，等待前先清提示再检查队列，入睡时由 futex 比较标志，避免检查与等待之间漏掉发布。消费和丢弃不再递减通知量，队列是否有数据仍由 head/tail 决定。

共享内存协议版本从 2 升至 3：字段布局没有增加，但通知字段含义改变，新旧进程必须协调升级。旧版本段按既有 CHECK_ERR 路径拒绝，不自动删除；停止旧参与者后，由应用管理旧段清理。

验证：基线实际函数的发布/通知窗口稳定失败，修复后通过；真实函数加受控调度覆盖旧提示、检查后发布、futex 等待和超时，故意把清提示移到检查之后的负例仍失败；22 状态的有限交错模型未发现漏唤醒，错误顺序模型给出反例。实际跨进程测试确认 v2/v3 双向拒绝且原数据仍可读取。增加消费完成后空等待、下一次发布和再次超时的公共 API 回归用例，组合树的 Debug/Release/开发检查关闭三种完整 runner 均通过。

此 PR 基于断言整理 [#279](https://github.com/Jiu-xiao/libxr/pull/279) 分支，仅包含通知修复及对应测试两个文件；队列、槽位回收及其他 IPC 生命周期机制未重新设计。受控函数测试和有限模型不等同整个共享内存实现的完整并发证明。

## Sourcery 摘要

修复 Linux 共享主题通知竞争问题，并使共享内存协议与修正后的唤醒语义保持一致。

错误修复：
- 通过将唤醒提示与队列占用状态分离，并协调通知等待与队列状态，防止 Linux 共享主题通知处理中的唤醒丢失竞争。
- 停止因错误递减通知状态而消费或丢弃消息，防止出现过期或下溢的通知。

增强功能：
- 将共享内存协议版本升级到 3，以反映通知语义的变化，并要求参与进程协同升级。

测试：
- 为共享主题 API 增加针对队列耗尽、后续发布以及超时行为的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Linux shared-topic notification races and align the shared-memory protocol with the corrected wakeup semantics.

Bug Fixes:
- Prevent lost-wakeup races in Linux shared-topic notification handling by separating wake hints from queue occupancy and coordinating notification waits with queue state.
- Stop consuming or discarding messages from incorrectly decrementing notification state, preventing stale or underflowed notifications.

Enhancements:
- Advance the shared-memory protocol version to 3 to reflect the changed notification semantics and require coordinated upgrades between participating processes.

Tests:
- Add regression coverage for drained queues, subsequent publications, and timeout behavior in the shared-topic API.

</details>