### PR TITLE
test: add manual GPIO loopback and interrupt checks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 目前仍只有说明。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) currently contains instructions only.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO 接线测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides wired GPIO tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前还没有测试代码，也不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. It has no test code yet and is not run by CI.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/gpio/README.md
+++ b/test/manual/driver/gpio/README.md
@@ -1,0 +1,63 @@
+# GPIO 手动测试 / Manual GPIO tests
+
+用一根线连接两个专用引脚：一个推挽输出，一个输入。测试检查高低电平回读，以及上升沿、下降沿或双沿中断。未测试开漏、内部上下拉的电气特性。
+
+Connect two dedicated pins with a wire: one push-pull output and one input. The tests check level readback and rising, falling or both-edge interrupts. Open-drain and internal pull resistor electrical behavior are not tested.
+
+## 接线和准备 / Wiring and setup
+
+两个引脚必须是不同的物理引脚，电压兼容、共地，没有其他输出驱动这条线。先初始化系统和 GPIO 对象，再从普通任务调用测试；不要从 ISR 或 GPIO 回调中调用。
+
+Use distinct physical pins with compatible voltages and a common ground. No other output may drive the wire. Initialize the system and GPIO objects first, then call from a normal task, never from an ISR or GPIO callback.
+
+读写测试要求输入中断关闭。中断测试还要求输入支持所选边沿，已配置有效中断资源，没有旧挂起事件或在途回调。测试期间独占这些引脚及中断资源；共享中断组的其他设备也不能使用它。
+
+Disable input interrupts before the loopback test. The interrupt test additionally requires support for the selected edge, a valid interrupt resource, and no old pending events or callbacks in progress. Reserve the pins and interrupt resources for the test, including any shared interrupt group.
+
+## 调用 / Usage
+
+把 `test/` 和 `test/manual/driver/` 加入应用的头文件搜索路径。只需包含头文件，无需另加测试源文件或执行器。
+
+Add `test/` and `test/manual/driver/` to the application include paths. Include the header; no extra test source or runner is needed.
+
+```cpp
+#include "gpio/test_gpio.hpp"
+
+// 只调用一次；两个 GPIO 对象由应用保留到复位。
+// Call once; the application retains both GPIO objects until reset.
+void RunGPIOTests(LibXR::GPIO& output, LibXR::GPIO& input)
+{
+  LibXR::Test::TestGPIO(output, input);
+
+  // MCU ISR 回调填 true；线程派发回调的平台（如 Linux）填 false。
+  // Use true for MCU ISR callbacks, false for task dispatch such as Linux.
+  static LibXR::Test::GPIOInterruptTest irq_test(output, input, true);
+  irq_test.Run(LibXR::GPIO::Direction::FALL_RISING_INTERRUPT);
+}
+```
+
+`TestGPIO(output, input, settle_ms, timeout_ms, iterations)` 每轮检查低、高电平。`GPIOInterruptTest::Run(edge, settle_ms, timeout_ms, iterations)` 每轮检查所选边沿应出现的回调和另一边沿不应出现的回调；双沿模式每轮应有两次回调。随后禁用中断，再翻转同样多轮，检查没有新回调。
+
+`TestGPIO(output, input, settle_ms, timeout_ms, iterations)` checks low and high levels each round. `GPIOInterruptTest::Run(edge, settle_ms, timeout_ms, iterations)` checks expected and unwanted callbacks for the selected edges; both-edge mode expects two callbacks per round. It then disables interrupts and repeats the toggles for the same number of rounds, checking for no new callbacks.
+
+两项默认各运行 1000 轮，最后一个参数填 1 可快速检查。中断模式也可选择 `RISING_INTERRUPT` 或 `FALL_INTERRUPT`，每次初始化只测一种模式，不要在同一个对象上连续调用 `Run()`。
+
+Both default to 1000 rounds; set the last argument to 1 for a quick check. Select `RISING_INTERRUPT` or `FALL_INTERRUPT` to check a single edge. Test one mode per initialization; do not call `Run()` repeatedly on the same object.
+
+`settle_ms` 默认 1 ms，控制电平稳定后的复查和多余回调的观察间隔；`timeout_ms` 默认 1000 ms，是每次等待电平或回调的上限，不是整项测试的总时限。调度较慢时可增加这两个值。这些有限观察不能证明以后永远没有迟到回调，也不测最高翻转频率。
+
+`settle_ms` defaults to 1 ms and controls level rechecks and observation for extra callbacks. `timeout_ms` defaults to 1000 ms and bounds each level or callback wait, not the whole test. Increase them for slower scheduling. These bounded observations cannot rule out all later callbacks and do not measure maximum toggle frequency.
+
+## 结束状态 / After the test
+
+检查失败会触发始终生效的 `TEST_ASSERT` 并立即停止。中断回调只写原子计数，检查和报错在调用线程进行。
+
+A failed check triggers the always-active `TEST_ASSERT` and stops immediately. Interrupt callbacks only record atomic values; checks and diagnostics run in the calling thread.
+
+正常返回后输出保持低电平。读写测试留下普通输入；中断测试留下关闭的中断和已注册的回调，不恢复原配置。GPIO 没有等待在途回调结束的接口，因此两个 GPIO 和中断测试对象都要保持地址不变并保留到复位。
+
+On success, the output stays low. The loopback test leaves a normal input; the interrupt test leaves interrupts disabled and its callback registered. Neither restores the original configuration. GPIO has no API to wait for in-flight callbacks, so retain both GPIO objects and the interrupt test object at stable addresses until reset.
+
+禁用期间的边沿可能留下硬件挂起位。再次使用该输入中断前，由平台初始化代码清理挂起状态或重新初始化；测试不会直接重新使能它。
+
+Edges while disabled may leave hardware pending bits. Have platform setup clear pending state or reinitialize the input before using its interrupt again; the test does not re-enable it.

--- a/test/manual/driver/gpio/test_gpio.hpp
+++ b/test/manual/driver/gpio/test_gpio.hpp
@@ -1,0 +1,190 @@
+/**
+ * @file test_gpio.hpp
+ * @brief GPIO 接线回环与边沿中断测试 / Wired GPIO loopback and edge interrupt tests.
+ *
+ * 用两个专用引脚检查高低电平、指定边沿的回调次数、回调上下文和中断禁用。
+ * Check levels, selected edge counts, callback context and interrupt disabling using
+ * two dedicated pins wired together. Keep the interrupt test object until reset.
+ */
+#pragma once
+
+#include <atomic>
+
+#include "gpio.hpp"
+#include "test_assert.hpp"
+#include "thread.hpp"
+
+namespace LibXR::Test
+{
+namespace Detail
+{
+inline void WaitForGPIOLevel(GPIO& input, bool level, uint32_t settle_ms,
+                             uint32_t timeout_ms)
+{
+  const uint32_t start = Thread::GetTime();
+  while (input.Read() != level)
+  {
+    TEST_ASSERT(Thread::GetTime() - start < timeout_ms);
+    Thread::Sleep(1);
+  }
+  // 到达目标电平后再观察一次，避免只检查到短暂跳变。
+  // Check again after settling rather than accepting only a transient level.
+  Thread::Sleep(settle_ms);
+  TEST_ASSERT(input.Read() == level);
+}
+}  // namespace Detail
+
+/**
+ * @brief 反复检查推挽输出到输入的接线回环 / Repeatedly check push-pull loopback.
+ * @pre 两个不同的物理引脚已连接且专供测试，输入中断未启用。从普通任务调用。
+ *      Wire two distinct, dedicated pins together; leave input interrupts disabled.
+ *      Call from normal task context.
+ * @param output 输出引脚 / Output pin.
+ * @param input 输入引脚 / Input pin.
+ * @param settle_ms 电平稳定后的观察间隔 / Observation interval after reaching the level.
+ * @param timeout_ms 每次等待电平的上限 / Deadline for each level wait.
+ * @param iterations 高低电平循环次数 / Number of low/high cycles.
+ */
+inline void TestGPIO(GPIO& output, GPIO& input, uint32_t settle_ms = 1,
+                     uint32_t timeout_ms = 1000, uint32_t iterations = 1000)
+{
+  TEST_ASSERT(&output != &input && iterations > 0);
+  TEST_ASSERT(settle_ms > 0 && settle_ms < timeout_ms && timeout_ms < UINT32_MAX / 2U);
+  TEST_ASSERT(input.SetConfig({GPIO::Direction::INPUT, GPIO::Pull::NONE}) ==
+              ErrorCode::OK);
+  TEST_ASSERT(output.SetConfig({GPIO::Direction::OUTPUT_PUSH_PULL, GPIO::Pull::NONE}) ==
+              ErrorCode::OK);
+  for (uint32_t i = 0; i < iterations; ++i)
+  {
+    output.Write(false);
+    Detail::WaitForGPIOLevel(input, false, settle_ms, timeout_ms);
+    output.Write(true);
+    Detail::WaitForGPIOLevel(input, true, settle_ms, timeout_ms);
+  }
+  output.Write(false);
+  Detail::WaitForGPIOLevel(input, false, settle_ms, timeout_ms);
+}
+
+/**
+ * @brief 长期保留的 GPIO 中断测试对象 / Caller-retained GPIO interrupt test object.
+ * @pre 引脚及本对象保留到复位，地址不变。输入中断资源须独占、无在途回调及旧挂起事件。
+ *      Retain the pins and this object at stable addresses until reset. Reserve the
+ *      input interrupt resource exclusively, with no active callback or old pending
+ * event.
+ */
+class GPIOInterruptTest
+{
+ public:
+  /**
+   * @param expected_in_isr 预期回调是否在 ISR 中执行 / Whether callbacks should run in
+   * ISR.
+   */
+  GPIOInterruptTest(GPIO& output, GPIO& input, bool expected_in_isr)
+      : output_(output), input_(input), expected_in_isr_(expected_in_isr)
+  {
+  }
+  GPIOInterruptTest(const GPIOInterruptTest&) = delete;
+  GPIOInterruptTest& operator=(const GPIOInterruptTest&) = delete;
+
+  /**
+   * @brief 检查指定边沿及禁用后的回调次数 / Check selected edges and disabled callbacks.
+   * @pre 从普通任务调用，每个对象只运行一次。结束后中断关闭，回调保持注册。
+   *      Call once per object from normal task context. Leaves interrupts disabled
+   *      and the callback registered.
+   * @param edge 上升沿、下降沿或双沿 / Rising, falling or both edges.
+   * @param settle_ms 无额外回调的观察间隔 / Observation interval for extra callbacks.
+   * @param timeout_ms 每次电平或回调等待的上限 / Deadline for each level or callback
+   * wait.
+   * @param iterations 启用和禁用阶段各自的循环次数 / Cycles in each enabled/disabled
+   * phase.
+   */
+  void Run(GPIO::Direction edge = GPIO::Direction::FALL_RISING_INTERRUPT,
+           uint32_t settle_ms = 1, uint32_t timeout_ms = 1000, uint32_t iterations = 1000)
+  {
+    TEST_ASSERT(&output_ != &input_ && iterations > 0 && iterations <= UINT32_MAX / 2U);
+    TEST_ASSERT(settle_ms > 0 && settle_ms < timeout_ms && timeout_ms < UINT32_MAX / 2U);
+    TEST_ASSERT(edge == GPIO::Direction::RISING_INTERRUPT ||
+                edge == GPIO::Direction::FALL_INTERRUPT ||
+                edge == GPIO::Direction::FALL_RISING_INTERRUPT);
+    TEST_ASSERT(input_.DisableInterrupt() == ErrorCode::OK);
+    TEST_ASSERT(input_.SetConfig({GPIO::Direction::INPUT, GPIO::Pull::NONE}) ==
+                ErrorCode::OK);
+    TEST_ASSERT(output_.SetConfig({GPIO::Direction::OUTPUT_PUSH_PULL,
+                                   GPIO::Pull::NONE}) == ErrorCode::OK);
+    const bool initial = edge == GPIO::Direction::FALL_INTERRUPT;
+    output_.Write(initial);
+    Detail::WaitForGPIOLevel(input_, initial, settle_ms, timeout_ms);
+
+    // 先稳定电平并绑定回调；部分平台配置边沿时就会启用中断。
+    // Stabilize the line and bind first; some platforms enable IRQs in SetConfig.
+    auto callback = GPIO::Callback::Create(
+        [](bool in_isr, GPIOInterruptTest* self)
+        {
+          if (in_isr != self->expected_in_isr_)
+          {
+            self->bad_context_.store(1, std::memory_order_relaxed);
+          }
+          self->calls_.fetch_add(1, std::memory_order_release);
+        },
+        this);
+    TEST_ASSERT(input_.RegisterCallback(callback) == ErrorCode::OK);
+    TEST_ASSERT(input_.SetConfig({edge, GPIO::Pull::NONE}) == ErrorCode::OK);
+    TEST_ASSERT(input_.EnableInterrupt() == ErrorCode::OK);
+    uint32_t expected = 0;
+    CheckCalls(expected, settle_ms, timeout_ms);
+    for (uint32_t i = 0; i < iterations; ++i)
+    {
+      output_.Write(!initial);
+      Detail::WaitForGPIOLevel(input_, !initial, settle_ms, timeout_ms);
+      CheckCalls(++expected, settle_ms, timeout_ms);
+      output_.Write(initial);
+      Detail::WaitForGPIOLevel(input_, initial, settle_ms, timeout_ms);
+      if (edge == GPIO::Direction::FALL_RISING_INTERRUPT)
+      {
+        ++expected;
+      }
+      CheckCalls(expected, settle_ms, timeout_ms);
+    }
+
+    TEST_ASSERT(input_.DisableInterrupt() == ErrorCode::OK);
+    for (uint32_t i = 0; i < iterations; ++i)
+    {
+      output_.Write(true);
+      Detail::WaitForGPIOLevel(input_, true, settle_ms, timeout_ms);
+      CheckCalls(expected, settle_ms, timeout_ms);
+      output_.Write(false);
+      Detail::WaitForGPIOLevel(input_, false, settle_ms, timeout_ms);
+      CheckCalls(expected, settle_ms, timeout_ms);
+    }
+    // 保持禁用；禁用期间的边沿可能留下挂起位，不能直接重新启用。
+    // Leave disabled: masked edges may latch pending bits, so do not re-enable here.
+  }
+
+ private:
+  void CheckCalls(uint32_t expected, uint32_t settle_ms, uint32_t timeout_ms)
+  {
+    const uint32_t start = Thread::GetTime();
+    for (;;)
+    {
+      const uint32_t calls = calls_.load(std::memory_order_acquire);
+      TEST_ASSERT(bad_context_.load(std::memory_order_relaxed) == 0);
+      TEST_ASSERT(calls <= expected);
+      if (calls == expected)
+      {
+        break;
+      }
+      TEST_ASSERT(Thread::GetTime() - start < timeout_ms);
+      Thread::Sleep(1);
+    }
+    Thread::Sleep(settle_ms);
+    TEST_ASSERT(calls_.load(std::memory_order_acquire) == expected);
+    TEST_ASSERT(bad_context_.load(std::memory_order_relaxed) == 0);
+  }
+
+  GPIO& output_;
+  GPIO& input_;
+  const bool expected_in_isr_;
+  std::atomic<uint32_t> calls_{0};
+  std::atomic<uint32_t> bad_context_{0};
+};
+}  // namespace LibXR::Test


### PR DESCRIPTION
Adds the first callable manual driver tests under `test/manual/driver/gpio/`, using two caller-provided GPIO pins wired output to input.

- `TestGPIO` repeatedly checks push-pull low/high readback.
- `GPIOInterruptTest` checks rising, falling or both-edge callback counts, the caller-specified callback context, and absence of new callbacks after disabling interrupts. Default 1000 rounds, adjustable as the last argument.
- Tests use public LibXR APIs and the shared `TEST_ASSERT`. The interrupt callback only records atomics. GPIO objects and the interrupt fixture must remain alive at stable addresses until reset; run one selected mode per initialization.
- Bilingual comments and local documentation explain wiring, parameters and final state. No product, CI or BSP changes; manual tests are not run by CI.

Validation: Linux Release/DEV_ASSERT=OFF product build and host behavioral fixture passed 18 expected outcomes, including 1000-round normal paths, delayed callbacks and deliberately broken inputs/callback delivery. A fixture that drops every 64th callback passes one round and fails 128 rounds. The fixture is kept outside the repository. This validates the test logic, not GPIO hardware or real ISR behavior.

The test header compiled with `-Wall -Wextra -Werror`, except that the existing `libxr_string.hpp:658` missing-field-initializers warning was retained as a warning. clang-format 21.1.8 and diff checks passed. On-board validation is recorded below.
Hardware validation (STM32G0B1CBT6, PB10 output wired to PB2 input): the unchanged PR head completed 1000 loopback cycles and 1000 interrupt cycles per fresh boot for rising, falling and both-edge modes. Actual callback counts were 1000/1000/2000, with no wrong-context flags. Each mode then completed 1000 disabled-interrupt cycles without extra callbacks. Results were read via SWD after free-running execution. Board remains on the completed both-edge firmware, output low and input IRQ disabled.

The isolated BSP test app supplies the missing EXTI2_3 HAL forwarding handler and initializes the dedicated pins/interrupt resource; it is not included in this PR. ARM GNU 14.2.1 Debug with developer assertions ON. This is specific G0B1 hardware evidence, not coverage of every backend.