### PR TITLE
fix(terminal): explicitly discard best-effort commit results

### DIFF
--- a/src/middleware/terminal/command.hpp
+++ b/src/middleware/terminal/command.hpp
@@ -221,7 +221,8 @@ void ExecuteCommand()
     return;
   }
 
-  write_stream_.Commit();
+  // 输出尽力提交后执行命令 / Commit output on a best-effort basis before running it.
+  (void)write_stream_.Commit();
   write_mutex_->Unlock();
   ans->Run(arg_number_, arg_tab_);
   write_mutex_->Lock();

--- a/src/middleware/terminal/driver.hpp
+++ b/src/middleware/terminal/driver.hpp
@@ -27,7 +27,7 @@ static void ThreadFun(Terminal* term)
     {
       term->write_mutex_->Lock();
       term->Parse(buffer);
-      term->write_stream_.Commit();
+      (void)term->write_stream_.Commit();
       term->write_mutex_->Unlock();
     }
   }
@@ -74,7 +74,7 @@ static void TaskFun(Terminal* term)
         term->write_mutex_->Lock();
         auto buffer = RawData(term->read_buff_, term->request_read_size_);
         term->Parse(buffer);
-        term->write_stream_.Commit();
+        (void)term->write_stream_.Commit();
         term->write_mutex_->Unlock();
         start_read();
         return;


### PR DESCRIPTION
Terminal 的线程输入、轮询输入和命令执行三个路径直接忽略了带有 [[nodiscard]] 的 Stream::Commit() 返回值，导致模板实例化时反复出现 -Wunused-result 警告。

用显式 `(void)` 弃值表达现有的尽力输出语义，继续执行原来的输入和命令流程。提交操作仍执行一次，不添加重试或致命错误处理。修改仅涉及 driver.hpp 和 command.hpp。

验证：在 Debug/DEV_ASSERT=ON、Release/ON、Release/OFF 三种配置下，以 -Werror=unused-result 显式实例化完整 Terminal 模板；原版均失败，修复版均通过。现有 Terminal 命令、显示、输入、集成四组测试通过，格式与 diff 检查通过。本次没有重跑三套完整测试或进行实机验证。

## Sourcery 摘要

Bug 修复：
- 显式丢弃尽力而为的终端输出提交结果，以避免未使用结果警告，同时保留现有的输入和命令执行行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Explicitly discard best-effort terminal output commit results to prevent unused-result warnings while preserving existing input and command execution behavior.

</details>