### PR TITLE
test: add UART loopback and configuration timing checks

### DIFF
--- a/src/driver/uart.hpp
+++ b/src/driver/uart.hpp
@@ -44,8 +44,11 @@ class UART
   {
     uint32_t baudrate;  ///< 波特率 / Baud rate
     // TODO: Mark, Space
-    Parity parity;      ///< 校验模式 / Parity mode
-    uint8_t data_bits;  ///< 数据位长度 / Number of data bits
+    Parity parity;  ///< 校验模式 / Parity mode
+    /// 有效数据位数。按字节接收时仅低 data_bits 位有效，高位由调用方按需屏蔽。
+    /// Number of valid data bits. For byte-wise RX, only the low data_bits bits are
+    /// valid; callers mask the unspecified upper bits when needed.
+    uint8_t data_bits;
     // TODO: 0.5 1.5
     uint8_t stop_bits;  ///< 停止位长度 / Number of stop bits
   };

--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ There are two kinds of tests:
 
 - **automatic**：在 Linux 上运行，由 CI 自动执行。测试核心功能和 Linux 能验证的系统、驱动行为。
   Runs on Linux in CI. Checks core functionality and system or driver behavior that can be tested on Linux.
-- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC、Flash、I2C、SPI 和 CAN / CAN FD 测试。
-  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC, Flash, I2C, SPI and CAN / CAN FD tests.
+- **manual**：需要具体系统或外设，由用户准备环境后调用。[system](manual/system/README.md) 已提供可调用的系统测试；[driver](manual/driver/README.md) 提供 GPIO、PWM、ADC、DAC、Flash、I2C、SPI、CAN / CAN FD 和 UART 测试。
+  Needs a particular system or peripheral and is called after the user sets it up. [system](manual/system/README.md) provides callable system tests; [driver](manual/driver/README.md) provides GPIO, PWM, ADC, DAC, Flash, I2C, SPI, CAN / CAN FD and UART tests.
 
 ## 构建并运行 / Build and run
 

--- a/test/manual/driver/README.md
+++ b/test/manual/driver/README.md
@@ -1,8 +1,8 @@
 # 驱动手动测试 / Manual driver tests
 
-这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)、[Flash 擦写测试](flash/README.md)、[I2C 寄存器读写测试](i2c/README.md)、[SPI 回环测试](spi/README.md)及 [CAN / CAN FD 内部回环测试](can/README.md)，不由 CI 执行。
+这里用于需要真实外设的测试，例如 UART 收发、ADC 采样和 Flash 读写。目前提供 [GPIO 读写和中断测试](gpio/README.md)、[PWM 回读测试](pwm/README.md)、[ADC 读数测试](adc/README.md)、[DAC 回读测试](dac/README.md)、[Flash 擦写测试](flash/README.md)、[I2C 寄存器读写测试](i2c/README.md)、[SPI 回环测试](spi/README.md)、[CAN / CAN FD 内部回环测试](can/README.md)及 [UART 回环测试](uart/README.md)，不由 CI 执行。
 
-This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md), [Flash erase/program tests](flash/README.md), [I2C register read/write tests](i2c/README.md), [SPI loopback tests](spi/README.md) and [CAN / CAN FD internal loopback tests](can/README.md) are available. CI does not run them.
+This directory is for tests that need real peripherals, such as UART transfers, ADC sampling and Flash access. [GPIO loopback and interrupt tests](gpio/README.md), [PWM readback tests](pwm/README.md), [ADC sampling tests](adc/README.md), [DAC readback tests](dac/README.md), [Flash erase/program tests](flash/README.md), [I2C register read/write tests](i2c/README.md), [SPI loopback tests](spi/README.md), [CAN / CAN FD internal loopback tests](can/README.md) and [UART loopback tests](uart/README.md) are available. CI does not run them.
 
 调用方完成设备初始化和接线，准备所需资源，再把设备对象传给测试函数。测试通过 LibXR 公共驱动接口操作设备，检查失败时立即停止。
 

--- a/test/manual/driver/transfer_wait.hpp
+++ b/test/manual/driver/transfer_wait.hpp
@@ -47,26 +47,39 @@ class TransferTestCompletion
   template <typename Submit>
   void Run(unsigned mode_index, Submit submit)
   {
+    Start(mode_index, submit);
+    Wait();
+  }
+
+  // 分开提交和等待，允许先挂接收再发送；同一实例须完成后才能再次提交。
+  // Split submission from waiting to arm RX before TX; finish before reusing an instance.
+  template <typename Submit>
+  void Start(unsigned mode_index, Submit submit)
+  {
     auto& operation = operations_[mode_index];
-    const Mode mode = operation.type;
+    mode_ = operation.type;
     Check();
     status_.store(Status::READY, std::memory_order_relaxed);
-    if (mode == Mode::CALLBACK)
+    if (mode_ == Mode::CALLBACK)
     {
       ++expected_calls_;
     }
     TEST_ASSERT(submit(operation) == ErrorCode::OK);
-    const uint32_t start = Thread::GetTime();
+    started_ = Thread::GetTime();
+  }
+
+  void Wait()
+  {
     for (;;)
     {
-      bool done = mode == Mode::BLOCK;
-      if (mode == Mode::POLLING)
+      bool done = mode_ == Mode::BLOCK;
+      if (mode_ == Mode::POLLING)
       {
         const auto status = status_.load(std::memory_order_acquire);
         TEST_ASSERT(status != Status::ERROR);
         done = status == Status::DONE;
       }
-      else if (mode == Mode::CALLBACK)
+      else if (mode_ == Mode::CALLBACK)
       {
         const uint32_t calls = calls_.load(std::memory_order_acquire);
         TEST_ASSERT(calls <= expected_calls_);
@@ -79,7 +92,7 @@ class TransferTestCompletion
       {
         break;
       }
-      TEST_ASSERT(Thread::GetTime() - start < timeout_ms_);
+      TEST_ASSERT(Thread::GetTime() - started_ < timeout_ms_);
       Thread::Sleep(1);
     }
     Check();
@@ -100,5 +113,7 @@ class TransferTestCompletion
   Transfer operations_[3];
   uint32_t timeout_ms_;
   uint32_t expected_calls_ = 0;
+  uint32_t started_ = 0;
+  Mode mode_ = Mode::BLOCK;
 };
 }  // namespace LibXR::Test::Detail

--- a/test/manual/driver/uart/README.md
+++ b/test/manual/driver/uart/README.md
@@ -1,0 +1,98 @@
+# UART 手动测试 / Manual UART test
+
+将 TX 接到 RX，反复发送不同长度的数据并逐字节回读。每个长度分别使用阻塞、轮询和回调完成方式。
+
+Wire TX to RX and repeatedly send and read back different packet lengths. Each length uses blocking, polling and callback completion.
+
+## 接线和准备 / Wiring and setup
+
+由应用初始化串口，使用 8 位数据和匹配的收发设置，配置好中断及所需的 DMA。RX 不能接其他发送端。测试期间独占串口，包括关闭该串口的日志输出；开始前接收队列须为空，且没有其他未完成的收发操作。
+
+Initialize the UART with 8-bit data and matching transmit/receive settings, including interrupts and any required DMA. Connect no other transmitter to RX. Reserve the UART, including disabling console output on it. Start with an empty receive queue and no other pending transfers.
+
+准备两个独立的 RAM 工作缓冲区，不得相互重叠，也不能与后端正在使用的缓冲区重叠。每个长度必须大于零，并同时不超过两个工作缓冲区和读写端口的容量。
+
+Provide two separate RAM work buffers, disjoint from each other and active backend buffers. Each length must be positive and fit both work buffers and both port capacities.
+
+## 调用 / Usage
+
+把 `test/` 和 `test/manual/driver/` 加入头文件搜索路径，从普通任务调用：
+
+Add `test/` and `test/manual/driver/` to the include paths and call from a normal task:
+
+```cpp
+#include "uart/test_uart.hpp"
+
+void CheckUART(LibXR::UART& uart, LibXR::RawData tx, LibXR::RawData rx,
+               std::initializer_list<size_t> lengths)
+{
+  LibXR::Test::TestUARTLoopback(uart, tx, rx, lengths);
+}
+```
+
+长度列表由应用选择，可包含短包、较长包和容量边界。最后两个参数是 `timeout_ms` 和 `iterations`，默认 1000 ms 和 100 轮。总包数为“长度数量 × 3 × 轮数”。重复传输能让队列读写位置回绕；具体 DMA 边界由板级工程选择长度和轮数来触及。
+
+Choose short, longer and capacity-boundary lengths in the application. The final arguments are `timeout_ms` and `iterations`, defaulting to 1000 ms and 100 rounds. Total packets are “number of lengths × 3 × rounds”. Repeated transfers wrap queue positions; the board project chooses lengths and rounds to reach its DMA boundaries.
+
+## 检查内容 / Checks
+
+阻塞方式先发再读。轮询和回调方式先提交读取，再发送，检查没有数据时挂起的读取能否完成。收发各用一套完成状态，允许操作同步完成，也允许稍后完成。
+
+Blocking mode writes before reading. Polling and callback modes submit the read before writing, checking that a read submitted without available data completes later. TX and RX use separate completion state; both inline and deferred completion are accepted.
+
+每次 `Write()` 返回后立即改写发送源缓冲区。回读仍须符合原始数据的生成规则，不能跟着发送源一起改变。接收区预先填入错误值，防止漏写后误通过。每包前后检查接收队列为空，整个测试不调用清空队列来掩盖残留数据。
+
+Overwrite the transmit source immediately after each `Write()` returns. Received bytes must still match the original generated pattern. Prefill RX with incorrect bytes to catch missing writes. Check that the receive queue is empty before and after each packet; never clear it to hide residual data.
+
+发送完成表示后端已接纳数据，不代表数据已全部发上线路，所以测试还必须等接收完成并核对内容。回调只更新原子状态，错误由调用线程通过 `TEST_ASSERT` 报告并停止。超时从各次提交返回后计算，不能强行中断后端调用内部的同步执行。
+
+TX completion means backend acceptance, not necessarily that all bytes have left the wire. The test also waits for RX and checks its contents. Callbacks update only atomic state; the calling thread reports failures through `TEST_ASSERT` and stops. Completion timeouts start when each submission returns and cannot preempt synchronous work inside a backend call.
+
+测试不创建辅助线程，不修改串口配置。正常返回时收发均已完成，工作缓冲区保留最后一包的测试内容。CI 不自动执行接线测试。
+
+The test creates no helper threads and leaves UART configuration unchanged. On normal return, both directions have completed and the work buffers retain the final packet's test contents. CI does not run this wired test automatically.
+
+每次只处理一个容量以内的数据包。这项收发测试不验证大包流式传输、多请求突发和错误恢复。配置和速率用下面的独立入口检查。
+
+The loopback test handles one packet within capacity at a time. It does not verify large streaming transfers, request bursts or error recovery. Use the separate entry below to check configuration and transfer rate.
+
+## 配置和耗时 / Configuration and timing
+
+`TestUARTConfig()` 设置一组配置，使用阻塞方式连续收发，逐包检查数据，并返回各包传输耗时之和。计时从 `Write()` 前开始，到完整 `Read()` 返回后结束，包含后端及调度开销，不包含数据准备和核对。没有额外的逐包休眠。
+
+`TestUARTConfig()` applies one configuration, transfers packets with blocking operations, checks every packet and returns the sum of transfer times. Each interval starts before `Write()` and ends after the complete `Read()` returns. It includes backend and scheduling overhead, excludes data preparation and checking, and adds no per-packet sleep.
+
+传入等长的独立收发缓冲区，每个缓冲区大小就是单包字节数，仍须不超过两个端口容量。支持按配置生成最多 8 位的数据；例如 7 位数据不会发送超出 0～127 的数值。微秒时间基须已初始化且分辨率足够。
+
+Supply separate, equal-size buffers; each buffer's size is the packet length and must fit both ports. Generated values respect up to 8 configured data bits; for example, 7-bit data stays within 0–127. Initialize a microsecond timebase with sufficient resolution.
+
+接收字节只有配置指定的低位是有效数据，高位没有规定值，由上层按需屏蔽。因此 7 位模式按 `received & 0x7F` 比较，8 位模式比较完整字节。测试不改写收到的原始字节。
+
+Only the configured low bits of a received byte are valid data. Upper bits are unspecified and callers mask them when needed. The test therefore compares `received & 0x7F` in 7-bit mode and the whole byte in 8-bit mode, leaving the raw received bytes unchanged.
+
+```cpp
+uint64_t CheckUARTConfig(LibXR::UART& uart, LibXR::UART::Configuration config,
+                         LibXR::RawData tx, LibXR::RawData rx,
+                         uint64_t min_us, uint64_t max_us)
+{
+  // 100 包传输时间的允许范围，由调用工程预先确定。
+  // The calling project determines the allowed time for 100 packets in advance.
+  return LibXR::Test::TestUARTConfig(uart, config, tx, rx, min_us, max_us);
+}
+```
+
+最后两个可选参数是包数 `iterations`（默认 100）和每次阻塞调用的超时 `timeout_ms`（默认 1000）。调用前须确认串口空闲、没有残留接收数据。后端应能用本次空闲配置请求设置的参数执行后续收发；`SetConfig()` 返回成功本身不等于已经验证参数生效。
+
+The final optional arguments are `iterations` (100 packets by default) and `timeout_ms` (1000 per blocking call). Start with an idle UART and no queued receive data. The backend must use the accepted idle configuration for subsequent transfers; a successful `SetConfig()` return alone does not verify that it took effect.
+
+耗时上下限由调用方在运行前给出，不从测量结果反推。线路时间可按“字节数 × 包数 × 每帧位数 ÷ 波特率”估算；再为调用、接收通知、协议间隙和调度延迟留出合理余量。范围必须足够窄，能区分准备测试的快慢档。返回值是含这些开销的时间，不是精确的波特率测量。
+
+Supply time bounds before running; do not derive them from the observed result. Estimate wire time as “bytes × packets × bits per frame ÷ baud rate”, then allow for calls, receive notifications, protocol gaps and scheduling latency. Keep the windows narrow enough to distinguish the selected fast and slow settings. The returned time includes these overheads and is not a precise baud-rate measurement.
+
+依次用 A、A、B、A 调用，可以检查重复设置和切换后恢复。每次调用前按后端要求等待线路空闲，这段等待放在测试外。函数正常返回后保留新配置，不自动恢复；需要恢复时由调用方再次设置原配置。
+
+Call with A, A, B, A to check repeated setup and switching back. Wait for line idle as required by the backend before each call, outside the test. A successful call retains the new configuration; the caller explicitly reapplies the original configuration when needed.
+
+耗时不能区分所有帧格式。例如 8E1 与 8N2 都是每字节 11 位。回环数据和耗时检查可发现部分错误配置，但不能代替独立接收端或逻辑分析仪对校验位、停止位和线路速率的确认。
+
+Timing cannot distinguish every frame format: 8E1 and 8N2 both use 11 bits per byte. Loopback data and timing can detect some configuration errors but do not replace an independent receiver or logic analyzer for verifying parity, stop bits and line rate.

--- a/test/manual/driver/uart/test_uart.hpp
+++ b/test/manual/driver/uart/test_uart.hpp
@@ -1,0 +1,193 @@
+/**
+ * @file test_uart.hpp
+ * @brief UART 接线回环测试 / Wired UART loopback test.
+ *
+ * 反复收发不同长度的数据，检查阻塞、轮询、回调完成、挂起读取和发送源复用。
+ * Repeat different packet lengths; check blocking, polling and callback completion,
+ * pending reads, and reuse of the caller's transmit buffer after Write returns.
+ * 配置测试另用阻塞收发检查数据及总耗时。 / A separate configuration test checks
+ * data and total transfer time using blocking operations.
+ */
+#pragma once
+
+#include <initializer_list>
+
+#include "test_assert.hpp"
+#include "timebase.hpp"
+#include "transfer_wait.hpp"
+#include "uart.hpp"
+
+namespace LibXR::Test
+{
+/**
+ * @brief 检查不同长度下的串口收发回环 / Check UART loopback at selected lengths.
+ * @pre 配置为 8 位数据，TX 接 RX，RX 不接其他输出；独占串口且初始接收队列为空。
+ *      Configure 8-bit data, connect TX to RX without other outputs, reserve the UART,
+ *      and start with an empty receive queue.
+ * @pre tx/rx 是独立工作 RAM，不能与彼此或后端正在使用的缓冲区重叠。
+ *      tx/rx must be separate work RAM, disjoint from each other and active backend
+ * buffers.
+ * @param uart 已初始化且可读写的串口 / Initialized UART with both directions enabled.
+ * @param tx 发送工作缓冲区，内容会被覆盖 / Transmit work buffer; contents are
+ * overwritten.
+ * @param rx 接收工作缓冲区，内容会被覆盖 / Receive work buffer; contents are overwritten.
+ * @param lengths 每轮的正字节数列表，须同时适合工作缓冲区及收发端口容量 /
+ *        Positive byte lengths per round, within both work buffers and port capacities.
+ * @param timeout_ms 每次 BLOCK 调用及各操作返回后的完成等待上限 /
+ *        Timeout for each BLOCK call and completion wait measured from each submission's
+ * return.
+ * @param iterations 重复轮数，每个长度测试三种完成方式 /
+ *        Rounds; each length uses all three completion modes.
+ */
+inline void TestUARTLoopback(UART& uart, RawData tx, RawData rx,
+                             std::initializer_list<size_t> lengths,
+                             uint32_t timeout_ms = 1000, uint32_t iterations = 100)
+{
+  TEST_ASSERT(uart.read_port_ != nullptr && uart.write_port_ != nullptr);
+  TEST_ASSERT(uart.read_port_->Readable() && uart.write_port_->Writable());
+  TEST_ASSERT(tx.addr_ != nullptr && rx.addr_ != nullptr);
+  TEST_ASSERT(iterations > 0 && lengths.size() > 0 &&
+              lengths.size() <= UINT32_MAX / iterations);
+  const auto tx_begin = reinterpret_cast<uintptr_t>(tx.addr_);
+  const auto rx_begin = reinterpret_cast<uintptr_t>(rx.addr_);
+  TEST_ASSERT(tx_begin >= rx_begin ? tx_begin - rx_begin >= rx.size_
+                                   : rx_begin - tx_begin >= tx.size_);
+  for (size_t length : lengths)
+  {
+    TEST_ASSERT(length > 0 && length <= tx.size_ && length <= rx.size_);
+    TEST_ASSERT(length <= uart.read_port_->Capacity() &&
+                length <= uart.write_port_->Capacity());
+  }
+  auto* sent = static_cast<uint8_t*>(tx.addr_);
+  auto* received = static_cast<uint8_t*>(rx.addr_);
+  Detail::TransferTestCompletion tx_completion(timeout_ms), rx_completion(timeout_ms);
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    for (size_t length : lengths)
+    {
+      for (unsigned mode = 0; mode < 3; ++mode)
+      {
+        TEST_ASSERT(uart.read_port_->Size() == 0);
+        const auto seed = static_cast<uint8_t>(round + length + mode * 85U);
+        auto expected = [&](size_t i) { return static_cast<uint8_t>((i % 251U) ^ seed); };
+        for (size_t i = 0; i < length; ++i)
+        {
+          sent[i] = expected(i);
+          received[i] = static_cast<uint8_t>(~expected(i));
+        }
+        auto read = [&](ReadOperation& op) { return uart.Read({received, length}, op); };
+        // 非阻塞方式先挂读取；BLOCK 先发再读，避免同一线程等待尚未发出的数据。
+        // Arm nonblocking reads first; BLOCK writes first to avoid waiting on itself.
+        if (mode != 0)
+        {
+          rx_completion.Start(mode, read);
+        }
+        tx_completion.Start(
+            mode, [&](WriteOperation& op) { return uart.Write({sent, length}, op); });
+        // Write 返回后立即复用源缓冲区，回读仍应是提交时的数据。
+        // Reuse the source immediately after Write returns; RX must retain the original.
+        for (size_t i = 0; i < length; ++i)
+        {
+          sent[i] = static_cast<uint8_t>(~expected(i));
+        }
+        if (mode == 0)
+        {
+          rx_completion.Start(mode, read);
+        }
+        tx_completion.Wait();
+        rx_completion.Wait();
+        for (size_t i = 0; i < length; ++i)
+        {
+          TEST_ASSERT(received[i] == expected(i));
+        }
+        TEST_ASSERT(uart.read_port_->Size() == 0);
+        tx_completion.Check();
+        rx_completion.Check();
+      }
+    }
+  }
+}
+/**
+ * @brief 检查配置后的回环数据和传输耗时 / Check loopback data and timing after
+ * configuration.
+ * @pre 沿用回环接线及独立缓冲区要求；从普通任务调用，串口空闲，微秒时间基已初始化。
+ *      Use the same loopback wiring and separate buffers; call from a normal task with
+ *      an idle UART and an initialized microsecond timebase.
+ * @pre 后端须在空闲配置请求之后，按新配置执行后续收发。
+ *      The backend must use the accepted idle configuration for subsequent transfers.
+ * @param uart 已初始化的串口 / Initialized UART.
+ * @param config 后端支持的配置，数据位数不超过 8 / Supported configuration with at most 8
+ * data bits.
+ * @param tx 发送工作区，其大小为每包长度 / Transmit work buffer; its size is the packet
+ * length.
+ * @param rx 等长的接收工作区 / Receive work buffer of equal size.
+ * @param min_elapsed_us 所有包传输耗时之和的下限，单位微秒 / Lower bound on summed
+ * transfer time in microseconds.
+ * @param max_elapsed_us 总耗时上限，包含调用、调度及协议间隙 / Upper bound including
+ * call, scheduling and protocol gaps.
+ * @param iterations 数据包数量 / Number of packets.
+ * @param timeout_ms 每次阻塞读写的超时 / Timeout for each blocking read or write.
+ * @return 实测的传输耗时之和，单位微秒 / Measured sum of transfer times in microseconds.
+ * @note 正常返回后保留新配置及工作区内容；重复调用可检查同配置重设和 A-B-A 切换。
+ *       Retains the new configuration and buffer contents. Repeat calls for same-config
+ *       setup and A-B-A switching. Timing alone cannot identify every framing setting.
+ * @note 接收数据只比较配置指定的有效低位，缓冲区中的原始高位保持不变。
+ *       Compare only the configured low data bits; retain the raw upper bits in RX.
+ */
+inline uint64_t TestUARTConfig(UART& uart, UART::Configuration config, RawData tx,
+                               RawData rx, uint64_t min_elapsed_us,
+                               uint64_t max_elapsed_us, uint32_t iterations = 100,
+                               uint32_t timeout_ms = 1000)
+{
+  TEST_ASSERT(Timebase::IsReady() && iterations > 0);
+  TEST_ASSERT(min_elapsed_us > 0 && max_elapsed_us >= min_elapsed_us);
+  TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
+  TEST_ASSERT(config.data_bits > 0 && config.data_bits <= 8);
+  TEST_ASSERT(uart.read_port_ != nullptr && uart.write_port_ != nullptr);
+  TEST_ASSERT(uart.read_port_->Readable() && uart.write_port_->Writable());
+  TEST_ASSERT(tx.addr_ != nullptr && rx.addr_ != nullptr && tx.size_ > 0 &&
+              tx.size_ == rx.size_);
+  TEST_ASSERT(tx.size_ <= uart.read_port_->Capacity() &&
+              tx.size_ <= uart.write_port_->Capacity());
+  const auto tx_begin = reinterpret_cast<uintptr_t>(tx.addr_);
+  const auto rx_begin = reinterpret_cast<uintptr_t>(rx.addr_);
+  TEST_ASSERT(tx_begin >= rx_begin ? tx_begin - rx_begin >= rx.size_
+                                   : rx_begin - tx_begin >= tx.size_);
+  TEST_ASSERT(uart.read_port_->Size() == 0);
+  Semaphore tx_sem, rx_sem;
+  WriteOperation write(tx_sem, timeout_ms);
+  ReadOperation read(rx_sem, timeout_ms);
+  TEST_ASSERT(uart.SetConfig(config) == ErrorCode::OK);
+  auto* sent = static_cast<uint8_t*>(tx.addr_);
+  auto* received = static_cast<uint8_t*>(rx.addr_);
+  const auto mask = static_cast<uint8_t>((1U << config.data_bits) - 1U);
+  uint64_t elapsed_us = 0;
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    auto expected = [&](size_t i)
+    { return static_cast<uint8_t>(((i % 251U) * 37U ^ round) & mask); };
+    for (size_t i = 0; i < tx.size_; ++i)
+    {
+      sent[i] = expected(i);
+      received[i] = static_cast<uint8_t>(~expected(i));
+    }
+    // 计到完整回读，不把发送入队当作线路完成；准备和检查留在计时区间外。
+    // Time through full readback, not TX admission; prepare and check outside the
+    // interval.
+    const auto start = Timebase::GetMicroseconds();
+    TEST_ASSERT(uart.Write({sent, tx.size_}, write) == ErrorCode::OK);
+    TEST_ASSERT(uart.Read(rx, read) == ErrorCode::OK);
+    elapsed_us += (Timebase::GetMicroseconds() - start).ToMicrosecond();
+    TEST_ASSERT(elapsed_us <= max_elapsed_us);
+    // 高位不属于有效数据，调用方按配置屏蔽；8 位模式仍比较全部位。
+    // Mask unspecified upper bits in the caller; 8-bit mode still checks every bit.
+    for (size_t i = 0; i < tx.size_; ++i)
+    {
+      TEST_ASSERT((received[i] & mask) == expected(i));
+    }
+    TEST_ASSERT(uart.read_port_->Size() == 0);
+  }
+  TEST_ASSERT(elapsed_us >= min_elapsed_us);
+  return elapsed_us;
+}
+}  // namespace LibXR::Test


### PR DESCRIPTION
新增两项可由用户调用的UART测试：
- `TestUARTLoopback()`：指定长度下重复检查阻塞、轮询、回调收发；非阻塞先挂读取再发送；Write返回后覆盖源缓冲区，回读仍须符合原始数据；检查接收队列没有残留。
- `TestUARTConfig()`：设置配置，按有效数据位生成数据，累计每包BLOCK Write到完整Read的时间，并检查调用方预先指定的上下限。可重复调用检查同配置重设和A-B-A切换。

UART接口补充有效位说明：按字节接收时，只保证配置指定的低位有效，高位未规定，由上层按需屏蔽。配置测试据此比较低data_bits位，保持接收缓冲区的原始内容；8位模式仍比较完整字节。STM32及其他后端算法未改动。

共用完成辅助增加Start/Wait，保留I²C/SPI的Run行为；补充双语说明及目录入口。一个提交、六个文件（产品接口仅注释变动）。板级工程、模拟代码和验证日志保留在仓库外。

验证：
- Linux GNU13.3 Release / DEV_ASSERT=OFF：原UART20项与配置22项预期结果通过。新增7位高位非零通过、7位有效低位损坏失败、8位最高位损坏失败；还检查配置被忽略、速率过快/过慢和其他传输错误。
- 共用辅助I²C38项、SPI20项回归通过；辅助此后未再修改。
- 独立只读语义复核、clang-format21.1.8及差异检查通过。ARM GNU14.2.1 Debug / DEV_ASSERT=ON固件编译链接通过。
- G0B1实机PB6→PA10，RX/TX DMA各256字节、工作区各128字节。原1152008N1回环2400包/145800字节通过；配置检查每组50包×128字节，预先给出理想线路时间90%～125%的窗口：

| 配置 | 实测传输时间之和 |
| --- | ---: |
| 115200 8N1 | 631497 μs |
| 115200 8N1 重复设置 | 631588 μs |
| 57600 8N1 | 1186400 μs |
| 38400 7E1 | 1742481 μs |
| 115200 8N2 | 686464 μs |
| 115200 8N1 恢复 | 631584 μs |

六组均通过，合计2700包/184200字节，21.632秒完成，结果0x600D600D且错误日志为空。BRR、校验使能及停止位寄存器也随配置变化。板子已恢复1152008N1，CPU停在完成位置，选项字节不变。

较早7E1的整字节比较失败属于不符合已明确有效位约定的测试判据，已更正；无需后端去除高位。耗时包含软件开销，不能唯一确定所有帧格式。未验证大包流式、多请求突发、活动传输中的配置切换、错误恢复或其他芯片；其他协议尚未增加配置计时测试。

主机严格告警仅保留已有libxr_string.hpp:658 missing-field-initializers非致命例外；板级快照有HAL PCD volatile及未用初始化函数告警。当前PR继续保持草稿，等待用户审核后合并dev；CI结果单独查看。

## Sourcery 摘要

添加由用户触发的 UART 回环和配置时序测试，并记录有效位语义以及可复用的传输完成处理逻辑。

新功能：
- 添加可调用的 UART 回环测试，覆盖阻塞式、轮询式和回调式传输，包括挂起读取、发送缓冲区复用以及接收队列验证。
- 添加可调用的 UART 配置时序检查，验证不同受支持位宽下的数据，并强制执行调用方提供的传输时间上限。

错误修复：
- 明确 UART 契约：逐字节接收仅保证配置的数据低位有效，从而避免对 7 位数据等配置执行无效的完整字节比较。

增强功能：
- 允许共享的传输测试完成辅助函数将操作提交与等待过程分离，同时保持现有 I2C 和 SPI 行为不变。

文档：
- 在手动测试索引中记录 UART 手动测试、设置要求、回环检查、配置时序语义以及使用方法。

测试：
- 添加 UART 回环和配置测试接口，用于用户触发的硬件验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add user-invoked UART loopback and configuration timing tests with documented valid-bit semantics and reusable transfer completion handling.

New Features:
- Add callable UART loopback coverage for blocking, polling, and callback transfers, including pending reads, transmit-buffer reuse, and receive-queue validation.
- Add callable UART configuration timing checks that validate data across supported bit widths and enforce caller-provided transfer-time bounds.

Bug Fixes:
- Clarify the UART contract so byte-wise reception guarantees only the configured low data bits, preventing invalid full-byte comparisons for configurations such as 7-bit data.

Enhancements:
- Allow shared transfer-test completion helpers to separate operation submission from waiting while preserving existing I2C and SPI behavior.

Documentation:
- Document UART manual tests, setup requirements, loopback checks, configuration timing semantics, and usage in the manual-test indexes.

Tests:
- Add UART loopback and configuration test interfaces for user-invoked hardware validation.

</details>