### PR TITLE
test: add classic CAN and CAN FD internal loopback checks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC、Flash、I2C 和 SPI 测试。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC, Flash, I2C and SPI tests.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC、Flash、I2C、SPI 和 CAN / CAN FD 测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC, Flash, I2C, SPI and CAN / CAN FD tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)、[Flash 擦写测试](flash/README.md)、[I2C 寄存器读写测试](i2c/README.md)及 [SPI 回环测试](spi/README.md)，不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)、[Flash 擦写测试](flash/README.md)、[I2C 寄存器读写测试](i2c/README.md)、[SPI 回环测试](spi/README.md)及 [CAN / CAN FD 内部回环测试](can/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md), [Flash erase/program tests](flash/README.md), [I2C register read/write tests](i2c/README.md) and [SPI loopback tests](spi/README.md) are available. CI does not run them.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md), [Flash erase/program tests](flash/README.md), [I2C register read/write tests](i2c/README.md), [SPI loopback tests](spi/README.md) and [CAN / CAN FD internal loopback tests](can/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/can/README.md
+++ b/test/manual/driver/can/README.md
@@ -1,0 +1,84 @@
+# CAN / CAN FD 手动测试 / Manual CAN and CAN FD tests
+
+使用控制器内部回环，逐帧检查经典 CAN 标准数据帧和扩展数据帧。每轮各发送 DLC 0～8 的帧，共 18 帧；第一轮包含 ID 的最小值和最大值，其余帧使用变化的 ID 和数据。
+
+Use controller internal loopback to check classic CAN standard and extended data frames. Each round sends DLC 0 through 8 for both types, for 18 frames total. The first round includes minimum and maximum IDs; other frames use varying IDs and data.
+
+## 准备控制器 / Prepare the controller
+
+调用方初始化系统、CAN 位时序、内部回环、接收过滤器和中断，并独占控制器。硬件过滤器应允许全部标准和扩展数据帧进入驱动。内部回环不需要外部收发器接线。
+
+Initialize the system, CAN bit timing, internal loopback, receive filters and interrupts, and reserve the controller. Hardware filters must admit all standard and extended data frames to the driver. Internal loopback needs no external transceiver wiring.
+
+构造测试对象前清理旧通信，确保没有排队帧或在途回调。接收回调须由后端串行调用；测试用一个小 SPSC 队列复制回调帧，不保留后端临时数据的引用。
+
+Finish old traffic before constructing the test object, with no queued frames or callbacks in flight. The backend must serialize receive callbacks. A small SPSC queue copies each callback frame rather than retaining a reference to temporary backend data.
+
+## 调用 / Usage
+
+把 `test/` 和 `test/manual/driver/` 加入应用的头文件搜索路径。在控制器配置完成后，从普通任务调用：
+
+Add `test/` and `test/manual/driver/` to the application's include paths. Once the controller is configured, call from a normal task:
+
+```cpp
+#include "can/test_can.hpp"
+
+// 只调用一次，can 对象也保留到复位。
+// Call once; retain the CAN object until reset too.
+void RunCANTest(LibXR::CAN& can)
+{
+  static LibXR::Test::CANLoopbackTest test(can);
+  test.Run();
+}
+```
+
+`Run(timeout_ms, iterations)` 默认每帧等待上限为 1000 ms，重复 1000 轮，即 18000 帧。最后一个参数填 1 可快速检查。超时限制提交返回后的接收等待，不能强行中断后端在 `AddMessage()` 内部的同步执行。
+
+`Run(timeout_ms, iterations)` defaults to a 1000 ms receive wait per frame and 1000 rounds, or 18000 frames. Use one round for a quick check. The timeout bounds receive waiting after submission returns; it cannot preempt synchronous work inside `AddMessage()`.
+
+**测试对象和 CAN 对象必须保持地址不变并保留到复位，每个对象只运行一次。** 当前接口没有注销订阅的方法。队列和订阅在构造时创建，循环中不分配内存或创建辅助线程。
+
+**Keep the test and CAN objects at stable addresses until reset, and run once per test object.** The current API cannot unregister subscriptions. Queue and subscriptions are created during construction; no memory or helper threads are allocated in the loop.
+
+## 检查内容 / Checks
+
+`AddMessage()` 成功只表示提交成功，测试必须收到对应帧才继续。每次只保留一个未完成帧，核对 ID、类型、DLC 和有效载荷，不假设多帧排队时的仲裁顺序。DLC 为零时不比较数据数组，其他帧也不比较 DLC 之外的字节。
+
+Successful `AddMessage()` only means submission succeeded; the test waits for the matching received frame. Only one frame is outstanding. Check ID, type, DLC and valid payload without assuming arbitration order for queued frames. Compare no payload for DLC zero and ignore bytes beyond DLC for other frames.
+
+回调只复制帧并更新原子状态，检查和报错在调用任务进行。错误事件、漏帧、队列溢出、数据不符或观测到的多余回调都会使 `TEST_ASSERT` 停止测试，不会丢弃异常后重试。
+
+Callbacks only copy frames and update atomic state; checks and diagnostics run in the caller. Error events, missing frames, queue overflow, mismatches or observed extra callbacks stop the test through `TEST_ASSERT`, without discarding failures and retrying.
+
+正常结束后不再发送，但内部回环配置和订阅仍保留。最后有 1 ms 的额外回调观察窗口，它不能证明以后永远没有迟到帧，也不能替代注销或回调退出确认。
+
+On success, sending stops but loopback configuration and subscriptions remain. A final 1 ms observation window checks for extra callbacks; it cannot rule out all later frames or replace unsubscribe or callback-exit confirmation.
+
+上述经典 CAN 测试不验证 CAN FD、远程帧、真实总线仲裁与 ACK、收发器、终端电阻或 BUS-OFF 恢复。内部回环的通过不能代替外部总线测试，CI 不自动运行此项测试。
+
+The classic CAN test above does not validate CAN FD, remote frames, real bus arbitration or ACK, transceivers, termination or bus-off recovery. Passing internal loopback does not replace an external bus test. CI does not run this test automatically.
+
+
+## CAN FD 内部回环 / CAN FD internal loopback
+
+FD 测试使用独立的 `FDCANLoopbackTest`，同样要求控制器独占、回调串行、对象保留到复位，每个测试对象只运行一次。先由调用方启用 CAN FD，并配置仲裁相位、数据相位和内部回环。
+
+Use the separate `FDCANLoopbackTest` for FD frames. The same exclusive-controller, serialized-callback and retain-until-reset requirements apply; run once per test object. The caller first enables CAN FD and configures nominal/data phase timing and internal loopback.
+
+```cpp
+#include "can/test_fdcan.hpp"
+
+void RunFDTest(LibXR::FDCAN& can)
+{
+  static LibXR::Test::FDCANLoopbackTest test(can);
+  test.Run();
+}
+```
+
+每轮分别发送标准和扩展 FD 帧，长度为 `0～8、12、16、20、24、32、48、64` 字节，共 32 帧。默认 1000 轮，即 32000 帧。检查 ID、类型、长度和有效数据，并检查 0～8 字节的短 FD 帧没有被误送到经典 CAN 回调。
+
+Each round sends standard and extended FD frames at lengths `0–8, 12, 16, 20, 24, 32, 48, 64` bytes, for 32 frames. The default 1000 rounds check 32000 frames. Validate ID, type, length and valid data, and reject short FD frames incorrectly routed to classic CAN callbacks.
+
+这里只使用 FD 可直接编码的长度，不规定其他长度如何补齐。当前 `FDPack` 回调没有 BRS、ESI 字段，因此它们不作为逐帧回读判据。通过内部回环也不能证明外部总线、电气时序或实际相位速率正确。
+
+Only canonical FD lengths are used; no padding policy is imposed for other lengths. The current `FDPack` callback exposes no BRS or ESI fields, so they are not checked per frame. Internal loopback also does not prove external bus, electrical timing or actual phase-rate correctness.

--- a/test/manual/driver/can/test_can.hpp
+++ b/test/manual/driver/can/test_can.hpp
@@ -1,0 +1,140 @@
+/**
+ * @file test_can.hpp
+ * @brief 经典 CAN 内部回环测试 / Classic CAN internal loopback test.
+ *
+ * 逐帧检查标准、扩展数据帧的 ID、DLC 0..8、有效数据以及漏帧和多余回调。
+ * Check standard/extended IDs, DLC 0..8, valid payload, missing frames and extra
+ * callbacks, with one outstanding frame. Retain the test object until reset.
+ */
+#pragma once
+
+#include <atomic>
+
+#include "can.hpp"
+#include "spsc_queue.hpp"
+#include "test_assert.hpp"
+#include "thread.hpp"
+
+namespace LibXR::Test
+{
+/**
+ * @brief 长期保留的 CAN 回环测试对象 / Caller-retained CAN loopback test object.
+ * @pre 调用方配置内部回环并独占控制器，允许接收全部标准和扩展数据帧。
+ *      Configure internal loopback, reserve the controller and accept all standard
+ *      and extended data frames.
+ * @pre 注册前没有旧帧或在途回调；后端串行调用接收回调，作为队列的唯一生产者。
+ *      Start without old frames or callbacks in flight; the backend must serialize
+ *      receive callbacks as the queue's sole producer.
+ * @pre CAN 和测试对象地址保持不变并保留到复位，当前接口不能注销订阅。
+ *      Keep CAN and this object at stable addresses until reset; subscriptions cannot be
+ * removed.
+ */
+class CANLoopbackTest
+{
+ public:
+  explicit CANLoopbackTest(CAN& can) : can_(can)
+  {
+    auto callback = CAN::Callback::Create(
+        [](bool, CANLoopbackTest* self, const CAN::ClassicPack& frame)
+        {
+          // 帧引用只在回调期间有效，先复制，再发布完成计数。
+          // Copy the ephemeral frame before publishing the completion count.
+          if (self->received_.Push(frame) != ErrorCode::OK)
+          {
+            self->overflow_.store(1, std::memory_order_relaxed);
+          }
+          self->calls_.fetch_add(1, std::memory_order_release);
+        },
+        this);
+    can_.Register(callback, CAN::Type::STANDARD);
+    can_.Register(callback, CAN::Type::EXTENDED);
+    can_.Register(callback, CAN::Type::ERROR);
+  }
+  CANLoopbackTest(const CANLoopbackTest&) = delete;
+  CANLoopbackTest& operator=(const CANLoopbackTest&) = delete;
+
+  /**
+   * @brief 逐帧发送并核对内部回环结果 / Send and verify internal loopback frame by frame.
+   * @pre 系统已初始化，从普通任务调用；每个对象只运行一次。
+   *      Initialize the system, call from normal task context, and run once per object.
+   * @param timeout_ms 每帧提交后等待接收的上限 / Receive deadline after each submission.
+   * @param iterations 轮数，每轮 18 帧 / Rounds, each containing 18 frames.
+   */
+  void Run(uint32_t timeout_ms = 1000, uint32_t iterations = 1000)
+  {
+    TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
+    TEST_ASSERT(iterations > 0 && iterations <= UINT32_MAX / 18U);
+    CheckEmpty(0);
+    uint32_t sequence = 0;
+    for (uint32_t round = 0; round < iterations; ++round)
+    {
+      for (unsigned extended = 0; extended < 2; ++extended)
+      {
+        const uint32_t id_mask = extended ? 0x1FFFFFFFU : 0x7FFU;
+        for (uint8_t length = 0; length <= 8; ++length)
+        {
+          CAN::ClassicPack sent{};
+          const auto type = extended ? CAN::Type::EXTENDED : CAN::Type::STANDARD;
+          const uint32_t id = (round == 0 && length < 2)
+                                  ? (length == 0 ? 0U : id_mask)
+                                  : (sequence * 0x1F123BB5U) & id_mask;
+          sent.type = type;
+          sent.id = id;
+          sent.dlc = length;
+          for (uint8_t i = 0; i < length; ++i)
+          {
+            sent.data[i] = static_cast<uint8_t>(sequence + i * 29U);
+          }
+          CheckEmpty(sequence);
+          TEST_ASSERT(can_.AddMessage(sent) == ErrorCode::OK);
+          const uint32_t start = Thread::GetTime();
+          for (;;)
+          {
+            const uint32_t calls = calls_.load(std::memory_order_acquire);
+            TEST_ASSERT(overflow_.load(std::memory_order_relaxed) == 0);
+            TEST_ASSERT(calls <= sequence + 1U);
+            if (calls == sequence + 1U)
+            {
+              break;
+            }
+            TEST_ASSERT(Thread::GetTime() - start < timeout_ms);
+            Thread::Sleep(1);
+          }
+          CAN::ClassicPack received{};
+          TEST_ASSERT(received_.Pop(received) == ErrorCode::OK);
+          TEST_ASSERT(sent.type == type && sent.id == id && sent.dlc == length);
+          TEST_ASSERT(received.type == type && received.id == id &&
+                      received.dlc == length);
+          // DLC 之外的数据没有意义，零长度帧不比较 payload。
+          // Bytes beyond DLC are unspecified; zero-length frames have no payload to
+          // compare.
+          for (uint8_t i = 0; i < length; ++i)
+          {
+            const auto value = static_cast<uint8_t>(sequence + i * 29U);
+            TEST_ASSERT(sent.data[i] == value && received.data[i] == value);
+          }
+          CheckEmpty(++sequence);
+        }
+      }
+    }
+    // 有限观察额外回调，不把它当作注销或等待所有未来回调的接口。
+    // Observe extra callbacks briefly; this is not unsubscribe or a future-callback
+    // barrier.
+    Thread::Sleep(1);
+    CheckEmpty(sequence);
+  }
+
+ private:
+  void CheckEmpty(uint32_t expected_calls) const
+  {
+    TEST_ASSERT(calls_.load(std::memory_order_acquire) == expected_calls);
+    TEST_ASSERT(overflow_.load(std::memory_order_relaxed) == 0);
+    TEST_ASSERT(received_.Size() == 0);
+  }
+
+  CAN& can_;
+  SPSCQueue<CAN::ClassicPack> received_{2};
+  std::atomic<uint32_t> calls_{0};
+  std::atomic<uint32_t> overflow_{0};
+};
+}  // namespace LibXR::Test

--- a/test/manual/driver/can/test_fdcan.hpp
+++ b/test/manual/driver/can/test_fdcan.hpp
@@ -1,0 +1,154 @@
+/**
+ * @file test_fdcan.hpp
+ * @brief CAN FD 内部回环测试 / CAN FD internal loopback test.
+ *
+ * 逐帧检查标准、扩展数据帧的 ID、FD 编码长度、有效数据及帧路由。
+ * Check standard/extended IDs, canonical FD lengths, payload and FD routing; detect extra
+ * callbacks, with one outstanding frame. Retain the test object until reset.
+ */
+#pragma once
+
+#include <atomic>
+
+#include "can.hpp"
+#include "spsc_queue.hpp"
+#include "test_assert.hpp"
+#include "thread.hpp"
+
+namespace LibXR::Test
+{
+/**
+ * @brief 长期保留的 CAN FD 回环测试对象 / Caller-retained CAN FD loopback test object.
+ * @pre 调用方配置 CAN FD、相位时序和内部回环，允许接收全部标准和扩展 FD 数据帧。
+ *      Configure CAN FD, phase timing and internal loopback; reserve the controller and
+ * accept standard and extended FD data frames.
+ * @pre 注册前没有旧帧或在途回调；后端串行调用接收回调，作为队列的唯一生产者。
+ *      Start without old frames or callbacks in flight; the backend must serialize
+ *      receive callbacks as the queue's sole producer.
+ * @pre CAN 和测试对象地址保持不变并保留到复位，当前接口不能注销订阅。
+ *      Keep CAN and this object at stable addresses until reset; subscriptions cannot be
+ * removed.
+ */
+class FDCANLoopbackTest
+{
+ public:
+  explicit FDCANLoopbackTest(FDCAN& can) : can_(can)
+  {
+    auto callback = FDCAN::CallbackFD::Create(
+        [](bool, FDCANLoopbackTest* self, const FDCAN::FDPack& frame)
+        {
+          // 帧引用只在回调期间有效，先复制，再发布完成计数。
+          // Copy the ephemeral frame before publishing the completion count.
+          if (self->received_.Push(frame) != ErrorCode::OK)
+          {
+            self->overflow_.store(1, std::memory_order_relaxed);
+          }
+          self->calls_.fetch_add(1, std::memory_order_release);
+        },
+        this);
+    can_.Register(callback, CAN::Type::STANDARD);
+    can_.Register(callback, CAN::Type::EXTENDED);
+    auto unexpected = CAN::Callback::Create(
+        [](bool, FDCANLoopbackTest* self, const CAN::ClassicPack&)
+        { self->unexpected_classic_.store(1, std::memory_order_release); }, this);
+    // 短 FD 帧也必须走 FD 回调；经典帧或错误事件均不是本次期望的数据。
+    // Even short FD frames must use FD callbacks; classic frames/errors are unexpected.
+    CAN& classic = can_;
+    classic.Register(unexpected, CAN::Type::STANDARD);
+    classic.Register(unexpected, CAN::Type::EXTENDED);
+    classic.Register(unexpected, CAN::Type::ERROR);
+  }
+  FDCANLoopbackTest(const FDCANLoopbackTest&) = delete;
+  FDCANLoopbackTest& operator=(const FDCANLoopbackTest&) = delete;
+
+  /**
+   * @brief 逐帧发送并核对内部回环结果 / Send and verify internal loopback frame by frame.
+   * @pre 系统已初始化，从普通任务调用；每个对象只运行一次。
+   *      Initialize the system, call from normal task context, and run once per object.
+   * @param timeout_ms 每帧提交后等待接收的上限 / Receive deadline after each submission.
+   * @param iterations 轮数，每轮 32 帧 / Rounds, each containing 32 frames.
+   */
+  void Run(uint32_t timeout_ms = 1000, uint32_t iterations = 1000)
+  {
+    TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
+    TEST_ASSERT(iterations > 0 && iterations <= UINT32_MAX / 32U);
+    CheckEmpty(0);
+    uint32_t sequence = 0;
+    // 只使用可直接编码的 FD 长度，不规定其他长度的补齐策略。
+    // Use canonical FD lengths without imposing a padding policy for other lengths.
+    const uint8_t lengths[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64};
+    for (uint32_t round = 0; round < iterations; ++round)
+    {
+      for (unsigned extended = 0; extended < 2; ++extended)
+      {
+        const uint32_t id_mask = extended ? 0x1FFFFFFFU : 0x7FFU;
+        for (uint8_t length : lengths)
+        {
+          FDCAN::FDPack sent{};
+          const auto type = extended ? CAN::Type::EXTENDED : CAN::Type::STANDARD;
+          const uint32_t id = (round == 0 && length < 2)
+                                  ? (length == 0 ? 0U : id_mask)
+                                  : (sequence * 0x1F123BB5U) & id_mask;
+          sent.type = type;
+          sent.id = id;
+          sent.len = length;
+          for (uint8_t i = 0; i < length; ++i)
+          {
+            sent.data[i] = static_cast<uint8_t>(sequence + i * 29U);
+          }
+          CheckEmpty(sequence);
+          TEST_ASSERT(can_.AddMessage(sent) == ErrorCode::OK);
+          const uint32_t start = Thread::GetTime();
+          for (;;)
+          {
+            const uint32_t calls = calls_.load(std::memory_order_acquire);
+            TEST_ASSERT(overflow_.load(std::memory_order_relaxed) == 0);
+            TEST_ASSERT(unexpected_classic_.load(std::memory_order_acquire) == 0);
+            TEST_ASSERT(calls <= sequence + 1U);
+            if (calls == sequence + 1U)
+            {
+              break;
+            }
+            TEST_ASSERT(Thread::GetTime() - start < timeout_ms);
+            Thread::Sleep(1);
+          }
+          FDCAN::FDPack received{};
+          TEST_ASSERT(received_.Pop(received) == ErrorCode::OK);
+          TEST_ASSERT(sent.type == type && sent.id == id && sent.len == length);
+          TEST_ASSERT(received.type == type && received.id == id &&
+                      received.len == length);
+          // len 之外的数据没有意义，零长度帧不比较 payload。
+          // Bytes beyond len are unspecified; zero-length frames have no payload to
+          // compare.
+          for (uint8_t i = 0; i < length; ++i)
+          {
+            const auto value = static_cast<uint8_t>(sequence + i * 29U);
+            TEST_ASSERT(sent.data[i] == value && received.data[i] == value);
+          }
+          CheckEmpty(++sequence);
+        }
+      }
+    }
+    // 有限观察额外回调，不把它当作注销或等待所有未来回调的接口。
+    // Observe extra callbacks briefly; this is not unsubscribe or a future-callback
+    // barrier.
+    Thread::Sleep(1);
+    CheckEmpty(sequence);
+  }
+
+ private:
+  void CheckEmpty(uint32_t expected_calls) const
+  {
+    TEST_ASSERT(calls_.load(std::memory_order_acquire) == expected_calls);
+    TEST_ASSERT(overflow_.load(std::memory_order_relaxed) == 0);
+    TEST_ASSERT(received_.Size() == 0);
+    TEST_ASSERT(unexpected_classic_.load(std::memory_order_acquire) == 0);
+  }
+
+  FDCAN& can_;
+  SPSCQueue<FDCAN::FDPack> received_{2};
+  std::atomic<uint32_t> calls_{0};
+  std::atomic<uint32_t> overflow_{0};
+  std::atomic<uint32_t> unexpected_classic_{0};
+};
+}  // namespace LibXR::Test


### PR DESCRIPTION
Adds two independent internal-loopback tests under `test/manual/driver/can/`, matching the common `src/driver/can.hpp` ownership:

- `CANLoopbackTest(CAN&)`: classic standard/extended data frames with DLC 0..8, 18 frames per round.
- `FDCANLoopbackTest(FDCAN&)`: standard/extended FD frames at canonical lengths 0..8, 12, 16, 20, 24, 32, 48 and 64 bytes, 32 frames per round. Short FD frames routed to classic callbacks are rejected.

Both keep one frame outstanding, wait for actual receive callbacks, and verify ID, type, length and valid payload against generated values. Sender data is checked independently too. Small SPSC queues copy ephemeral callback frames; atomic counts/flags detect overflow, missing/extra frames and errors without logging/asserting in ISR. Controllers and test objects remain alive at stable addresses until reset because subscriptions cannot be removed. No per-frame allocations, helper threads or product driver/API changes. Board configuration and host/hardware fixtures remain outside the repository; manual tests are not added to CI execution.

Validation:
- Classic G0B1 FDCAN1 internal loopback: 1000 rounds, 18000 frames (9000 of each ID type), all DLCs 0..8 and payload checks passed. The classic test header remains byte-identical to that tested version.
- Separate FD firmware on the same G0B1: 1000 rounds, 32000 FD frames (16000 of each ID type), 504000 payload bytes checked, including the final byte of 64-byte frames and short-frame FD routing. PASS and empty diagnostic buffer after a 40 s free run; the test completed in about 32 s with 32000 IRQ entries.
- FD/BRS was enabled by the isolated HAL initialization, with nominal 500 kbit/s and data 2 Mbit/s timing. Readback showed DBTP=0x00010C10, NBTP=0x00070C01 and CCCR=0x000013A0. The current STM32 SetConfig implementation does not apply fd_mode; this test does not claim to verify that configuration field. FDPack exposes no received BRS/ESI flags, so those are not checked per frame.
- ARM GNU 14.2.1 Debug/DEV_ASSERT ON full classic and FD firmware links passed with no undefined symbols. J-Link verified flashing; option bytes remained unchanged. Final board state is the completed FD test firmware, CPU halted and internal FD loopback configured.
- Linux Release/DEV_ASSERT OFF builds passed with both headers included together. All 19 classic and 22 FD host outcomes passed, including immediate/deferred transport, wrong fields/data, misrouting to classic, 64-byte truncation/tail corruption, stale/duplicate/dropped/error frames, overflow and invalid inputs. These fixtures are not hardware evidence.
- clang-format 21.1.8 and diff checks passed. The host probe retains the known libxr_string.hpp:658 missing-initializer warning as nonfatal under otherwise -Wall -Wextra -Werror; the isolated BSP retains unused generated init-function warnings.

Noncanonical FD-length padding, remote frames, external transceivers/termination, actual bus arbitration/ACK, bus-off recovery and independent phase-rate measurement are outside these tests. A final short quiet interval is not an unsubscribe or lifetime barrier.

## Sourcery 摘要

新增手动 CAN 和 CAN FD 内部环回检查，并提供全面的帧验证和使用文档。

新功能：
- 新增手动经典 CAN 和 CAN FD 内部环回测试，涵盖标准数据帧和扩展数据帧，并对所有受支持的帧长度进行载荷验证。

增强功能：
- 提供有界且回调安全的帧检查，能够检测溢出、帧缺失、额外回调以及错误路由。
- 为 CAN/CAN FD 手动测试补充控制器设置、对象生命周期要求、调用方式、覆盖范围和限制等文档。

文档：
- 更新手动测试索引，加入 CAN 和 CAN FD 覆盖范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add manual CAN and CAN FD internal-loopback checks with comprehensive frame validation and usage documentation.

New Features:
- Add manual classic CAN and CAN FD internal-loopback tests covering standard and extended data frames with payload validation across supported frame lengths.

Enhancements:
- Provide bounded, callback-safe frame checking with overflow, missing-frame, extra-callback, and incorrect-routing detection.
- Document controller setup, object lifetime requirements, invocation, coverage, and limitations for the CAN/CAN FD manual tests.

Documentation:
- Update manual test indexes to include CAN and CAN FD coverage.

</details>