### PR TITLE
test: add manual DAC readback checks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM 和 ADC 测试。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM and ADC tests.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC 和 DAC 测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC and DAC tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)及 [ADC 读数测试](adc/README.md)，不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)及 [DAC 回读测试](dac/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md) and [ADC sampling tests](adc/README.md) are available. CI does not run them.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md) and [DAC readback tests](dac/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/dac/README.md
+++ b/test/manual/driver/dac/README.md
@@ -1,0 +1,53 @@
+# DAC 手动测试 / Manual DAC test
+
+将 DAC 输出接到 ADC 输入，反复输出“低→中→高→中→低”五个电压点。每次写入后等待固定时间，再复用 `TestADC` 检查连续 16 次读数，读取间隔为 1 ms。
+
+Wire the DAC output to an ADC input and repeatedly apply five levels: low, middle, high, middle and low. After a fixed settling delay, reuse `TestADC` to check 16 readings, 1 ms apart.
+
+## 接线和准备 / Wiring and setup
+
+调用方初始化 DAC、ADC 和系统时间基，独占两个通道。信号源和采样设备需要共地，输入端不能同时连接其他输出。最低、最高电压由调用方给定，中间电压取两者平均；测试没有默认量程。
+
+Initialize the DAC, ADC and system timebase, and reserve both channels. The output and sampling device need a common ground; no other output may drive the input. The caller supplies the lower and upper voltages, and the middle is their average. The test has no default voltage range.
+
+所选范围必须同时满足 DAC 的有效输出范围和 ADC 的允许输入范围。部分 DAC 在接近电源轨时不能保持精度，应按实际器件与负载选择范围。
+
+The range must fit both the DAC's usable output range and the ADC's allowed input range. Some DACs lose accuracy near the supply rails; choose the range for the actual device and load.
+
+## 调用 / Usage
+
+把 `test/` 和 `test/manual/driver/` 加入应用的头文件搜索路径，从普通任务调用。由应用传入适用的电压范围与容差：
+
+Add `test/` and `test/manual/driver/` to the application's include paths and call from a normal task. Supply the appropriate voltage range and tolerance from the application:
+
+```cpp
+#include "dac/test_dac.hpp"
+
+void RunDACTest(LibXR::DAC& dac, LibXR::ADC& adc,
+                float min_voltage, float max_voltage, float tolerance_voltage)
+{
+  LibXR::Test::TestDAC(dac, adc, min_voltage, max_voltage, tolerance_voltage);
+}
+```
+
+完整参数为 `TestDAC(dac, adc, min_voltage, max_voltage, tolerance_voltage, settle_ms, iterations)`。电压与容差以 V 为单位。容差必须小于相邻电压差的一半，否则旧电压可能被误判为新电压。
+
+The full call is `TestDAC(dac, adc, min_voltage, max_voltage, tolerance_voltage, settle_ms, iterations)`. Voltages and tolerance are in V. Tolerance must be less than half the spacing between adjacent levels so an old level cannot be accepted as the new one.
+
+默认每次写入后等待 5 ms，重复 100 轮，共检查 8000 次读数。最后一个参数填 1 可做快速检查。稳定时间应覆盖 DAC 建立、外部电路响应和 ADC 缓冲区或滤波结果更新；按实际系统在测试前确定，不会在失败后自动延长。
+
+Defaults are a 5 ms delay after each write and 100 rounds, for 8000 readings. Set the last argument to 1 for a quick check. Choose the settling time before the test to cover DAC settling, the external circuit and ADC buffer or filter updates. It is not automatically extended after a failure.
+
+## 结果与结束状态 / Results and final state
+
+每次 `Write()` 必须成功，每个 ADC 读数都必须有效且在容差内，失败立即触发 `TEST_ASSERT`。没有额外线程、回调或动态分配，CI 不自动运行这项接线测试。
+
+Every `Write()` must succeed, and every ADC reading must be finite and within tolerance. Failure immediately triggers `TEST_ASSERT`. The test creates no extra threads, callbacks or dynamic allocations, and CI does not run this wired test automatically.
+
+正常返回后 DAC 保持最低测试电压，ADC 继续原有工作方式。测试不恢复原输出电压；通用 DAC 接口没有关闭输出的方法。
+
+On success, the DAC holds the lower test voltage and the ADC keeps its original operating mode. The original output voltage is not restored; the generic DAC interface has no output-disable method.
+
+回读结果同时受 DAC、接线、ADC 和参考电压影响。它适合发现输出不更新、电压明显错误或间歇异常，但失败时仍需区分信号源和采样端。若 DAC 与 ADC 共用参考电压，这项回环不能代替独立仪器的绝对精度或完整线性度测量。
+
+Readback depends on the DAC, wiring, ADC and voltage reference. It can reveal stale output, incorrect levels or intermittent errors, but a failure still needs to be traced to the output or sampling side. When the DAC and ADC share a reference, loopback does not replace absolute accuracy or full linearity measurement with an independent instrument.

--- a/test/manual/driver/dac/test_dac.hpp
+++ b/test/manual/driver/dac/test_dac.hpp
@@ -1,0 +1,61 @@
+/**
+ * @file test_dac.hpp
+ * @brief 用 ADC 回读 DAC 输出的测试 / DAC output test using ADC readback.
+ *
+ * 在调用方指定的电压范围内反复升降，每个电压点通过 TestADC 检查连续读数。
+ * Repeatedly step up and down within the caller's voltage range and use TestADC
+ * to check consecutive readings at every level. Leave the output at the lower level.
+ */
+#pragma once
+
+#include "adc/test_adc.hpp"
+#include "dac.hpp"
+
+namespace LibXR::Test
+{
+/**
+ * @brief 反复设置 DAC 电压并检查 ADC 回读 / Repeatedly set DAC voltage and check ADC
+ * reads.
+ * @pre DAC 输出接 ADC 输入，两个设备和系统已初始化，从普通任务调用。
+ *      Wire DAC output to ADC input, initialize both devices and the system,
+ *      and call from normal task context.
+ * @pre 电压范围须同时满足 DAC 输出与 ADC 输入要求，稳定时间须包含采样缓冲区更新。
+ *      Choose a range supported by both devices and allow settling time for
+ *      the circuit and any ADC sample buffer update.
+ * @param dac 被测 DAC 输出 / DAC output under test.
+ * @param adc 用于回读的 ADC 通道 / ADC channel used for readback.
+ * @param min_voltage 测试最低电压，V / Lower test voltage in V.
+ * @param max_voltage 测试最高电压，V / Upper test voltage in V.
+ * @param tolerance_voltage 每次读数的绝对误差上限，V，须小于相邻电压差的一半 /
+ *        Absolute tolerance per reading in V, less than half the adjacent level spacing.
+ * @param settle_ms 每次写入后的固定等待时间 / Fixed delay after each write in
+ * milliseconds.
+ * @param iterations 完整升降轮数 / Number of complete up/down rounds.
+ */
+inline void TestDAC(DAC& dac, ADC& adc, float min_voltage, float max_voltage,
+                    float tolerance_voltage, uint32_t settle_ms = 5,
+                    uint32_t iterations = 100)
+{
+  TEST_ASSERT(std::isfinite(min_voltage) && std::isfinite(max_voltage));
+  const float middle =
+      static_cast<float>((static_cast<double>(min_voltage) + max_voltage) / 2.0);
+  TEST_ASSERT(min_voltage < middle && middle < max_voltage);
+  TEST_ASSERT(std::isfinite(tolerance_voltage) && tolerance_voltage >= 0.0f);
+  TEST_ASSERT(2.0 * tolerance_voltage < static_cast<double>(middle) - min_voltage);
+  TEST_ASSERT(2.0 * tolerance_voltage < static_cast<double>(max_voltage) - middle);
+  TEST_ASSERT(iterations > 0 && settle_ms < UINT32_MAX / 2U);
+
+  const float voltages[] = {min_voltage, middle, max_voltage, middle, min_voltage};
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    for (float voltage : voltages)
+    {
+      TEST_ASSERT(dac.Write(voltage) == ErrorCode::OK);
+      Thread::Sleep(settle_ms);
+      // 每个电压点检查 16 次，间隔 1 ms；超差立即失败，不延长等待重试。
+      // Check 16 readings, 1 ms apart; fail on an outlier without extending the wait.
+      TestADC(adc, voltage, tolerance_voltage, 1, 16);
+    }
+  }
+}
+}  // namespace LibXR::Test


### PR DESCRIPTION
Adds `TestDAC(DAC&, ADC&, min_voltage, max_voltage, tolerance_voltage, settle_ms, iterations)` under `test/manual/driver/dac/`. It writes low/middle/high/middle/low and reuses `TestADC` for 16 consecutive readings at each point. Voltage bounds and tolerance are required caller inputs; there is no built-in voltage range.

Defaults are a fixed 5 ms settling delay and 100 rounds, with 1 ms between readings. Bounds and tolerance are checked before writing; the tolerance must keep adjacent acceptance ranges separate. Every Write must succeed and every read must be finite and in range. Successful completion leaves DAC at the lower test voltage. The test does not create threads or callbacks, restore the old voltage or modify product drivers.

The PR contains one 61-line test header, bilingual generic documentation and two index-link updates. Board configuration, concrete pins, host stand-ins and verification artifacts are kept outside the repository. Manual tests are not added to CI execution.

Validation:
- Linux Release/DEV_ASSERT OFF product and first-include header build passed. Nineteen deterministic host outcomes matched: different voltage ranges (including 5 V, bipolar and large finite values), invalid ranges/tolerances, write failure, lost/wrong output, insufficient settling, nonfinite/outlier ADC reads, and periodic write loss. A fixture dropping every 64th write passes one round but fails 100 rounds. This verifies test logic, not physical devices.
- Full STM32G0B1 firmware compiled and linked with ARM GNU 14.2.1 Debug/DEV_ASSERT ON using actual STM32DAC/STM32ADC; no undefined symbols. This is compile evidence only.
- clang-format 21.1.8 and diff checks passed. The host probe keeps the pre-existing libxr_string.hpp:658 missing-field-initializers warning nonfatal under otherwise -Wall -Wextra -Werror. The isolated BSP has unused generated init-function warnings.

Hardware validation: the unchanged PR head passed on STM32G0B1CBT6 with DAC output wired to ADC input. The board application supplied 0.3/3.0 V bounds and a fixed 0.1 V tolerance: 100 low/middle/high/middle/low rounds, 500 writes and 8000 ADC reads completed in 10 s. Native J-Link verified flashing; execution ran freely for 15 s before reading success and an empty diagnostic buffer. The board retains the DAC test firmware, CPU halted at completion and DAC channel enabled at the lower 0.3 V setting. No option bytes were changed. Board configuration and hardware evidence remain outside the repository. DAC-to-ADC loopback validates the combined path and cannot replace independent absolute-accuracy or full-linearity measurement.