### PR TITLE
test: add manual I2C register read and write checks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC 和 Flash 测试。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC and Flash tests.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC、Flash 和 I2C 测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC, Flash and I2C tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)及 [Flash 擦写测试](flash/README.md)，不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)、[Flash 擦写测试](flash/README.md)及 [I2C 寄存器读写测试](i2c/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md) and [Flash erase/program tests](flash/README.md) are available. CI does not run them.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md), [Flash erase/program tests](flash/README.md) and [I2C register read/write tests](i2c/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/i2c/README.md
+++ b/test/manual/driver/i2c/README.md
@@ -1,0 +1,81 @@
+# I2C 手动测试 / Manual I2C test
+
+提供固定寄存器读取和可读写寄存器的写入回读两项测试。两项都使用阻塞、轮询和回调三种完成方式，等当前操作完成后才开始下一次。
+
+Two tests cover fixed-register reads and write/readback of writable registers. Both use blocking, polling and callback completion, starting the next operation only after the current one completes.
+
+## 准备设备 / Prepare the device
+
+调用方初始化 I2C 总线、从机、系统时间基和中断／DMA 资源，并独占总线。确认供电、共地和 SDA/SCL 上拉电平符合两端要求。
+
+Initialize the bus, slave, system timebase and required interrupt/DMA resources, and reserve the bus. Check power, common ground and SDA/SCL pull-up levels against both devices' requirements.
+
+固定读取测试选择内容固定、没有清除状态等读取副作用的寄存器，例如已确认的器件标识。预期值来自器件资料或其他独立依据，不能先读取一次，再把读取结果当作正确答案。不要用持续变化的传感器测量值作固定值比较。
+
+For the fixed-read test, choose stable registers without read side effects such as clearing status, for example a verified device identifier. Derive expected bytes from device documentation or other independent evidence, not from a previous read of the same device. Do not compare changing sensor measurements against fixed bytes.
+
+从机地址不带 R/W 位；7 位或 10 位寻址模式由调用方配置。寄存器地址长度明确传入 `BYTE_8` 或 `BYTE_16`。连续读取多个字节时，确认从机支持这种访问方式，而且长度没有超过后端的传输或 DMA 缓冲区限制。
+
+Supply the slave address without the R/W bit; configure 7-bit or 10-bit addressing in the caller. Explicitly select `BYTE_8` or `BYTE_16` for the register address. For multi-byte reads, verify the slave's access behavior and the backend's transfer/DMA buffer limits.
+
+## 固定寄存器读取 / Fixed-register reads
+
+把 `test/` 和 `test/manual/driver/` 加入应用的头文件搜索路径，从普通任务调用：
+
+Add `test/` and `test/manual/driver/` to the application's include paths and call from a normal task:
+
+```cpp
+#include "i2c/test_i2c.hpp"
+
+void CheckRegisters(LibXR::I2C& bus, uint16_t device, uint16_t reg,
+                    LibXR::I2C::MemAddrLength address_length,
+                    LibXR::ConstRawData expected, LibXR::RawData buffer)
+{
+  LibXR::Test::TestI2CMemRead(bus, device, reg, address_length, expected, buffer);
+}
+```
+
+`expected` 的长度决定每次读取多少字节，`buffer` 至少需要同样大小。预期数据必须保持不变，且不能与实际接收区重叠。调用期间保留总线对象及两个缓冲区；后端完成操作后不得继续访问本次缓冲区或通知对象。
+
+The length of `expected` determines the transfer size; `buffer` must be at least that large. Expected bytes must remain unchanged and must not overlap the receive area. Keep the bus and both buffers alive throughout the call; completed operations must not continue accessing their buffers or notification targets.
+
+最后两个参数为 `timeout_ms` 和 `iterations`，默认 1000 ms、1000 轮，即 3000 次读取。次数填 1 可快速检查。超时值传给 BLOCK 操作，并限制 `MemRead()` 返回后的轮询或回调等待；它不能强行中断后端在 `MemRead()` 内部执行的同步调用。
+
+The final arguments are `timeout_ms` and `iterations`, defaulting to 1000 ms and 1000 rounds, or 3000 reads. Use one round for a quick check. The timeout is passed to BLOCK operations and bounds polling/callback waits after `MemRead()` returns; it cannot preempt synchronous work inside the backend call.
+
+## 写入后回读 / Write and read back
+
+`TestI2CMemWriteRead` 交替写入调用方提供的两组数据，每次写入完成后按指定时间等待，再回读并逐字节比较。两组数据必须不同、长度相同，而且都是目标区域允许的值；测试不会自行生成反码去修改未知控制位。
+
+`TestI2CMemWriteRead` alternates two caller-provided patterns. After each write completes, wait the specified interval, read back and compare every byte. Patterns must be distinct, equal-sized and legal for the selected region; the test does not invent inverted values for unknown control bits.
+
+```cpp
+LibXR::Test::TestI2CMemWriteRead(bus, device, reg, address_length,
+                                first_pattern, second_pattern, buffer);
+```
+
+输入区与接收区不能重叠。目标必须支持写入后原样回读，不能选具有命令副作用或无法原样回读的寄存器。分页、写入寿命和写后稳定时间由调用方按实际器件确认。
+
+Neither pattern may overlap the receive area. Choose registers that read back the written bytes, without command side effects. The caller must verify paging, write endurance and settling time for the device.
+
+最后三个参数为 `settle_ms`、`timeout_ms` 和 `iterations`，默认 0 ms、1000 ms 和 100 轮。每轮在三种完成方式下分别写入两组数据，共六次写入和六次回读。`settle_ms` 从写完成开始计时；非易失存储器尤其需要按写周期和寿命调整参数。
+
+The final three arguments are `settle_ms`, `timeout_ms` and `iterations`, defaulting to 0 ms, 1000 ms and 100 rounds. Each round uses both patterns in all three completion modes: six writes and six reads. Settling starts after write completion; adjust it and the round count for nonvolatile memory's write cycle and endurance.
+
+成功后保留第二组数据。需要保留原值时，由调用工程在测试前保存，成功后恢复并核对。测试失败会立即停止，不能承诺失败时已恢复原值。
+
+Success leaves the second pattern in place. If old values must be preserved, the calling application saves them before testing, then restores and verifies them after success. Failure stops immediately; restoration after a failed test is not guaranteed.
+
+## 检查内容 / Checks
+
+每次读取前，接收区填入预期值的反码，防止未复制数据却误通过。阻塞方式检查调用结果；轮询方式等待 `DONE` 并拒绝 `ERROR`；回调方式检查成功结果及观测到的回调次数。最后逐字节比较数据，任何错误都立即触发始终生效的 `TEST_ASSERT`，不重试。
+
+Before each read, fill the receive area with inverted expected bytes so missing copies cannot pass. Blocking mode checks the call result; polling waits for `DONE` and rejects `ERROR`; callback mode checks success and observed completion counts. Compare every byte after completion. Any failure immediately triggers the always-active `TEST_ASSERT`, without retries.
+
+回调可能在提交函数内直接执行，也可能稍后从任务或 ISR 执行。测试不写死回调上下文，回调中只更新原子计数和错误标志；报错在调用线程进行。回调只创建一次并在所有轮次中复用，循环中不创建线程或分配通知对象。测试失败会停止，不会带着未完成的操作返回。
+
+Callbacks may run inline during submission or later in a task or ISR. The test does not assume one callback context; callbacks only update atomic counts and an error flag, while diagnostics run in the calling thread. A callback is created once and reused across rounds; no threads or notification objects are created in the loop. A failed test stops rather than returning with an operation pending.
+
+CI 不自动运行这项设备测试。寄存器读写通过，只证明相应路径；它不代表长包 DMA、普通 `Read/Write`、总线速率或异常恢复已经验证。设备型号、具体地址、寄存器与接线留在调用工程中。
+
+CI does not run this device test automatically. Passing register read/write checks only validates the exercised paths; it does not establish long-transfer DMA, plain `Read/Write`, bus speed or error recovery. Keep device models, addresses, registers and wiring in the calling project.

--- a/test/manual/driver/i2c/test_i2c.hpp
+++ b/test/manual/driver/i2c/test_i2c.hpp
@@ -1,0 +1,258 @@
+/**
+ * @file test_i2c.hpp
+ * @brief I2C 寄存器读写测试 / I2C register read and write tests.
+ *
+ * 用阻塞、轮询和回调方式检查固定寄存器，以及两组调用方数据的写入回读。
+ * Check fixed registers and write/readback of two caller-supplied patterns in
+ * blocking, polling and callback modes. Device-specific values belong to the caller.
+ */
+#pragma once
+
+#include <atomic>
+#include <cstring>
+
+#include "i2c.hpp"
+#include "test_assert.hpp"
+#include "thread.hpp"
+
+namespace LibXR::Test
+{
+namespace Detail
+{
+inline void CheckI2CRegister(uint16_t slave_addr, uint16_t mem_addr,
+                             I2C::MemAddrLength addr_length)
+{
+  TEST_ASSERT(slave_addr <= 0x3FFU);
+  TEST_ASSERT(addr_length == I2C::MemAddrLength::BYTE_8 ||
+              addr_length == I2C::MemAddrLength::BYTE_16);
+  TEST_ASSERT(addr_length != I2C::MemAddrLength::BYTE_8 || mem_addr <= 0xFFU);
+}
+
+inline void CheckI2CBuffers(ConstRawData expected, RawData buffer)
+{
+  TEST_ASSERT(expected.addr_ != nullptr && buffer.addr_ != nullptr);
+  TEST_ASSERT(expected.size_ > 0 && expected.size_ <= buffer.size_);
+  const auto source = reinterpret_cast<uintptr_t>(expected.addr_);
+  const auto destination = reinterpret_cast<uintptr_t>(buffer.addr_);
+  TEST_ASSERT(source >= destination ? source - destination >= expected.size_
+                                    : destination - source >= expected.size_);
+}
+
+inline void PoisonI2CBuffer(ConstRawData expected, RawData buffer)
+{
+  const auto* wanted = static_cast<const uint8_t*>(expected.addr_);
+  auto* received = static_cast<uint8_t*>(buffer.addr_);
+  for (size_t i = 0; i < expected.size_; ++i)
+  {
+    received[i] = static_cast<uint8_t>(~wanted[i]);
+  }
+}
+
+inline void CheckI2CData(ConstRawData expected, RawData buffer)
+{
+  const auto* wanted = static_cast<const uint8_t*>(expected.addr_);
+  const auto* received = static_cast<const uint8_t*>(buffer.addr_);
+  for (size_t i = 0; i < expected.size_; ++i)
+  {
+    TEST_ASSERT(received[i] == wanted[i]);
+  }
+}
+
+/** @brief 两项 I2C 测试共用的完成通知 / Completion state shared by the two I2C tests. */
+class I2CTestCompletion
+{
+  using Transfer = Operation<ErrorCode>;
+  using Status = Transfer::OperationPollingStatus;
+  using Mode = Transfer::OperationType;
+
+ public:
+  explicit I2CTestCompletion(uint32_t timeout_ms)
+      : callback_(Transfer::Callback::Create(
+            [](bool, I2CTestCompletion* self, ErrorCode result)
+            {
+              if (result != ErrorCode::OK)
+              {
+                self->failed_.store(1, std::memory_order_relaxed);
+              }
+              // 最后一次访问上下文才发布完成；ISR 中不打印或断言。
+              // Publish on the last context access; no logging or assertions in ISR.
+              self->calls_.fetch_add(1, std::memory_order_release);
+            },
+            this)),
+        operations_{Transfer(semaphore_, timeout_ms), Transfer(status_),
+                    Transfer(callback_)},
+        timeout_ms_(timeout_ms)
+  {
+    TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
+  }
+
+  template <typename Submit>
+  void Run(unsigned mode_index, Submit submit)
+  {
+    auto& operation = operations_[mode_index];
+    const Mode mode = operation.type;
+    Check();
+    status_.store(Status::READY, std::memory_order_relaxed);
+    if (mode == Mode::CALLBACK)
+    {
+      ++expected_calls_;
+    }
+    TEST_ASSERT(submit(operation) == ErrorCode::OK);
+    const uint32_t start = Thread::GetTime();
+    for (;;)
+    {
+      bool done = mode == Mode::BLOCK;
+      if (mode == Mode::POLLING)
+      {
+        const auto status = status_.load(std::memory_order_acquire);
+        TEST_ASSERT(status != Status::ERROR);
+        done = status == Status::DONE;
+      }
+      else if (mode == Mode::CALLBACK)
+      {
+        const uint32_t calls = calls_.load(std::memory_order_acquire);
+        TEST_ASSERT(calls <= expected_calls_);
+        done = calls == expected_calls_;
+      }
+      TEST_ASSERT(failed_.load(std::memory_order_relaxed) == 0);
+      // 同步完成时直接继续；不要求必须观察到 RUNNING。
+      // Continue immediately for inline completion; observing RUNNING is not required.
+      if (done)
+      {
+        break;
+      }
+      TEST_ASSERT(Thread::GetTime() - start < timeout_ms_);
+      Thread::Sleep(1);
+    }
+    Check();
+  }
+
+  void Check() const
+  {
+    TEST_ASSERT(calls_.load(std::memory_order_acquire) == expected_calls_);
+    TEST_ASSERT(failed_.load(std::memory_order_relaxed) == 0);
+  }
+
+ private:
+  Semaphore semaphore_;
+  std::atomic<Status> status_{Status::READY};
+  std::atomic<uint32_t> calls_{0};
+  std::atomic<uint32_t> failed_{0};
+  Transfer::Callback callback_;
+  Transfer operations_[3];
+  uint32_t timeout_ms_;
+  uint32_t expected_calls_ = 0;
+};
+}  // namespace Detail
+
+/**
+ * @brief 检查三种完成方式下的固定寄存器读数 / Check fixed reads in three completion
+ * modes.
+ * @pre 总线和设备已初始化并由测试独占，寄存器允许重复读取且内容固定。
+ *      Initialize and reserve the bus/device; registers must support stable repeated
+ * reads.
+ * @param i2c 已初始化的 I2C / Initialized I2C controller.
+ * @param slave_addr 不带 R/W 位的从机地址 / Slave address without the R/W bit.
+ * @param mem_addr 起始寄存器地址 / Starting register address.
+ * @param addr_length 寄存器地址长度 / Register address width.
+ * @param expected 预期字节，决定读取长度，不能与接收区重叠 / Expected bytes defining the
+ *        read length; must not overlap the receive area.
+ * @param buffer 接收区，容量至少为 expected 大小 / Receive storage, at least expected
+ * size.
+ * @param timeout_ms BLOCK 超时及返回后的完成等待上限 / BLOCK timeout and post-return wait
+ * limit.
+ * @param iterations 轮数，每轮三次读取 / Rounds, with three reads per round.
+ */
+inline void TestI2CMemRead(I2C& i2c, uint16_t slave_addr, uint16_t mem_addr,
+                           I2C::MemAddrLength addr_length, ConstRawData expected,
+                           RawData buffer, uint32_t timeout_ms = 1000,
+                           uint32_t iterations = 1000)
+{
+  Detail::CheckI2CRegister(slave_addr, mem_addr, addr_length);
+  Detail::CheckI2CBuffers(expected, buffer);
+  TEST_ASSERT(iterations > 0);
+  Detail::I2CTestCompletion completion(timeout_ms);
+  const RawData read_buffer{buffer.addr_, expected.size_};
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    for (unsigned mode = 0; mode < 3; ++mode)
+    {
+      Detail::PoisonI2CBuffer(expected, read_buffer);
+      completion.Run(mode,
+                     [&](ReadOperation& operation)
+                     {
+                       return i2c.MemRead(slave_addr, mem_addr, read_buffer, operation,
+                                          addr_length, false);
+                     });
+      Detail::CheckI2CData(expected, read_buffer);
+      completion.Check();
+    }
+  }
+}
+
+/**
+ * @brief 交替写入两组合法数据并回读 / Alternate two legal patterns and check readback.
+ * @pre 目标区域须专供测试，支持原样回读；两组数据均合法且长度相同。
+ *      Reserve a region that reads back written bytes; both patterns must be legal and
+ * equal-sized.
+ * @pre 调用方负责分页、写入寿命、保存与恢复原值；成功后保留第二组数据。
+ *      The caller handles paging, endurance and saving/restoring old values. Leaves the
+ * second pattern.
+ * @param i2c 已初始化并独占的总线 / Initialized, exclusively reserved bus.
+ * @param slave_addr 不带 R/W 位的从机地址 / Slave address without the R/W bit.
+ * @param mem_addr 可读写区域起始地址 / Start of the read/write region.
+ * @param addr_length 寄存器地址长度 / Register address width.
+ * @param first 第一组合法写入数据 / First legal write pattern.
+ * @param second 不同的第二组数据 / Distinct second pattern.
+ * @param buffer 独立回读缓冲区，不能与任一写入数据重叠 / Separate receive buffer,
+ * disjoint from both patterns.
+ * @param settle_ms 写完成到回读之间的等待时间 / Delay between write completion and
+ * readback.
+ * @param timeout_ms BLOCK 超时及返回后的完成等待上限 / BLOCK timeout and post-return wait
+ * limit.
+ * @param iterations 轮数，每轮各六次写入和读取 / Rounds, each with six writes and six
+ * reads.
+ */
+inline void TestI2CMemWriteRead(I2C& i2c, uint16_t slave_addr, uint16_t mem_addr,
+                                I2C::MemAddrLength addr_length, ConstRawData first,
+                                ConstRawData second, RawData buffer,
+                                uint32_t settle_ms = 0, uint32_t timeout_ms = 1000,
+                                uint32_t iterations = 100)
+{
+  Detail::CheckI2CRegister(slave_addr, mem_addr, addr_length);
+  Detail::CheckI2CBuffers(first, buffer);
+  Detail::CheckI2CBuffers(second, buffer);
+  TEST_ASSERT(first.size_ == second.size_);
+  TEST_ASSERT(std::memcmp(first.addr_, second.addr_, first.size_) != 0);
+  TEST_ASSERT(settle_ms < UINT32_MAX / 2U && iterations > 0 &&
+              iterations <= UINT32_MAX / 4U);
+  Detail::I2CTestCompletion completion(timeout_ms);
+  const ConstRawData patterns[] = {first, second};
+  const RawData read_buffer{buffer.addr_, first.size_};
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    for (unsigned mode = 0; mode < 3; ++mode)
+    {
+      for (const auto& pattern : patterns)
+      {
+        completion.Run(mode,
+                       [&](WriteOperation& operation)
+                       {
+                         return i2c.MemWrite(slave_addr, mem_addr, pattern, operation,
+                                             addr_length, false);
+                       });
+        Thread::Sleep(settle_ms);
+        Detail::PoisonI2CBuffer(pattern, read_buffer);
+        completion.Run(mode,
+                       [&](ReadOperation& operation)
+                       {
+                         return i2c.MemRead(slave_addr, mem_addr, read_buffer, operation,
+                                            addr_length, false);
+                       });
+        Detail::CheckI2CData(pattern, read_buffer);
+        completion.Check();
+      }
+    }
+  }
+}
+}  // namespace LibXR::Test


### PR DESCRIPTION
Adds two caller-configured I2C register tests under `test/manual/driver/i2c/`:

- `TestI2CMemRead`: fixed-register reads against expected bytes, default 1000 rounds/3000 reads.
- `TestI2CMemWriteRead`: alternate two distinct legal patterns, wait for write completion and an optional settling interval, then read back and compare. Default 100 rounds, six writes and six reads per round. The caller handles paging/endurance and preservation; success leaves the second pattern.

Both exercise BLOCK, POLLING and CALLBACK completion using shared internal wait logic. Receive buffers are poisoned, expected/pattern bytes remain separate, terminal errors and observed duplicate/missing completion fail immediately. Callbacks only record atomic state; one callback/semaphore/status set is reused per test invocation, with no helper threads or per-round allocations. Device addresses, registers, legal patterns and transfer sizes are caller inputs. No product driver, SetConfig or CI manual-test registration changes.

Four files only: the generic header, bilingual local documentation and two index links. Device-specific backup/restoration, pins, board code, host fixtures and logs remain outside the repository.

Validation:
- STM32G0B1 + GY-85 ADXL345, 3.3 V: 1000 rounds of fixed DEVID reads (3000 reads), followed by 1000 write/readback rounds (6000 writes and 6000 reads), passed with all three completion modes. The board app used documented OFSX register 0x1E with legal values 0x01/0xFE, saved its original 0x00, and restored/read-verified 0x00 after success. DEVID 0x00 remained the independent fixed 0xE5 expectation. See [ADXL345 register definitions](https://www.analog.com/media/en/technical-documentation/data-sheets/adxl345.pdf). No power/address/control registers were changed.
- Actual hardware transfers are one byte and use the STM32 short synchronous HAL paths; callbacks complete inline. This is not hardware DMA validation. ARM GNU 14.2.1 Debug with developer assertions ON, flash verified by J-Link; free run then debugger result showed success and an empty error log. CPU remains halted at completion with the revised test image; sensor offset was restored.
- Linux Release/DEV_ASSERT OFF product/header builds and 38 host outcomes passed: 23 read cases rerun after sharing completion logic, plus 15 write/read cases. These cover immediate/deferred completion with real Operation/Semaphore, register/address widths, wrong/missing/partial data, failed/missing/duplicate write completion, invalid inputs, and periodic lost writes. Deferred transport and 10-bit address coverage are host-fixture evidence only.
- clang-format 21.1.8 and diff checks passed. The host probe keeps the known libxr_string.hpp:658 missing-initializer warning nonfatal under otherwise -Wall -Wextra -Werror. The isolated BSP has unused init-function warnings. G0B1 link has no undefined symbols.

Timeouts cannot preempt synchronous work inside a backend call. Tests stop on failure rather than promising restoration while I/O may still be active. Plain Read/Write, bus-speed accuracy, long DMA transfers and fault recovery need separate protocol-specific verification.

## Sourcery 总结

新增手动 I2C 寄存器读写以及写入/回读检查，用于在所有支持的完成模式下验证真实设备。

新功能：
- 新增由调用方配置的手动 I2C 寄存器读写和写入/回读测试，涵盖阻塞、轮询和回调完成模式。

增强功能：
- 验证传输输入，并在重复检查期间检测未完成、重复、失败或不匹配的 I2C 操作。

文档：
- 在双语测试指南中记录手动 I2C 测试的设置、使用方法、安全注意事项和限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add manual I2C register read and write/readback checks for validating real devices across all supported completion modes.

New Features:
- Add caller-configured manual I2C register read and write/readback tests covering blocking, polling, and callback completion modes.

Enhancements:
- Validate transfer inputs and detect incomplete, duplicate, failed, or mismatched I2C operations during repeated checks.

Documentation:
- Document setup, usage, safety considerations, and limitations for the manual I2C tests in bilingual test guides.

</details>