### PR TITLE
test: add manual PWM waveform checks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO 接线测试。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides wired GPIO tests.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM 接线测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides wired GPIO and PWM tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)，不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)及 [PWM 回读测试](pwm/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md) are available. CI does not run them.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md) and [PWM readback tests](pwm/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/pwm/README.md
+++ b/test/manual/driver/pwm/README.md
@@ -1,0 +1,54 @@
+# PWM 手动测试 / Manual PWM test
+
+把 PWM 输出接到一个 GPIO 输入，用软件回读检查波形。测试只使用 `PWM`、`GPIO` 和 `Timebase` 公共接口，不创建线程，不注册中断回调，也不由 CI 自动运行。
+
+Connect a PWM output to a GPIO input and check the waveform by polling. The test uses only the public `PWM`, `GPIO` and `Timebase` APIs. It creates no threads or interrupt callbacks and is not run automatically by CI.
+
+## 接线和准备 / Wiring and setup
+
+使用电压兼容、共地的两个专用引脚，不要连接电机或其他负载。输出应为高电平有效的普通 PWM，输入须支持内部下拉，且输入中断已关闭。调用方初始化 PWM 通道和微秒时间基，并独占整个 PWM 定时器，避免改频率影响其他通道。
+
+Use two dedicated pins with compatible voltages and a common ground, without a motor or other load. Use active-high PWM and an input supporting internal pull-down, with input interrupts disabled. Initialize the PWM channel and microsecond timebase, and reserve the whole PWM timer so frequency changes cannot affect other channels.
+
+## 调用 / Usage
+
+把 `test/` 和 `test/manual/driver/` 加入应用的头文件搜索路径，从普通任务调用：
+
+Add `test/` and `test/manual/driver/` to the application's include paths and call from a normal task:
+
+```cpp
+#include "pwm/test_pwm.hpp"
+
+void RunPWMTest(LibXR::PWM& pwm, LibXR::GPIO& input)
+{
+  LibXR::Test::TestPWM(pwm, input);
+}
+```
+
+完整参数为 `TestPWM(pwm, input, frequency_hz, tolerance_us, iterations)`：
+
+The full call is `TestPWM(pwm, input, frequency_hz, tolerance_us, iterations)`:
+
+| 参数 / Argument | 默认 / Default | 含义 / Meaning |
+| --- | --- | --- |
+| `frequency_hz` | 100 | 检查此频率及两倍频率 / Test this frequency and twice this value |
+| `tolerance_us` | 100 | 周期和高电平时间的绝对误差上限 / Absolute tolerance for period and high time |
+| `iterations` | 100 | 完整轮数；填 1 可快速检查 / Complete rounds; use 1 for a quick check |
+
+每轮在两个频率下分别检查 25%、50%、75% 占空比，测量相邻的上升、下降、上升沿；再检查 0% 恒低、100% 恒高，以及禁用后停止跳变、重新启用后恢复 50% 波形。每次更新后固定等待两个周期，不会重试失败的测量。
+
+Each round checks 25%, 50% and 75% duty at both frequencies by measuring consecutive rising, falling and rising edges. It then checks constant low at 0%, constant high at 100%, no transitions after disabling, and restoration of a 50% waveform after re-enabling. Every update gets a fixed two-cycle settling interval; failed measurements are not retried.
+
+## 测量限制与结束状态 / Measurement limits and final state
+
+这是低频轮询测试。测试期间不要让其他工作长时间抢占调用任务；采样间隔必须远小于最短高／低电平时间。容差应在测试前按时间基精度和调度延迟确定，最多为较短周期的 5%。如果平台无法满足采样要求，应改用外部仪器，不能靠不断放宽容差取得通过结果。
+
+This is a low-frequency polling test. Avoid long preemptions of the calling task; the sampling interval must be much shorter than the shortest high/low interval. Choose the tolerance before testing from timebase precision and scheduling latency, up to 5% of the shorter period. Use external equipment if the platform cannot sample fast enough, rather than repeatedly increasing the tolerance until it passes.
+
+时间以 LibXR 时间基为参照；若它与 PWM 共用时钟，测试不能校准该时钟的绝对频率。测试不测最高频率、细小毛刺、互补输出或死区。
+
+Timing is relative to the LibXR timebase. If it shares the PWM clock, the test cannot calibrate that clock's absolute frequency. It does not measure maximum frequency, narrow glitches, complementary outputs or dead time.
+
+失败触发始终生效的 `TEST_ASSERT` 并停止。正常返回前设置 0% 并禁用输出，输入保留下拉配置；不恢复原频率和占空比。禁用输出可能保持某个电平或变为高阻，测试只要求停止周期跳变。
+
+A failure triggers the always-active `TEST_ASSERT` and stops. On success, duty is set to 0% and output is disabled; the input retains its pull-down. The original frequency and duty are not restored. A disabled output may hold a level or become high-impedance; the test only requires periodic transitions to stop.

--- a/test/manual/driver/pwm/test_pwm.hpp
+++ b/test/manual/driver/pwm/test_pwm.hpp
@@ -1,0 +1,127 @@
+/**
+ * @file test_pwm.hpp
+ * @brief PWM 接线回读测试 / Wired PWM readback test.
+ *
+ * 用 GPIO 轮询测量两种频率下的周期和高电平时间，检查 0%/100% 占空比及启停。
+ * Poll a GPIO to measure period and high time at two frequencies; check 0%/100%
+ * duty cycles and disabling/re-enabling. Intended for low-frequency signals.
+ */
+#pragma once
+
+#include "gpio.hpp"
+#include "pwm.hpp"
+#include "test_assert.hpp"
+#include "timebase.hpp"
+
+namespace LibXR::Test
+{
+/**
+ * @brief 反复检查 PWM 波形、占空比和启停 / Repeatedly check PWM timing, duty and enable.
+ * @pre 输出接专用输入，PWM 高电平有效，输入支持下拉且中断已关闭。独占 PWM 定时器。
+ *      Connect active-high PWM to a dedicated input supporting pull-down, with its
+ *      interrupts disabled. Reserve the PWM timer exclusively.
+ * @pre 微秒时间基已初始化。从普通任务调用；采样和抢占延迟须远小于最短脉宽。
+ *      Initialize the microsecond timebase. Call from normal task context; sampling
+ *      and preemption delays must be much shorter than the shortest pulse.
+ * @param output 已初始化的 PWM / Initialized PWM output.
+ * @param input 接线回读输入 / Wired readback input.
+ * @param frequency_hz 测试此频率及其两倍 / Test this frequency and twice this value.
+ * @param tolerance_us 周期及高电平时间的绝对误差上限 / Absolute period/high-time
+ * tolerance.
+ * @param iterations 完整测试轮数 / Number of complete rounds.
+ */
+inline void TestPWM(PWM& output, GPIO& input, uint32_t frequency_hz = 100,
+                    uint32_t tolerance_us = 100, uint32_t iterations = 100)
+{
+  TEST_ASSERT(Timebase::IsReady() && iterations > 0);
+  TEST_ASSERT(frequency_hz > 0 && frequency_hz <= 500000U);
+  TEST_ASSERT(tolerance_us > 0 && tolerance_us <= (1000000U / (frequency_hz * 2U)) / 20U);
+  TEST_ASSERT(input.SetConfig({GPIO::Direction::INPUT, GPIO::Pull::DOWN}) ==
+              ErrorCode::OK);
+
+  auto elapsed = [](MicrosecondTimestamp start)
+  { return (Timebase::GetMicroseconds() - start).ToMicrosecond(); };
+  auto settle = [&](uint32_t period_us)
+  {
+    const auto start = Timebase::GetMicroseconds();
+    // 预装载寄存器可能在下个周期更新，测量前固定等待两个周期。
+    // Preloaded values may update next cycle; always settle for two cycles.
+    while (elapsed(start) < 2U * period_us)
+    {
+    }
+  };
+  auto wait_level = [&](bool level, uint32_t period_us)
+  {
+    const auto start = Timebase::GetMicroseconds();
+    while (input.Read() != level)
+    {
+      TEST_ASSERT(elapsed(start) < 2U * period_us);
+    }
+    return Timebase::GetMicroseconds();
+  };
+  auto check_stable = [&](bool level, uint32_t period_us)
+  {
+    const auto start = Timebase::GetMicroseconds();
+    do
+    {
+      TEST_ASSERT(input.Read() == level);
+    } while (elapsed(start) < 2U * period_us);
+  };
+  auto check_time = [&](uint64_t actual, uint32_t expected)
+  {
+    const uint64_t error = actual > expected ? actual - expected : expected - actual;
+    TEST_ASSERT(error <= tolerance_us);
+  };
+  auto check_waveform = [&](uint32_t period_us, uint32_t duty_percent)
+  {
+    // 先同步到低电平，再取相邻的上升、下降、上升沿；不重试失败的周期。
+    // Synchronize low, then capture consecutive rising/falling/rising edges; no retries.
+    wait_level(false, period_us);
+    const auto rise = wait_level(true, period_us);
+    const auto fall = wait_level(false, period_us);
+    const auto next_rise = wait_level(true, period_us);
+    check_time((next_rise - rise).ToMicrosecond(), period_us);
+    check_time((fall - rise).ToMicrosecond(), period_us * duty_percent / 100U);
+  };
+
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    for (uint32_t multiplier = 1; multiplier <= 2; ++multiplier)
+    {
+      const uint32_t frequency = frequency_hz * multiplier;
+      const uint32_t period_us = 1000000U / frequency;
+      TEST_ASSERT(output.Disable() == ErrorCode::OK);
+      TEST_ASSERT(output.SetConfig({frequency}) == ErrorCode::OK);
+      TEST_ASSERT(output.SetDutyCycle(0.25f) == ErrorCode::OK);
+      TEST_ASSERT(output.Enable() == ErrorCode::OK);
+      for (uint32_t duty = 25; duty <= 75; duty += 25)
+      {
+        TEST_ASSERT(output.SetDutyCycle(static_cast<float>(duty) / 100.0f) ==
+                    ErrorCode::OK);
+        settle(period_us);
+        check_waveform(period_us, duty);
+      }
+
+      TEST_ASSERT(output.SetDutyCycle(0.0f) == ErrorCode::OK);
+      settle(period_us);
+      check_stable(false, period_us);
+      TEST_ASSERT(output.SetDutyCycle(1.0f) == ErrorCode::OK);
+      settle(period_us);
+      check_stable(true, period_us);
+
+      TEST_ASSERT(output.SetDutyCycle(0.5f) == ErrorCode::OK);
+      settle(period_us);
+      TEST_ASSERT(output.Disable() == ErrorCode::OK);
+      settle(period_us);
+      // 禁用可能保持某个电平，也可能高阻；只要求不再出现周期跳变。
+      // Disable may hold a level or become high-impedance; require no periodic edges.
+      check_stable(input.Read(), period_us);
+      TEST_ASSERT(output.Enable() == ErrorCode::OK);
+      settle(period_us);
+      check_waveform(period_us, 50);
+    }
+  }
+  TEST_ASSERT(output.SetDutyCycle(0.0f) == ErrorCode::OK);
+  TEST_ASSERT(output.Disable() == ErrorCode::OK);
+}
+}  // namespace LibXR::Test


### PR DESCRIPTION
Adds `TestPWM(PWM&, GPIO&, frequency_hz, tolerance_us, iterations)` under `test/manual/driver/pwm/`. A caller-provided GPIO reads the wired PWM output to check period, high time, constant levels at 0%/100% duty, disabling and re-enabling.

Each round tests the requested frequency and twice that frequency, with 25%/50%/75% duty plus a 50% restart check. Defaults are 100/200 Hz, a fixed 100 us tolerance and 100 rounds. The test polls in normal context, requires a working microsecond timebase and dedicated active-high PWM/input pins, and leaves PWM disabled. Bilingual comments and local documentation explain setup and measurement limits. No threads, callbacks or CI manual-test registration are added; product sources are unchanged.

Validation:
- STM32G0B1CBT6, TIM1_CH1 PA8 wired to PB2: default 100 rounds passed in about 45 s using the unchanged test header, real STM32PWM/STM32GPIO and HAL. This checks 800 complete waveform measurements plus endpoint and disabled-output observations. Results were read via SWD after free-running execution. Final timer/output disabled, input low. ARM GNU 14.2.1 Debug with developer assertions ON.
- A separate deterministic host fixture passed 16 expected outcomes, including incorrect frequency/duty, stuck/inverted input, failed enable/disable, timestamp wrap and periodic lost duty updates. It validates the oracle, not physical PWM, and is kept outside the repository along with the board app and logs.
- Linux Release/DEV_ASSERT OFF product and header build passed. The probe uses `-Wall -Wextra -Werror` with the previously identified `libxr_string.hpp:658` missing-field-initializers warning kept nonfatal. clang-format 21.1.8 and diff checks passed.

The GPIO polling method targets low frequencies and bounded sampling latency. Timing is relative to LibXR's timebase; a shared oscillator is not independently calibrated. Complementary output, dead time, narrow glitches and maximum frequency are outside this test.

## Sourcery 总结

添加一个手动调用的 PWM 波形验证测试，用于验证硬件连接的 GPIO 回读功能。

新功能：
- 添加手动 PWM 回读测试，在多个占空比下测量两种频率的周期和高电平时间，并验证端点、禁用和重新启用行为。

增强功能：
- 记录 PWM 测试接线方式、调用方法、运行限制、测量局限性以及最终状态行为。

文档：
- 更新手动测试文档，加入 PWM GPIO 回读测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

添加一个手动调用的 PWM 波形验证测试，用于验证硬件连接的 GPIO 回读。

新功能：
- 添加手动 PWM GPIO 回读测试，覆盖两个频率下的波形时序、多个占空比、端点电平以及禁用/重新启用行为。

文档：
- 记录 PWM 手动测试的接线方式、调用方法、运行限制、测量局限性和最终状态行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a manually invoked PWM waveform verification test for hardware-connected GPIO readback.

New Features:
- Add a manual PWM GPIO readback test covering waveform timing at two frequencies, multiple duty cycles, endpoint levels, and disable/re-enable behavior.

Documentation:
- Document PWM manual-test wiring, invocation, operating constraints, measurement limitations, and final-state behavior.

</details>

</details>