### PR TITLE
test: add manual SPI full-duplex loopback checks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC、Flash 和 I2C 测试。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC, Flash and I2C tests.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC、Flash、I2C 和 SPI 测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC, Flash, I2C and SPI tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)、[Flash 擦写测试](flash/README.md)及 [I2C 寄存器读写测试](i2c/README.md)，不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)、[Flash 擦写测试](flash/README.md)、[I2C 寄存器读写测试](i2c/README.md)及 [SPI 回环测试](spi/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md), [Flash erase/program tests](flash/README.md) and [I2C register read/write tests](i2c/README.md) are available. CI does not run them.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md), [Flash erase/program tests](flash/README.md), [I2C register read/write tests](i2c/README.md) and [SPI loopback tests](spi/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/i2c/test_i2c.hpp
+++ b/test/manual/driver/i2c/test_i2c.hpp
@@ -8,12 +8,12 @@
  */
 #pragma once
 
-#include <atomic>
 #include <cstring>
 
 #include "i2c.hpp"
 #include "test_assert.hpp"
 #include "thread.hpp"
+#include "transfer_wait.hpp"
 
 namespace LibXR::Test
 {
@@ -58,91 +58,6 @@ inline void CheckI2CData(ConstRawData expected, RawData buffer)
   }
 }
 
-/** @brief 两项 I2C 测试共用的完成通知 / Completion state shared by the two I2C tests. */
-class I2CTestCompletion
-{
-  using Transfer = Operation<ErrorCode>;
-  using Status = Transfer::OperationPollingStatus;
-  using Mode = Transfer::OperationType;
-
- public:
-  explicit I2CTestCompletion(uint32_t timeout_ms)
-      : callback_(Transfer::Callback::Create(
-            [](bool, I2CTestCompletion* self, ErrorCode result)
-            {
-              if (result != ErrorCode::OK)
-              {
-                self->failed_.store(1, std::memory_order_relaxed);
-              }
-              // 最后一次访问上下文才发布完成；ISR 中不打印或断言。
-              // Publish on the last context access; no logging or assertions in ISR.
-              self->calls_.fetch_add(1, std::memory_order_release);
-            },
-            this)),
-        operations_{Transfer(semaphore_, timeout_ms), Transfer(status_),
-                    Transfer(callback_)},
-        timeout_ms_(timeout_ms)
-  {
-    TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
-  }
-
-  template <typename Submit>
-  void Run(unsigned mode_index, Submit submit)
-  {
-    auto& operation = operations_[mode_index];
-    const Mode mode = operation.type;
-    Check();
-    status_.store(Status::READY, std::memory_order_relaxed);
-    if (mode == Mode::CALLBACK)
-    {
-      ++expected_calls_;
-    }
-    TEST_ASSERT(submit(operation) == ErrorCode::OK);
-    const uint32_t start = Thread::GetTime();
-    for (;;)
-    {
-      bool done = mode == Mode::BLOCK;
-      if (mode == Mode::POLLING)
-      {
-        const auto status = status_.load(std::memory_order_acquire);
-        TEST_ASSERT(status != Status::ERROR);
-        done = status == Status::DONE;
-      }
-      else if (mode == Mode::CALLBACK)
-      {
-        const uint32_t calls = calls_.load(std::memory_order_acquire);
-        TEST_ASSERT(calls <= expected_calls_);
-        done = calls == expected_calls_;
-      }
-      TEST_ASSERT(failed_.load(std::memory_order_relaxed) == 0);
-      // 同步完成时直接继续；不要求必须观察到 RUNNING。
-      // Continue immediately for inline completion; observing RUNNING is not required.
-      if (done)
-      {
-        break;
-      }
-      TEST_ASSERT(Thread::GetTime() - start < timeout_ms_);
-      Thread::Sleep(1);
-    }
-    Check();
-  }
-
-  void Check() const
-  {
-    TEST_ASSERT(calls_.load(std::memory_order_acquire) == expected_calls_);
-    TEST_ASSERT(failed_.load(std::memory_order_relaxed) == 0);
-  }
-
- private:
-  Semaphore semaphore_;
-  std::atomic<Status> status_{Status::READY};
-  std::atomic<uint32_t> calls_{0};
-  std::atomic<uint32_t> failed_{0};
-  Transfer::Callback callback_;
-  Transfer operations_[3];
-  uint32_t timeout_ms_;
-  uint32_t expected_calls_ = 0;
-};
 }  // namespace Detail
 
 /**
@@ -171,7 +86,7 @@ inline void TestI2CMemRead(I2C& i2c, uint16_t slave_addr, uint16_t mem_addr,
   Detail::CheckI2CRegister(slave_addr, mem_addr, addr_length);
   Detail::CheckI2CBuffers(expected, buffer);
   TEST_ASSERT(iterations > 0);
-  Detail::I2CTestCompletion completion(timeout_ms);
+  Detail::TransferTestCompletion completion(timeout_ms);
   const RawData read_buffer{buffer.addr_, expected.size_};
   for (uint32_t round = 0; round < iterations; ++round)
   {
@@ -226,7 +141,7 @@ inline void TestI2CMemWriteRead(I2C& i2c, uint16_t slave_addr, uint16_t mem_addr
   TEST_ASSERT(std::memcmp(first.addr_, second.addr_, first.size_) != 0);
   TEST_ASSERT(settle_ms < UINT32_MAX / 2U && iterations > 0 &&
               iterations <= UINT32_MAX / 4U);
-  Detail::I2CTestCompletion completion(timeout_ms);
+  Detail::TransferTestCompletion completion(timeout_ms);
   const ConstRawData patterns[] = {first, second};
   const RawData read_buffer{buffer.addr_, first.size_};
   for (uint32_t round = 0; round < iterations; ++round)

--- a/test/manual/driver/spi/README.md
+++ b/test/manual/driver/spi/README.md
@@ -1,0 +1,59 @@
+# SPI 手动测试 / Manual SPI test
+
+将主机 MOSI 接到 MISO，调用 `ReadAndWrite()` 同时发送和接收已知数据。每个指定长度都分别检查阻塞、轮询和回调完成方式，逐字节验证接收数据和发送缓冲区。
+
+Wire the master's MOSI to MISO and use `ReadAndWrite()` to transmit and receive known data simultaneously. For every selected length, check blocking, polling and callback completion, received bytes and the transmit buffer contents.
+
+## 接线和准备 / Wiring and setup
+
+初始化为 **8 位帧、全双工主机**，MISO 上不能同时连接其他输出。调用方完成时钟、模式、片选和中断／DMA 配置，并独占总线。先选择适合回环接线的保守速率。
+
+Configure an **8-bit full-duplex master**, with no other output driving MISO. The caller configures clock, mode, chip select and interrupt/DMA resources and reserves the bus. Start at a conservative rate suitable for the loopback wiring.
+
+传入两个独立的 RAM 工作缓冲区，不得相互重叠，也不能使用后端当前正在操作的缓冲区。各次传输的长度须满足实际容量、对齐和内存访问要求。测试不更改 SPI 配置。
+
+Supply two separate RAM work buffers, disjoint from each other and the backend's active buffers. Transfer lengths must meet the actual capacity, alignment and memory-access requirements. The test does not change the SPI configuration.
+
+## 调用 / Usage
+
+把 `test/` 和 `test/manual/driver/` 加入应用的头文件搜索路径，从普通任务调用。由应用提供缓冲区和适用的长度列表：
+
+Add `test/` and `test/manual/driver/` to the application's include paths and call from a normal task. Supply the buffers and appropriate lengths from the application:
+
+```cpp
+#include "spi/test_spi.hpp"
+
+void CheckSPI(LibXR::SPI& spi, LibXR::RawData tx, LibXR::RawData rx,
+               std::initializer_list<size_t> lengths)
+{
+  LibXR::Test::TestSPILoopback(spi, tx, rx, lengths);
+}
+```
+
+选择短包、较长包以及合法的边界长度。如果后端按长度选择不同传输方式，应由调用工程选择能触及这些分支的长度；通用测试不内置 DMA 阈值。
+
+Select short, longer and valid boundary lengths. If the backend chooses a transfer path based on length, the calling project should select lengths that exercise those paths. The generic test contains no DMA threshold.
+
+最后两个参数为 `timeout_ms` 和 `iterations`，默认 1000 ms 和 1000 轮。总传输次数为“长度数量 × 3 × 轮数”，最后一个参数填 1 可快速检查。
+
+The final arguments are `timeout_ms` and `iterations`, defaulting to 1000 ms and 1000 rounds. Total transfers are “number of lengths × 3 × rounds”; use one round for a quick check.
+
+## 检查内容 / Checks
+
+发送内容随位置、长度、轮次和完成方式变化。接收区预先填入错误值，防止没有复制数据却误通过。完成后，收发内容都与生成规则比较，不会仅凭两个缓冲区相等就判定成功。
+
+Transmit data varies with position, length, round and completion mode. Prefill the receive area with incorrect bytes to detect missing copies. After completion, compare both buffers against the generated pattern rather than merely checking that they match each other.
+
+测试复用与 I2C 测试相同的完成等待辅助代码，允许同步或异步完成。回调只更新原子状态，所有报错在调用线程进行。超时参数不能强行中断后端调用内部的同步执行；失败触发 `TEST_ASSERT` 并停止，不带着未完成的操作返回。
+
+The test reuses the completion-wait helper used by I2C tests and accepts inline or deferred completion. Callbacks only update atomic state; diagnostics run in the calling thread. The timeout cannot preempt synchronous work inside the backend call. Failure triggers `TEST_ASSERT` and stops rather than returning with a pending operation.
+
+两个工作缓冲区都会被改写，正常结束后保留最后一帧数据。测试不创建辅助线程，回调和等待对象在轮次间复用；CI 不自动运行接线测试。
+
+Both work buffers are overwritten and retain the final frame on success. No helper threads are created; callback and wait state are reused between rounds. CI does not run the wired test automatically.
+
+## 验证范围 / Scope
+
+这项回环检查等长全双工数据通路。它不验证单独 `Read()`／`Write()` 的空方向处理、`MemRead()`／`MemWrite()` 的从机协议、`Transfer()` 或双缓冲的专门行为。片选时序、实际时钟频率和模式是否符合外部设备要求，也不能仅靠同一控制器的自回环证明。
+
+This loopback checks equal-length full-duplex data transfers. It does not validate empty-direction handling in separate `Read()`/`Write()` calls, slave protocols in `MemRead()`/`MemWrite()`, or the dedicated behavior of `Transfer()` and double buffering. Self-loopback on one controller also cannot independently prove chip-select timing, actual clock frequency or mode compliance with an external device.

--- a/test/manual/driver/spi/test_spi.hpp
+++ b/test/manual/driver/spi/test_spi.hpp
@@ -1,0 +1,88 @@
+/**
+ * @file test_spi.hpp
+ * @brief SPI 全双工接线回环测试 / Wired full-duplex SPI loopback test.
+ *
+ * 在指定长度下反复同时收发，检查三种完成方式、接收内容和发送缓冲区保持不变。
+ * Repeat equal-length transfers in three completion modes; check received bytes
+ * and that the transmitted bytes remain unchanged. Requires MOSI wired to MISO.
+ */
+#pragma once
+
+#include <initializer_list>
+
+#include "spi.hpp"
+#include "test_assert.hpp"
+#include "transfer_wait.hpp"
+
+namespace LibXR::Test
+{
+/**
+ * @brief 检查不同长度下的全双工回环 / Check full-duplex loopback at selected lengths.
+ * @pre 初始化为 8 位帧全双工主机，MOSI 接 MISO，MISO 不连接其他输出。
+ *      Configure an 8-bit full-duplex master; wire MOSI to MISO without other outputs on
+ * MISO.
+ * @pre 独占总线；tx/rx 是独立工作 RAM，不能与彼此或后端正在使用的缓冲区重叠。
+ *      Reserve the bus; tx/rx must be separate work RAM, disjoint from each other and
+ * active backend buffers.
+ * @param spi 已初始化的 SPI / Initialized SPI controller.
+ * @param tx 发送工作缓冲区，内容会被覆盖 / Transmit work buffer; contents are
+ * overwritten.
+ * @param rx 接收工作缓冲区，内容会被覆盖 / Receive work buffer; contents are overwritten.
+ * @param lengths 每轮测试的字节数列表，须满足后端容量和对齐要求 /
+ *        Byte lengths tested each round, within backend capacity/alignment requirements.
+ * @param timeout_ms BLOCK 超时及返回后的完成等待上限 / BLOCK timeout and post-return wait
+ * limit.
+ * @param iterations 重复轮数，每个长度均测试三种完成方式 /
+ *        Rounds; every length uses all three completion modes.
+ */
+inline void TestSPILoopback(SPI& spi, RawData tx, RawData rx,
+                            std::initializer_list<size_t> lengths,
+                            uint32_t timeout_ms = 1000, uint32_t iterations = 1000)
+{
+  TEST_ASSERT(tx.addr_ != nullptr && rx.addr_ != nullptr);
+  TEST_ASSERT(iterations > 0 && lengths.size() > 0 &&
+              lengths.size() <= UINT32_MAX / iterations);
+  const auto tx_begin = reinterpret_cast<uintptr_t>(tx.addr_);
+  const auto rx_begin = reinterpret_cast<uintptr_t>(rx.addr_);
+  TEST_ASSERT(tx_begin >= rx_begin ? tx_begin - rx_begin >= rx.size_
+                                   : rx_begin - tx_begin >= tx.size_);
+  for (size_t length : lengths)
+  {
+    TEST_ASSERT(length > 0 && length <= tx.size_ && length <= rx.size_);
+  }
+  auto* sent = static_cast<uint8_t*>(tx.addr_);
+  auto* received = static_cast<uint8_t*>(rx.addr_);
+  Detail::TransferTestCompletion completion(timeout_ms);
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    for (size_t length : lengths)
+    {
+      for (unsigned mode = 0; mode < 3; ++mode)
+      {
+        const auto seed = static_cast<uint8_t>(round + length + mode * 85U);
+        auto expected = [&](size_t i) { return static_cast<uint8_t>((i % 251U) ^ seed); };
+        for (size_t i = 0; i < length; ++i)
+        {
+          sent[i] = expected(i);
+          received[i] = static_cast<uint8_t>(~expected(i));
+        }
+        completion.Run(mode,
+                       [&](SPI::OperationRW& operation)
+                       {
+                         return spi.ReadAndWrite({received, length}, {sent, length},
+                                                 operation, false);
+                       });
+        // 分别对照生成规则，避免收发缓冲区被同时改坏后仍相等。
+        // Check both against the pattern, not just each other, to catch shared
+        // corruption.
+        for (size_t i = 0; i < length; ++i)
+        {
+          TEST_ASSERT(sent[i] == expected(i));
+          TEST_ASSERT(received[i] == expected(i));
+        }
+        completion.Check();
+      }
+    }
+  }
+}
+}  // namespace LibXR::Test

--- a/test/manual/driver/transfer_wait.hpp
+++ b/test/manual/driver/transfer_wait.hpp
@@ -1,0 +1,104 @@
+/**
+ * @file transfer_wait.hpp
+ * @brief 驱动测试共用的操作完成等待 / Operation completion waits shared by driver tests.
+ *
+ * 复用阻塞、轮询和回调通知，检查错误、超时及观测到的回调次数。
+ * Reuse blocking, polling and callback notifications; check errors, timeouts and
+ * observed callback counts. This helper does not submit transfers by itself.
+ */
+#pragma once
+
+#include <atomic>
+
+#include "operation.hpp"
+#include "test_assert.hpp"
+#include "thread.hpp"
+
+namespace LibXR::Test::Detail
+{
+/** @brief 一组可复用的测试完成通知 / Reusable completion notifications for tests. */
+class TransferTestCompletion
+{
+  using Transfer = Operation<ErrorCode>;
+  using Status = Transfer::OperationPollingStatus;
+  using Mode = Transfer::OperationType;
+
+ public:
+  explicit TransferTestCompletion(uint32_t timeout_ms)
+      : callback_(Transfer::Callback::Create(
+            [](bool, TransferTestCompletion* self, ErrorCode result)
+            {
+              if (result != ErrorCode::OK)
+              {
+                self->failed_.store(1, std::memory_order_relaxed);
+              }
+              // 最后一次访问上下文才发布完成；ISR 中不打印或断言。
+              // Publish on the last context access; no logging or assertions in ISR.
+              self->calls_.fetch_add(1, std::memory_order_release);
+            },
+            this)),
+        operations_{Transfer(semaphore_, timeout_ms), Transfer(status_),
+                    Transfer(callback_)},
+        timeout_ms_(timeout_ms)
+  {
+    TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
+  }
+
+  template <typename Submit>
+  void Run(unsigned mode_index, Submit submit)
+  {
+    auto& operation = operations_[mode_index];
+    const Mode mode = operation.type;
+    Check();
+    status_.store(Status::READY, std::memory_order_relaxed);
+    if (mode == Mode::CALLBACK)
+    {
+      ++expected_calls_;
+    }
+    TEST_ASSERT(submit(operation) == ErrorCode::OK);
+    const uint32_t start = Thread::GetTime();
+    for (;;)
+    {
+      bool done = mode == Mode::BLOCK;
+      if (mode == Mode::POLLING)
+      {
+        const auto status = status_.load(std::memory_order_acquire);
+        TEST_ASSERT(status != Status::ERROR);
+        done = status == Status::DONE;
+      }
+      else if (mode == Mode::CALLBACK)
+      {
+        const uint32_t calls = calls_.load(std::memory_order_acquire);
+        TEST_ASSERT(calls <= expected_calls_);
+        done = calls == expected_calls_;
+      }
+      TEST_ASSERT(failed_.load(std::memory_order_relaxed) == 0);
+      // 同步完成时直接继续；不要求必须观察到 RUNNING。
+      // Continue immediately for inline completion; observing RUNNING is not required.
+      if (done)
+      {
+        break;
+      }
+      TEST_ASSERT(Thread::GetTime() - start < timeout_ms_);
+      Thread::Sleep(1);
+    }
+    Check();
+  }
+
+  void Check() const
+  {
+    TEST_ASSERT(calls_.load(std::memory_order_acquire) == expected_calls_);
+    TEST_ASSERT(failed_.load(std::memory_order_relaxed) == 0);
+  }
+
+ private:
+  Semaphore semaphore_;
+  std::atomic<Status> status_{Status::READY};
+  std::atomic<uint32_t> calls_{0};
+  std::atomic<uint32_t> failed_{0};
+  Transfer::Callback callback_;
+  Transfer operations_[3];
+  uint32_t timeout_ms_;
+  uint32_t expected_calls_ = 0;
+};
+}  // namespace LibXR::Test::Detail


### PR DESCRIPTION
Adds `TestSPILoopback(SPI&, tx, rx, lengths, timeout_ms, iterations)` under `test/manual/driver/spi/`. It tests equal-length 8-bit full-duplex transfers in BLOCK, POLLING and CALLBACK modes using caller-selected lengths. Generated bytes vary by position, length, round and mode. Receive storage is poisoned; both receive and transmit contents are checked against the generated pattern after completion.

The existing I2C completion helper moves to `test/manual/driver/transfer_wait.hpp` for reuse. Its class body is unchanged apart from naming/formatting, and I2C public test APIs are unchanged. No separate notification framework or duplicated wait logic is added. The new SPI test is 88 lines. Device pins, frame/clock configuration, DMA threshold and board adapters remain outside the generic test/docs.

Validation:
- STM32G0B1, MOSI-to-MISO wiring, caller configuration 8-bit mode 0 / nominal 1 MHz, lengths 1/2/3/4/17/32, all three completion modes, 1000 rounds: 18000 transfers passed in about 8 s, 177000 bytes checked in each direction. Current backend threshold 3 selects 9000 short and 9000 DMA transfers; the board recorded 27000 DMA IRQ entries. Both TX immutability and RX data comparisons passed with an empty error log.
- ARM GNU 14.2.1 Debug with developer assertions ON; full firmware link passed with no undefined symbols. J-Link verified flashing, ran freely for 15 s and read a PASS result. Final controller idle, CPU halted at completion; option bytes unchanged. The isolated BSP configures 8-bit frames, slow enough clocking and SPI-only forwarding in its shared DMA IRQ (the stock handler also referenced uninitialized UART DMA handles). No product driver changes.
- Linux Release/DEV_ASSERT OFF product/header build and 58 host outcomes passed: 20 SPI cases covering immediate/deferred transport, wrong/missing/partial data, corrupt TX/both buffers, missing/duplicate/error completion, invalid input and periodic corruption; plus all 38 I2C read/write cases rerun after moving the common helper. Host transport/board fixtures and logs are outside the repository.
- clang-format 21.1.8 and diff checks passed. The host probe retains the known libxr_string.hpp:658 missing-initializer warning as nonfatal under otherwise -Wall -Wextra -Werror. The isolated BSP retains unused generated init-function warnings.

The test does not change SPI configuration or toggle a device-specific CS. It does not validate standalone Read/Write, register commands, zero-copy Transfer/double-buffer behavior, actual clock frequency or electrical CPOL/CPHA compliance. It is a bounded full-duplex loopback result for the tested configuration, not all SPI behavior. Manual tests are not added to CI execution.

## Sourcery 摘要

新增可复用的手动 SPI 全双工回环检查，并将其完成处理逻辑与现有 I2C 测试共享。

新功能：
- 新增手动 SPI MOSI-to-MISO 回环测试，覆盖阻塞、轮询和回调模式下等长度的 8 位全双工传输。
- 记录 SPI 手动测试的设置、用法、检查项和验证范围。

增强功能：
- 将 I2C 测试中的可复用传输完成等待逻辑提取到共享的驱动程序测试辅助工具中。

文档：
- 更新手动测试索引，加入 SPI 回环测试覆盖范围，并明确说明这些测试不会由 CI 运行。

测试：
- 验证调用方选择的长度和重复轮次下生成的发送与接收数据模式，包括发送缓冲区不可变性以及对已填充接收缓冲区的检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a reusable manual SPI full-duplex loopback check and share its completion handling with existing I2C tests.

New Features:
- Add a manual SPI MOSI-to-MISO loopback test covering equal-length 8-bit full-duplex transfers in blocking, polling, and callback modes.
- Document SPI manual-test setup, usage, checks, and validation scope.

Enhancements:
- Extract the reusable transfer-completion waiting logic from the I2C tests into a shared driver-test helper.

Documentation:
- Update manual-test indexes to include SPI loopback coverage and clarify that these tests are not run by CI.

Tests:
- Validate generated transmit and receive patterns across caller-selected lengths and repeated rounds, including transmit-buffer immutability and poisoned receive-buffer detection.

</details>