### PR TITLE
test: add region-scoped manual Flash checks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC 和 DAC 测试。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC and DAC tests.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC 和 Flash 测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC and Flash tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)及 [DAC 回读测试](dac/README.md)，不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)及 [Flash 擦写测试](flash/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md) and [DAC readback tests](dac/README.md) are available. CI does not run them.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md) and [Flash erase/program tests](flash/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/flash/README.md
+++ b/test/manual/driver/flash/README.md
@@ -1,0 +1,62 @@
+# Flash 手动测试 / Manual Flash test
+
+在调用方指定的专用区域内，检查擦除、顺序写入和完整回读。每轮写入一组位置相关数据，再擦除并写入它的反码，确认旧数据不会残留。正常结束时再擦除一次。
+
+Check erase, sequential programming and complete readback within a caller-reserved region. Each round programs a position-dependent pattern, erases it and programs its bitwise inverse to check that old data does not remain. Erase once more on successful completion.
+
+## 准备区域 / Prepare the region
+
+测试会破坏指定区域原有的数据。调用方必须保留一个可整体擦除的合法区域，确保不包含程序、配置或其他需要保存的内容。内部擦写规则应一致，不要跨越行为不同的区域。
+
+The test destroys existing data in the selected region. Reserve a legally whole-erasable range containing no firmware, configuration or other data to preserve. Use compatible erase/program rules throughout the range; do not cross into a region with different behavior.
+
+`MinEraseSize()` 和 `MinWriteSize()` 只用于排除明显的对齐错误，不能证明实际扇区边界、区域独立性或写入批次是否合法。这些条件仍由调用方根据设备和区域确认。
+
+`MinEraseSize()` and `MinWriteSize()` reject obvious alignment errors; they do not establish physical sector boundaries, erase isolation or legal write batches. The caller must verify these conditions for the actual device and region.
+
+提供一块独占的 RAM 缓冲区，其大小作为每次 `Write()` 和 `Read()` 的长度。大小应为合法写入批次，并能整除测试区域；地址须满足后端要求的 RAM 对齐。测试不分配内存，缓冲区内容会被改写。
+
+Supply an exclusive RAM buffer whose size is used for every `Write()` and `Read()`. It must be a legal programming batch that divides the region size, with the RAM alignment required by the backend. The test allocates no memory and overwrites the buffer contents.
+
+## 调用 / Usage
+
+把 `test/` 和 `test/manual/driver/` 加入应用的头文件搜索路径，从设备允许的普通执行上下文调用。例如，由应用提供已经确认的区域和擦除态：
+
+Add `test/` and `test/manual/driver/` to the application's include paths and call from a normal execution context supported by the device. Have the application supply the verified region and erased state:
+
+```cpp
+#include "flash/test_flash.hpp"
+
+void RunFlashTest(LibXR::Flash& flash, size_t offset, size_t size,
+                  LibXR::RawData buffer, std::optional<uint8_t> erased_value)
+{
+  LibXR::Test::TestFlash(flash, offset, size, buffer, erased_value);
+}
+```
+
+`offset` 相对于传入的 Flash 对象，不是固定物理地址。`erased_value` 没有默认值：若该区域擦除后每字节确定为 `0x00` 或 `0xFF`，就显式传入对应值；未知、未定义或不是重复字节时传 `std::nullopt`，跳过空白值比较。测试不会把一次读取的结果当作正确擦除态。
+
+`offset` is relative to the supplied Flash object, not a fixed physical address. `erased_value` has no default. Explicitly pass the documented byte, such as `0x00` or `0xFF`, when the erased region consists of that repeated value. Pass `std::nullopt` for unknown, undefined or nonuniform erased contents to skip blank comparison. The test never learns the expected erased state from a read.
+
+## 测试步骤 / Test sequence
+
+1. 整体擦除区域；提供了擦除值时逐字节检查。
+   Erase the entire region; compare every byte if an erased value was supplied.
+2. 按地址递增写入位置相关数据，全部写完后完整回读比较。
+   Program a position-dependent pattern in ascending order, then compare full readback.
+3. 再擦除，按同样顺序写入反码并完整回读。
+   Erase again, program the inverted pattern in the same order and compare full readback.
+4. 所有轮次结束后再次擦除；提供了擦除值时检查最终空白状态。
+   Erase after all rounds; verify the final blank state if an erased value was supplied.
+
+每个编程单元在一次擦除后只写一次。回读前会用错误值覆盖工作缓冲区，以发现未执行或只完成部分复制的 `Read()`。失败立即触发始终生效的 `TEST_ASSERT`，不会重试或恢复原数据。
+
+Each programming unit is written once per erase cycle. Before reading, the work buffer is filled with incorrect bytes to detect missing or partial copies by `Read()`. Failure immediately triggers the always-active `TEST_ASSERT`; the test neither retries nor restores old data.
+
+最后一个可选参数 `iterations` 默认为 1，总共发出 **`2 × iterations + 1` 次区域擦除请求**。默认就是 3 次；不要照搬其他外设的千轮压测次数。传 `nullopt` 时，只能确认最后的擦除调用成功，不能声称核对过空白读值。
+
+The optional final argument, `iterations`, defaults to 1, for **`2 × iterations + 1` region erase requests** in total: 3 by default. Do not copy thousand-round settings from other peripheral tests. With `nullopt`, final erase success means the call succeeded, not that blank contents were verified.
+
+这项测试不推断子区域可独立擦除，也不测试逆序编程、未擦除重写、跨不同规则区域、掉电恢复或擦写寿命。CI 不自动运行这项破坏性测试。
+
+This test does not infer independently erasable subregions or test reverse programming, rewriting without erase, crossings between incompatible regions, power-loss recovery or endurance. CI does not run this destructive test automatically.

--- a/test/manual/driver/flash/test_flash.hpp
+++ b/test/manual/driver/flash/test_flash.hpp
@@ -1,0 +1,109 @@
+/**
+ * @file test_flash.hpp
+ * @brief 专用区域内的 Flash 擦写回读测试 / Flash erase, program and readback in a
+ * reserved region.
+ *
+ * 整体擦除后按地址递增写入，再回读比较；重新擦除后写入反码，结束时再次擦除。
+ * Erase the region, program in ascending order and compare reads; erase and repeat
+ * with the inverted pattern, then erase once more. Check blank bytes only if specified.
+ */
+#pragma once
+
+#include <cstring>
+#include <optional>
+
+#include "flash.hpp"
+#include "test_assert.hpp"
+
+namespace LibXR::Test
+{
+/**
+ * @brief 检查合法区域内的顺序写入和擦除后重写 / Check sequential programming and
+ * erase/rewrite.
+ * @pre 区域必须专供测试、可整体擦除，内部擦写规则一致，不包含程序或待保留数据。
+ *      Reserve a legally whole-erasable region with compatible programming rules,
+ *      containing no firmware or data to preserve.
+ * @pre buffer 是独占 RAM，大小为该区域合法写入批次，地址满足后端对 RAM 的对齐要求。
+ *      Supply exclusive RAM with a legal write-batch size and backend-required RAM
+ * alignment.
+ * @param flash 已初始化的 Flash / Initialized Flash device.
+ * @param offset 测试区相对 Flash 对象的起始偏移 / Region offset within the Flash object.
+ * @param size 测试区大小，必须是 buffer 大小的整数倍 / Region size, a multiple of buffer
+ * size.
+ * @param buffer 写入和回读共用的工作缓冲区 / Shared programming/readback work buffer.
+ * @param erased_value 该区域确定的擦除字节值，未知或未定义时传 nullopt /
+ *        Defined erased byte for this region, or nullopt if unknown or unspecified.
+ * @param iterations 重复轮数，总擦除次数为 2*iterations+1 / Rounds; 2*iterations+1 erases
+ * total.
+ */
+inline void TestFlash(Flash& flash, size_t offset, size_t size, RawData buffer,
+                      std::optional<uint8_t> erased_value, uint32_t iterations = 1)
+{
+  const size_t erase_size = flash.MinEraseSize();
+  const size_t write_size = flash.MinWriteSize();
+  TEST_ASSERT(erase_size > 0 && write_size > 0 && iterations > 0);
+  TEST_ASSERT(offset <= flash.Size() && size > 0 && size <= flash.Size() - offset);
+  TEST_ASSERT(offset % erase_size == 0 && size % erase_size == 0);
+  TEST_ASSERT(offset % write_size == 0);
+  TEST_ASSERT(buffer.addr_ != nullptr && buffer.size_ > 0 && buffer.size_ <= size);
+  TEST_ASSERT(buffer.size_ % write_size == 0 && size % buffer.size_ == 0);
+  auto* bytes = static_cast<uint8_t*>(buffer.addr_);
+
+  auto erase = [&]
+  {
+    TEST_ASSERT(flash.Erase(offset, size) == ErrorCode::OK);
+    if (erased_value.has_value())
+    {
+      for (size_t pos = 0; pos < size; pos += buffer.size_)
+      {
+        // 先填入错误值，避免 Read 未复制数据却误通过。
+        // Prefill incorrect bytes so a Read that copies nothing cannot pass.
+        std::memset(bytes, static_cast<uint8_t>(~*erased_value), buffer.size_);
+        TEST_ASSERT(flash.Read(offset + pos, buffer) == ErrorCode::OK);
+        for (size_t i = 0; i < buffer.size_; ++i)
+        {
+          TEST_ASSERT(bytes[i] == *erased_value);
+        }
+      }
+    }
+  };
+
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    for (uint32_t inverted = 0; inverted < 2; ++inverted)
+    {
+      auto pattern = [&](size_t position)
+      {
+        // 251 字节循环不与常见的 2 的幂块大小重合；下一遍逐位取反。
+        // A 251-byte cycle avoids common power-of-two block periods; invert next pass.
+        const auto value = static_cast<uint8_t>(position % 251U + round);
+        return static_cast<uint8_t>(value ^ (inverted ? 0xFFU : 0U));
+      };
+      erase();
+      for (size_t pos = 0; pos < size; pos += buffer.size_)
+      {
+        for (size_t i = 0; i < buffer.size_; ++i)
+        {
+          bytes[i] = pattern(offset + pos + i);
+        }
+        TEST_ASSERT(flash.Write(offset + pos, {bytes, buffer.size_}) == ErrorCode::OK);
+      }
+      // 完成整遍写入后再读取，不穿插逆序写入或重复编程。
+      // Read only after the full pass; never program backwards or program a unit twice.
+      for (size_t pos = 0; pos < size; pos += buffer.size_)
+      {
+        for (size_t i = 0; i < buffer.size_; ++i)
+        {
+          bytes[i] = static_cast<uint8_t>(~pattern(offset + pos + i));
+        }
+        TEST_ASSERT(flash.Read(offset + pos, buffer) == ErrorCode::OK);
+        for (size_t i = 0; i < buffer.size_; ++i)
+        {
+          TEST_ASSERT(bytes[i] == pattern(offset + pos + i));
+        }
+      }
+    }
+  }
+  erase();
+}
+}  // namespace LibXR::Test


### PR DESCRIPTION
Adds `TestFlash(Flash&, offset, size, buffer, erased_value, iterations)` under `test/manual/driver/flash/`. The caller supplies a reserved, legally erasable region, a legal RAM write batch and either the region's erased byte or `std::nullopt`; no erased value is assumed.

Each round erases the whole region, programs a position-dependent pattern in ascending address order and compares full readback, then erases and repeats with the bitwise-inverted pattern. Programming units are not revisited within an erase cycle. Every read buffer is prefilled with incorrect expected bytes so a missing or partial Read cannot pass using old buffer contents. One final erase leaves the test area erased; blank contents are compared only when explicitly specified. Default one round sends three region erase requests (2*N+1 in general).

The test does not infer internal erase geometry, independently erasable subregions or crossings between different region rules from minimum sizes. Region/batch validity and additional RAM alignment remain caller responsibilities. No product driver/API change, heap allocation or CI manual-test registration. The PR contains the generic header, bilingual local docs and two index links; board addresses, BSP code and fixtures stay outside the repository.

Validation:
- Linux Release/DEV_ASSERT OFF product and first-include header compiled; 26 host outcomes matched. The fixture enforces strictly ascending, once-per-unit programming and different regional erase sizes. It covers erased 0xFF, erased 0x00 and nonuniform unknown erased contents, plus missed/partial/failed erase/write/read, wrong addresses, invalid inputs and periodic lost writes. Empty/partial Read failures are detected with and without blank checks. This is fixture evidence, not physical CH32/G431 validation.
- STM32G0B1 full firmware compiled with ARM GNU 14.2.1 Debug/DEV_ASSERT ON and no undefined symbols. The isolated linker reserves a 4 KiB tail region; actual nonempty Flash load segments end at 0x0800B07C, below that reservation. Board-only runtime guards check 128 KiB/single-bank geometry before erase. The user subsequently approved the reserved region and hardware execution; results are recorded below.
- clang-format 21.1.8 and diff checks passed. The host probe retains the known libxr_string.hpp:658 missing-initializer warning as nonfatal. The isolated BSP has unused init-function warnings and a linker RWX warning from HAL .RamFunc code placed with RAM data by its generated linker script.

Hardware validation: unchanged PR head passed on STM32G0B1CBT6 using the explicitly approved final 4 KiB. One round completed both ascending pattern/complement passes with full readback and three region erases, including blank checks against the specified 0xFF. The test wrote 8 KiB total across two passes, in 32-byte batches. Before execution, the full 128 KiB Flash was backed up and 128 KiB/single-bank geometry was checked. After firmware installation, a new baseline was captured; after the test, an independent debugger read confirmed that the 124 KiB outside the test region was byte-identical and the final 4 KiB was all 0xFF. Option bytes were unchanged and the diagnostic buffer was empty. The CPU remains halted at test completion with the Flash test firmware installed.

This is evidence for the tested G0B1 region only, not hardware validation of CH32/G431 or other region rules. Unknown erased contents intentionally skip blank-value verification, including after the final erase call. The test does not cover power loss, endurance, reverse programming or erase isolation between separately declared regions.