### PR TITLE
test: add SPI configuration timing checks

### DIFF
--- a/test/manual/driver/spi/README.md
+++ b/test/manual/driver/spi/README.md
@@ -10,9 +10,9 @@ Wire the master's MOSI to MISO and use `ReadAndWrite()` to transmit and receive 
 
 Configure an **8-bit full-duplex master**, with no other output driving MISO. The caller configures clock, mode, chip select and interrupt/DMA resources and reserves the bus. Start at a conservative rate suitable for the loopback wiring.
 
-传入两个独立的 RAM 工作缓冲区，不得相互重叠，也不能使用后端当前正在操作的缓冲区。各次传输的长度须满足实际容量、对齐和内存访问要求。测试不更改 SPI 配置。
+传入两个独立的 RAM 工作缓冲区，不得相互重叠，也不能使用后端当前正在操作的缓冲区。各次传输的长度须满足实际容量、对齐和内存访问要求。`TestSPILoopback()` 不更改 SPI 配置。
 
-Supply two separate RAM work buffers, disjoint from each other and the backend's active buffers. Transfer lengths must meet the actual capacity, alignment and memory-access requirements. The test does not change the SPI configuration.
+Supply two separate RAM work buffers, disjoint from each other and the backend's active buffers. Transfer lengths must meet the actual capacity, alignment and memory-access requirements. `TestSPILoopback()` does not change the SPI configuration.
 
 ## 调用 / Usage
 
@@ -51,6 +51,39 @@ The test reuses the completion-wait helper used by I2C tests and accepts inline 
 两个工作缓冲区都会被改写，正常结束后保留最后一帧数据。测试不创建辅助线程，回调和等待对象在轮次间复用；CI 不自动运行接线测试。
 
 Both work buffers are overwritten and retain the final frame on success. No helper threads are created; callback and wait state are reused between rounds. CI does not run the wired test automatically.
+
+## 配置和耗时 / Configuration and timing
+
+`TestSPIConfig()` 设置一组配置，然后用阻塞方式连续全双工收发，检查接收内容和发送区保持不变，并返回每次传输耗时之和。计时只包住 `ReadAndWrite()` 调用，包含等待实际完成的时间，不包含数据准备和核对，也不添加逐次休眠。
+
+`TestSPIConfig()` applies one configuration, repeats blocking full-duplex transfers, checks RX and unchanged TX contents, and returns the sum of transfer times. Each interval covers `ReadAndWrite()` through completion. Data preparation and checking are outside the interval; no per-transfer sleep is added.
+
+仍使用 8 位全双工主机和 MOSI→MISO 接线，关闭双缓冲。传入等长、独立的工作缓冲区，其大小就是单次传输长度，须满足后端容量、对齐和内存访问要求。调用前总线须空闲，微秒时间基已初始化且分辨率足够。
+
+Use an 8-bit full-duplex master with MOSI wired to MISO and double buffering disabled. Supply equal-size, separate work buffers; their size is the transfer length and must meet backend capacity, alignment and memory-access requirements. Start with an idle bus and an initialized microsecond timebase of sufficient resolution.
+
+```cpp
+uint64_t CheckSPIConfig(LibXR::SPI& spi, LibXR::SPI::Configuration config,
+                        LibXR::RawData tx, LibXR::RawData rx,
+                        uint64_t min_us, uint64_t max_us)
+{
+  // 100 次传输的耗时范围，由调用工程预先确定。
+  // The calling project determines the time bounds for 100 transfers in advance.
+  return LibXR::Test::TestSPIConfig(spi, config, tx, rx, min_us, max_us);
+}
+```
+
+最后两个可选参数是传输次数 `iterations`（默认 100）和单次阻塞超时 `timeout_ms`（默认 1000）。耗时上下限须在运行前确定：线路时间可按“字节数 × 8 × 次数 ÷ SCK 频率”估算，再计入调用、调度和硬件间隙。选择足够长的传输，让这些开销不至于掩盖快慢分频的差别。
+
+The final optional arguments are `iterations` (100 by default) and `timeout_ms` (1000 per blocking call). Set bounds before running: estimate wire time as “bytes × 8 × transfers ÷ SCK frequency”, then allow for calls, scheduling and hardware gaps. Use transfers long enough that overhead does not hide the difference between fast and slow prescalers.
+
+依次用 A、A、B、A 调用，可以检查重复设置、切换及恢复。也可传入不同的时钟极性和相位，检查设置后能否正常回环。正常返回后保留新配置，需要恢复时由调用方重新设置。
+
+Call with A, A, B, A to check repeated setup, switching and restoration. Other polarity and phase settings can also be supplied to check loopback after setup. The new configuration remains active on return; the caller explicitly restores it when needed.
+
+`GetBusSpeed()` 根据配置和后端报告的源时钟计算，不能单独证明分频已作用于硬件。实测耗时补充检查实际传输速度，但包含软件开销，不是精确的 SCK 频率测量。
+
+`GetBusSpeed()` calculates a value from configuration and the reported source clock; it cannot alone prove that the hardware prescaler changed. Measured duration adds an observable transfer-rate check, but includes software overhead and is not a precise SCK frequency measurement.
 
 ## 验证范围 / Scope
 

--- a/test/manual/driver/spi/test_spi.hpp
+++ b/test/manual/driver/spi/test_spi.hpp
@@ -5,6 +5,8 @@
  * 在指定长度下反复同时收发，检查三种完成方式、接收内容和发送缓冲区保持不变。
  * Repeat equal-length transfers in three completion modes; check received bytes
  * and that the transmitted bytes remain unchanged. Requires MOSI wired to MISO.
+ * 配置测试另检查指定配置下的回环数据和传输耗时。
+ * A separate configuration test checks loopback data and transfer time after setup.
  */
 #pragma once
 
@@ -12,6 +14,7 @@
 
 #include "spi.hpp"
 #include "test_assert.hpp"
+#include "timebase.hpp"
 #include "transfer_wait.hpp"
 
 namespace LibXR::Test
@@ -84,5 +87,75 @@ inline void TestSPILoopback(SPI& spi, RawData tx, RawData rx,
       }
     }
   }
+}
+/**
+ * @brief 检查配置后的 SPI 回环数据和耗时 / Check SPI loopback data and timing after
+ * setup.
+ * @pre 沿用 8 位全双工主机接线及独立缓冲区要求，关闭双缓冲。从普通任务调用，
+ *      总线空闲，微秒时间基已初始化。
+ *      Use the same 8-bit full-duplex master wiring and separate buffers, with double
+ *      buffering disabled. Call from a normal task with an idle bus and a ready
+ *      microsecond timebase.
+ * @param spi 已初始化的 SPI / Initialized SPI controller.
+ * @param config 后端支持的配置 / Configuration supported by the backend.
+ * @param tx 发送工作区，其大小为每次传输长度 / Transmit work buffer; its size is the
+ * transfer length.
+ * @param rx 等长的接收工作区 / Receive work buffer of equal size.
+ * @param min_elapsed_us 所有传输耗时之和的下限，单位微秒 / Lower bound on summed transfer
+ * time in microseconds.
+ * @param max_elapsed_us 总耗时上限，包含调用、调度及传输间隙 / Upper bound including
+ * calls, scheduling and transfer gaps.
+ * @param iterations 传输次数 / Number of transfers.
+ * @param timeout_ms 每次阻塞调用的超时 / Timeout for each blocking call.
+ * @return 实测的传输耗时之和，单位微秒 / Measured sum of transfer times in microseconds.
+ * @note 正常返回后保留新配置及工作区内容；重复调用可检查同配置重设和 A-B-A 切换。
+ *       回环和耗时不能独立确认线路上的时钟极性和相位。
+ *       Retains the new configuration and buffer contents. Repeat calls for same-config
+ *       setup and A-B-A switching. Loopback and timing do not independently verify
+ *       the electrical clock polarity or phase.
+ */
+inline uint64_t TestSPIConfig(SPI& spi, SPI::Configuration config, RawData tx, RawData rx,
+                              uint64_t min_elapsed_us, uint64_t max_elapsed_us,
+                              uint32_t iterations = 100, uint32_t timeout_ms = 1000)
+{
+  TEST_ASSERT(Timebase::IsReady() && iterations > 0);
+  TEST_ASSERT(min_elapsed_us > 0 && max_elapsed_us >= min_elapsed_us);
+  TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
+  TEST_ASSERT(!config.double_buffer);
+  TEST_ASSERT(tx.addr_ != nullptr && rx.addr_ != nullptr && tx.size_ > 0 &&
+              tx.size_ == rx.size_);
+  const auto tx_begin = reinterpret_cast<uintptr_t>(tx.addr_);
+  const auto rx_begin = reinterpret_cast<uintptr_t>(rx.addr_);
+  TEST_ASSERT(tx_begin >= rx_begin ? tx_begin - rx_begin >= rx.size_
+                                   : rx_begin - tx_begin >= tx.size_);
+  Semaphore semaphore;
+  SPI::OperationRW operation(semaphore, timeout_ms);
+  TEST_ASSERT(spi.SetConfig(config) == ErrorCode::OK);
+  auto* sent = static_cast<uint8_t*>(tx.addr_);
+  auto* received = static_cast<uint8_t*>(rx.addr_);
+  uint64_t elapsed_us = 0;
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    auto expected = [&](size_t i)
+    { return static_cast<uint8_t>((i % 251U) * 37U ^ round); };
+    for (size_t i = 0; i < tx.size_; ++i)
+    {
+      sent[i] = expected(i);
+      received[i] = static_cast<uint8_t>(~expected(i));
+    }
+    // BLOCK 返回时传输已完成；准备和检查放在计时区间外。
+    // BLOCK returns after completion; prepare and check outside the measured interval.
+    const auto start = Timebase::GetMicroseconds();
+    TEST_ASSERT(spi.ReadAndWrite(rx, {sent, tx.size_}, operation) == ErrorCode::OK);
+    elapsed_us += (Timebase::GetMicroseconds() - start).ToMicrosecond();
+    TEST_ASSERT(elapsed_us <= max_elapsed_us);
+    for (size_t i = 0; i < tx.size_; ++i)
+    {
+      TEST_ASSERT(sent[i] == expected(i));
+      TEST_ASSERT(received[i] == expected(i));
+    }
+  }
+  TEST_ASSERT(elapsed_us >= min_elapsed_us);
+  return elapsed_us;
 }
 }  // namespace LibXR::Test


### PR DESCRIPTION
新增 `TestSPIConfig()`：设置调用方提供的配置，用 BLOCK `ReadAndWrite()` 重复全双工回环，独立核对 RX 和保持不变的 TX，并检查传输总耗时是否落在预先给出的范围内。计时包含实际传输和完成等待，数据准备及检查放在区间外，无逐次 Sleep、重试或自动放宽阈值。

可重复调用检查同配置重设、快慢分频切换、四种时钟模式和恢复。使用8位全双工主机、独立等长工作缓冲区及关闭双缓冲；保留新配置。耗时包含软件开销，回环不能独立证明时钟极性/相位的电气符合性。

只改SPI测试头文件和本目录双语README，一个提交、两个文件。原TestSPILoopback正文、共用辅助、产品代码和CI配置均未改动；板级工程与主机模拟保留在仓库外。

验证：Linux GNU13.3 Release / DEV_ASSERT=OFF配置22项预期结果和原SPI20项回归通过，包含分频被忽略、速度过快/过慢、RX/TX损坏、完成错误和非法参数。独立只读语义复核通过，两处文案建议已修正。clang-format21.1.8及差异检查通过；ARM GNU14.2.1 Debug / DEV_ASSERT=ON完整G0B1固件编译链接通过。

主机严格告警仅保留已有libxr_string.hpp:658 missing-field-initializers非致命例外；板级快照有HAL PCD volatile及未用初始化函数告警。未验证双缓冲、单独Read/Write、寄存器协议、并发配置、其他芯片或精确SCK频率。当前PR待用户审核后合并dev。

G0B1实机：PA7 MOSI→PA6 MISO，SPI1为8位全双工主机，DMA及用户收发缓冲区各256字节。原1/2/3/4/17/32字节×3方式×1000轮（18000次、177000字节）通过。配置检查每组256字节×50次，源时钟64MHz，DIV64名义1MHz、DIV256名义250kHz，耗时窗口在运行前固定为理想线路时间的90%～130%：

| 配置 | 50次传输实测总时间 |
| --- | ---: |
| mode 0 / DIV64 | 132682 μs |
| mode 0 / DIV64 重复设置 | 132681 μs |
| mode 0 / DIV256 | 516498 μs |
| mode 1 / DIV64 | 107164 μs |
| mode 2 / DIV64 | 132679 μs |
| mode 3 / DIV64 | 107161 μs |
| mode 0 / DIV64 恢复 | 132675 μs |

七组数据和耗时均通过，CR1的分频、极性、相位位也与配置相符。合计18350次传输、266600字节，完成时tick为9928ms，DMA IRQ28050次；结果0x600D600D且错误日志为空。板子保留SPI测试固件，CPU停在完成位置，最终mode0/DIV64，选项字节不变。自回环和寄存器核对不是外部逻辑分析仪测量。

## Sourcery 总结

新增 SPI 配置环回时序覆盖，并记录其用法和测量限制。

新功能：
- 新增 `TestSPIConfig()`，用于验证 SPI 环回数据完整性，并汇总调用方提供的各项配置下的阻塞传输时序。

增强：
- 明确现有环回测试不会更改 SPI 配置，并记录配置时序检查、边界、用法和限制。

文档：
- 记录重复配置、切换与恢复检查、时序边界选择，以及使用环回时序推断电气时钟行为的限制。

测试：
- 扩展 SPI 手动测试覆盖范围，以验证配置应用、重复及切换时钟模式、RX/TX 完整性、完成时序以及无效参数处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add SPI configuration loopback timing coverage while documenting its usage and measurement limitations.

New Features:
- Add `TestSPIConfig()` to validate SPI loopback data integrity and aggregate blocking-transfer timing across caller-supplied configurations.

Enhancements:
- Clarify that the existing loopback test leaves SPI configuration unchanged and document configuration timing checks, bounds, usage, and limitations.

Documentation:
- Document repeated configuration, switching and restoration checks, timing-bound selection, and the limitations of using loopback timing to infer electrical clock behavior.

Tests:
- Extend SPI manual-test coverage to verify configuration application, repeated and switched clock modes, RX/TX integrity, completion timing, and invalid-parameter handling.

</details>