### PR TITLE
test: add manual ADC voltage checks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM 接线测试。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides wired GPIO and PWM tests.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM 和 ADC 测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM and ADC tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)及 [PWM 回读测试](pwm/README.md)，不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)及 [ADC 读数测试](adc/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md) and [PWM readback tests](pwm/README.md) are available. CI does not run them.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md) and [ADC sampling tests](adc/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/adc/README.md
+++ b/test/manual/driver/adc/README.md
@@ -1,0 +1,52 @@
+# ADC 手动测试 / Manual ADC test
+
+给 ADC 提供一个已知且稳定的输入电压，连续检查读数，并返回最小值、最大值和平均值。每个读数都要在允许误差内，不能用平均值掩盖异常采样。
+
+Supply a known, stable input voltage, check consecutive readings and return their minimum, maximum and mean. Every reading must be within tolerance; a mean cannot hide a bad sample.
+
+## 准备输入 / Prepare the input
+
+调用方初始化 ADC、参考电压和系统时间基，保证输入没有超过 ADC 允许范围。切换电压后，先等待电路和 ADC 采样结果稳定，再调用测试；如果驱动使用 DMA 或滤波缓冲区，也要留出更新这些数据的时间。
+
+Initialize the ADC, reference voltage and system timebase, and keep the input within the ADC's allowed range. After changing the voltage, allow the circuit and ADC readings to settle before calling the test, including any DMA or filter buffer update time.
+
+信号源由调用方选择，可以是外部电源、分压电路、GPIO 或 DAC。GPIO 高低电平适合检查端点和读数更新，但不能检查中间电压或线性度。测试本身不控制信号源，也不要求板上有 DAC。
+
+The caller chooses the source: an external supply, divider, GPIO or DAC. GPIO levels can check endpoints and reading updates, but not intermediate voltages or linearity. The test does not control the source or require an on-board DAC.
+
+## 调用 / Usage
+
+把 `test/` 和 `test/manual/driver/` 加入应用的头文件搜索路径，从普通任务调用。例如输入已经稳定在已知的 1.2 V 时：
+
+Add `test/` and `test/manual/driver/` to the application's include paths and call from a normal task. For an input already settled at a known 1.2 V, for example:
+
+```cpp
+#include "adc/test_adc.hpp"
+
+LibXR::Test::ADCTestResult CheckInput(LibXR::ADC& adc)
+{
+  return LibXR::Test::TestADC(adc, 1.2f, 0.05f);
+}
+```
+
+完整参数为 `TestADC(adc, expected_voltage, tolerance_voltage, interval_ms, samples)`。电压和容差以 V 为单位；示例允许每个读数偏离目标最多 0.05 V，这个值不是所有板子的默认精度要求，应根据实际信号源和 ADC 设定。
+
+The full call is `TestADC(adc, expected_voltage, tolerance_voltage, interval_ms, samples)`. Voltages and tolerance are in V. The example allows each reading to differ by at most 0.05 V; this is not a universal accuracy requirement. Choose it for the actual source and ADC.
+
+默认读取 1000 次，两次读取之间等待 1 ms。最后一个参数控制次数，填 1 可快速检查；间隔填 0 表示连续读取。读取次数不等于独立转换次数，因为部分驱动返回的是缓存或滤波结果。
+
+By default, the test reads 1000 times with a 1 ms delay between reads. The last argument sets the count; use 1 for a quick check or an interval of 0 for back-to-back reads. Read count is not necessarily conversion count: some drivers return cached or filtered data.
+
+`ADCTestResult` 的 `minimum`、`maximum` 和 `average` 都是电压值，可由应用打印或在调试器中查看。遇到 NaN、无穷大或超出容差的读数时，始终生效的 `TEST_ASSERT` 会立即停止测试，不会丢弃异常值后重试。
+
+`ADCTestResult.minimum`, `maximum` and `average` are voltages for application logging or debugger inspection. NaN, infinity or an out-of-tolerance value triggers the always-active `TEST_ASSERT` immediately; bad readings are not discarded and retried.
+
+## 检查读数更新 / Check reading updates
+
+恒定输入不能发现所有“卡在旧值”的问题。调用方可以反复切换两个或多个电压，等待固定的稳定时间后，以新的预期电压调用本测试。具体接线、切换方法和重复轮数留在调用方工程中。
+
+A constant input cannot reveal every stale-reading failure. The caller can repeatedly switch between two or more voltages, wait a fixed settling interval and call the test with the new expected voltage. Keep the wiring, switching method and repetition count in the caller's project.
+
+测试不会改变 ADC 配置或停止采样。返回后设备继续保持原有工作方式。用同一参考电压下的 GPIO 或 DAC 回环，只能验证对应的功能与更新行为，不能代替独立信号源的绝对精度测量。
+
+The test neither reconfigures the ADC nor stops sampling; the device keeps its original operating mode. GPIO or DAC loopback sharing the reference checks the corresponding function and updates, but does not replace absolute accuracy measurement with an independent source.

--- a/test/manual/driver/adc/test_adc.hpp
+++ b/test/manual/driver/adc/test_adc.hpp
@@ -1,0 +1,74 @@
+/**
+ * @file test_adc.hpp
+ * @brief 已知输入电压下的 ADC 连续读数测试 / ADC sampling test at a known input voltage.
+ *
+ * 每次读数都必须有效且处于允许误差内，返回最小值、最大值和平均值。
+ * Require every reading to be finite and within tolerance; return min, max and mean.
+ * 调用方提供稳定电压，测试不控制信号源。The caller supplies a stable voltage.
+ */
+#pragma once
+
+#include <cmath>
+
+#include "adc.hpp"
+#include "test_assert.hpp"
+#include "thread.hpp"
+
+namespace LibXR::Test
+{
+/** @brief ADC 采样统计 / ADC sample statistics. */
+struct ADCTestResult
+{
+  float minimum;  ///< 最小电压，V / Minimum voltage in V.
+  float maximum;  ///< 最大电压，V / Maximum voltage in V.
+  float average;  ///< 平均电压，V / Mean voltage in V.
+};
+
+/**
+ * @brief 检查已知电压下的连续读数 / Check consecutive readings at a known voltage.
+ * @pre ADC 和系统已初始化，输入与采样结果已稳定；从普通任务调用。
+ *      Initialize the ADC and system, allow the input and sampled data to settle,
+ *      and call from normal task context.
+ * @param adc 已初始化的 ADC 通道 / Initialized ADC channel.
+ * @param expected_voltage 预期电压，V / Expected voltage in V.
+ * @param tolerance_voltage 每次读数的绝对误差上限，V / Absolute tolerance per reading in
+ * V.
+ * @param interval_ms 两次读取之间的等待，0 表示连续读取 / Delay between reads; 0 reads
+ * back-to-back.
+ * @param samples 读取次数 / Number of readings.
+ * @return 本次读数的统计结果 / Statistics for these readings.
+ */
+inline ADCTestResult TestADC(ADC& adc, float expected_voltage, float tolerance_voltage,
+                             uint32_t interval_ms = 1, uint32_t samples = 1000)
+{
+  TEST_ASSERT(std::isfinite(expected_voltage));
+  TEST_ASSERT(std::isfinite(tolerance_voltage) && tolerance_voltage >= 0.0f);
+  TEST_ASSERT(samples > 0 && interval_ms < UINT32_MAX / 2U);
+  ADCTestResult result{};
+  double sum = 0.0;
+  for (uint32_t i = 0; i < samples; ++i)
+  {
+    const float voltage = adc.Read();
+    TEST_ASSERT(std::isfinite(voltage));
+    // 先检查每个读数，平均值不能掩盖偶发的错误采样。
+    // Check each reading first; a mean must not hide occasional bad samples.
+    TEST_ASSERT(std::fabs(static_cast<double>(voltage) - expected_voltage) <=
+                tolerance_voltage);
+    if (i == 0 || voltage < result.minimum)
+    {
+      result.minimum = voltage;
+    }
+    if (i == 0 || voltage > result.maximum)
+    {
+      result.maximum = voltage;
+    }
+    sum += voltage;
+    if (interval_ms != 0 && i + 1U < samples)
+    {
+      Thread::Sleep(interval_ms);
+    }
+  }
+  result.average = static_cast<float>(sum / samples);
+  return result;
+}
+}  // namespace LibXR::Test


### PR DESCRIPTION
Adds `TestADC(ADC&, expected_voltage, tolerance_voltage, interval_ms, samples)` under `test/manual/driver/adc/`. Every reading must be finite and within the caller's fixed voltage tolerance. The function returns minimum, maximum and mean; it does not average away failures, retry, reconfigure the ADC or control the signal source.

Defaults are 1000 reads, with a 1 ms delay between reads. A zero interval supports back-to-back reads. The source can be external or prepared by the caller using GPIO/DAC; neither is a dependency of the test. Bilingual comments and generic documentation explain setup, cached/filtered readings and changing the input between calls. No product-source or CI changes.

Validation:
- STM32G0B1CBT6, PB10 GPIO wired to PA0 ADC1_IN0: 1000 low/high rounds, 16 reads at each level, 32000 reads total, completed in about 34 s. Real STM32ADC using single-channel circular DMA and a 16-conversion buffer; fixed 2 ms settling before each block. Fixed expectations 0/3.3 V with 0.1 V tolerance. Low min/max/mean: 0.001461/0.004130/0.002750 V; high: 3.296273/3.298791/3.297414 V. These are filtered driver Read results, not independent raw conversions. This tests endpoints and updates, not absolute calibration or linearity.
- Ubuntu Linux Release/DEV_ASSERT OFF product and first-include header build; 13 host fixture outcomes matched, including summary values, sampling intervals, NaN/infinity, out-of-range readings and invalid arguments. Every 64th bad reading passes a one-read run and fails a 1000-read run. Fixture/code/logs remain outside the repository.
- G0B1 build used ARM GNU 14.2.1 Debug with developer assertions ON. Native J-Link verified flashing, ran freely for 45 s, then read the success marker and statistics. Final GPIO low; CPU halted at completion, ADC sampling remains configured.
- clang-format 21.1.8 and diff checks passed. The host probe used -Wall -Wextra -Werror with the pre-existing libxr_string.hpp:658 missing-field-initializers warning kept nonfatal. The isolated board app skips unrelated generated peripheral init functions, which produce unused-function warnings.

The board app, GPIO switching sequence, specific pins and hardware artifacts are not included in the committed test/docs. No DAC or helper thread is required.

## Sourcery 总结

新增手动 ADC 电压验证工具，并记录如何使用稳定的调用方提供的输入。

新功能：
- 新增手动 ADC 测试，用于根据固定的电压容差验证连续读数，并返回最小值、最大值和平均值。

改进：
- 记录手动 ADC 的设置方法、稳定输入要求、缓存或滤波后的读数、可配置的采样间隔，以及如何在输入变化时检查读数更新。

文档：
- 更新手动测试索引以包含 ADC 测试，并添加双语 ADC 使用指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a manual ADC voltage validation utility and document how to use it with stable, caller-provided inputs.

New Features:
- Add a manual ADC test that validates consecutive readings against a fixed voltage tolerance and returns minimum, maximum, and average values.

Enhancements:
- Document manual ADC setup, stable-input requirements, cached or filtered readings, configurable sampling intervals, and checking reading updates across changing inputs.

Documentation:
- Update manual test indexes to include ADC testing and add bilingual ADC usage guidance.

</details>