### PR TITLE
feat(structure): shared ObjectPool handles and Ninja test fix

### DIFF
--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -43,13 +44,24 @@ concept PoolIndexQueue =
  * @brief 基于空闲索引队列的 RAII 槽池。
  * @brief RAII slot pool backed by a free-index queue.
  *
- * 该池使用一个索引队列管理空闲槽位；成功获取后返回 move-only `Handle`，其析构会
- * 自动把槽位索引归还到空闲队列。这样上层只依赖四类队列共享的最小 typed 接口。
+ * 成功申请建立一个共享引用；最后一个引用释放时归还索引，不析构或清空负载。
+ * Handle 可写，ConstHandle 只读；计数不提供负载读写同步。运行操作不分配内存。
+ * 每槽引用数不得超过 UINT32_MAX。池及外部槽存储必须比全部句柄活得更久。
+ * 构造和析构需要静止状态，不能在 ISR 执行。同一句柄对象的并发访问须由调用方同步。
  *
- * This pool uses one index queue to manage free slots. Successful acquisition
- * returns one move-only `Handle`, whose destructor automatically returns the
- * slot index back to the free queue. This keeps the upper layer dependent only
- * on the minimal typed interface shared by the queue family.
+ * Acquire creates one shared reference; final release returns the index without
+ * destroying or clearing the payload. Handle permits writes, ConstHandle is
+ * read-only; counting does not synchronize payload access. Runtime operations
+ * allocate no memory. Each slot must have at most UINT32_MAX references. Pool and
+ * external storage outlive all handles. Construction/destruction require quiescence
+ * outside ISR. Concurrent operations on the same handle require synchronization.
+ *
+ * 同一池的申请不得并发或重入。普通队列需外部串行化队列访问；SPSC 只有一个最终归还方；
+ * MPMC 允许并发归还。ISR 支持还取决于平台原子实现，不保证单次操作的固定耗时。
+ * Acquisitions on a pool must not overlap or reenter. Ordinary queues require
+ * externally serialized queue access; SPSC permits one final-return producer;
+ * MPMC permits concurrent returns. ISR use requires suitable target atomics and
+ * does not imply a fixed per-operation latency bound.
  *
  * @tparam Data 槽内对象类型。 Slot object type.
  * @tparam FreeQueue 空闲索引队列类型。 Free-index queue type.
@@ -70,162 +82,205 @@ class BasicObjectPool
                 "BasicObjectPool requires an unsigned index queue");
 
   /**
-   * @class Handle
-   * @brief 对象池槽位的 move-only RAII 句柄。
-   * @brief Move-only RAII handle for one object-pool slot.
-   *
-   * 句柄持有一个槽位索引及所属 pool 指针；析构时会自动把索引归还到空闲队列。
-   * The handle stores one slot index plus its owning pool pointer, and returns
-   * the index to the free queue automatically on destruction.
+   * @brief 对象及其引用计数的常驻存储。 Resident payload and reference-count storage.
+   * @note 外部存储须提供 Slot 数组，并保持到池及所有句柄使用结束。
+   *       External Slot arrays must outlive pool use and all handles.
    */
-  class Handle
+  class Slot
   {
    public:
-    /**
-     * @brief 构造一个空 handle。
-     * @brief Construct an empty handle.
-     */
-    Handle() = default;
+    /// @brief 默认构造负载。 Default-construct the payload.
+    Slot()
+      requires std::is_default_constructible_v<Data>
+    = default;
 
-    /**
-     * @brief 用指定 pool 和槽位索引构造 handle。
-     * @brief Construct a handle from the given pool and slot index.
-     * @param pool 所属对象池。 Owning object pool.
-     * @param index 槽位索引。 Slot index.
-     */
-    Handle(BasicObjectPool* pool, IndexType index) : pool_(pool), index_(index) {}
+    /// @brief 用参数原地构造负载。 Construct the payload in place from arguments.
+    template <typename... Args>
+      requires std::is_constructible_v<Data, Args...>
+    explicit Slot(std::in_place_t, Args&&... args) : data_(std::forward<Args>(args)...)
+    {
+    }
 
-    /// @brief 禁止拷贝构造。 Non-copyable.
-    Handle(const Handle&) = delete;
-    /// @brief 禁止拷贝赋值。 Non-copy-assignable.
-    Handle& operator=(const Handle&) = delete;
+    Slot(const Slot&) = delete;
+    Slot& operator=(const Slot&) = delete;
+    Slot(Slot&&) = delete;
+    Slot& operator=(Slot&&) = delete;
 
-    /**
-     * @brief 移动构造 handle，并转移槽位所有权。
-     * @brief Move-construct the handle and transfer slot ownership.
-     * @param other 被转移的源 handle。 Source handle being moved from.
-     */
-    Handle(Handle&& other) noexcept
+   private:
+    friend class BasicObjectPool;
+    std::atomic<uint32_t> references_{0};
+    Data data_;
+  };
+
+ private:
+  /// @brief 同一共享所有权的访问限定实现。 Access-qualified shared ownership.
+  template <bool IsConst>
+  class BasicHandle
+  {
+    using AccessType = std::conditional_t<IsConst, const Data, Data>;
+
+   public:
+    /// @brief 构造空句柄。 Construct an empty handle.
+    BasicHandle() = default;
+
+    /// @brief 复制现有引用。 Retain an existing reference.
+    BasicHandle(const BasicHandle& other) noexcept
+        : pool_(other.pool_), index_(other.index_)
+    {
+      Retain();
+    }
+
+    /// @brief 复制为只读引用。 Copy a mutable reference into a read-only handle.
+    template <bool OtherConst>
+      requires(IsConst && !OtherConst)
+    BasicHandle(const BasicHandle<OtherConst>& other) noexcept
+        : pool_(other.pool_), index_(other.index_)
+    {
+      Retain();
+    }
+
+    /// @brief 转移引用并清空源句柄。 Transfer ownership and empty the source.
+    BasicHandle(BasicHandle&& other) noexcept
         : pool_(std::exchange(other.pool_, nullptr)),
           index_(std::exchange(other.index_, IndexType{}))
     {
     }
 
-    /**
-     * @brief 移动赋值 handle，并转移槽位所有权。
-     * @brief Move-assign the handle and transfer slot ownership.
-     * @param other 被转移的源 handle。 Source handle being moved from.
-     * @return 当前 handle 的引用。 Reference to this handle.
-     */
-    Handle& operator=(Handle&& other) noexcept
+    /// @brief 转移为只读引用。 Transfer mutable ownership into a read-only handle.
+    template <bool OtherConst>
+      requires(IsConst && !OtherConst)
+    BasicHandle(BasicHandle<OtherConst>&& other) noexcept
+        : pool_(std::exchange(other.pool_, nullptr)),
+          index_(std::exchange(other.index_, IndexType{}))
     {
-      if (this == &other)
-      {
-        return *this;
-      }
+    }
 
-      Reset();
-      pool_ = std::exchange(other.pool_, nullptr);
-      index_ = std::exchange(other.index_, IndexType{});
+    /// @brief 替换引用，先保留源再释放旧引用。 Retain source before releasing old
+    /// ownership.
+    BasicHandle& operator=(const BasicHandle& other) noexcept
+    {
+      if (pool_ != other.pool_ || index_ != other.index_)
+      {
+        BasicHandle copy(other);
+        Swap(copy);
+      }
       return *this;
     }
 
-    /**
-     * @brief 析构 handle，并自动归还槽位。
-     * @brief Destroy the handle and return the slot automatically.
-     */
-    ~Handle() { Reset(); }
+    /// @brief 从可写句柄复制赋值。 Copy-assign from a mutable handle.
+    template <bool OtherConst>
+      requires(IsConst && !OtherConst)
+    BasicHandle& operator=(const BasicHandle<OtherConst>& other) noexcept
+    {
+      if (pool_ != other.pool_ || index_ != other.index_)
+      {
+        BasicHandle copy(other);
+        Swap(copy);
+      }
+      return *this;
+    }
 
-    /**
-     * @brief 判断当前 handle 是否持有有效槽位。
-     * @brief Return whether this handle currently owns a valid slot.
-     * @return 持有有效槽位返回 `true`，否则返回 `false`。
-     *         Returns `true` when this handle owns a valid slot, otherwise `false`.
-     */
+    /// @brief 转移赋值并释放旧引用。 Move-assign and release previous ownership.
+    BasicHandle& operator=(BasicHandle&& other) noexcept
+    {
+      if (this != &other)
+      {
+        BasicHandle moved(std::move(other));
+        Swap(moved);
+      }
+      return *this;
+    }
+
+    /// @brief 从可写句柄转移赋值。 Move-assign from a mutable handle.
+    template <bool OtherConst>
+      requires(IsConst && !OtherConst)
+    BasicHandle& operator=(BasicHandle<OtherConst>&& other) noexcept
+    {
+      BasicHandle moved(std::move(other));
+      Swap(moved);
+      return *this;
+    }
+
+    /// @brief 释放本引用；最后一个引用归还槽位。 Release; the final reference returns the
+    /// slot.
+    ~BasicHandle() { Reset(); }
+
+    /// @brief 是否持有引用。 Whether this handle owns a reference.
     [[nodiscard]] bool Valid() const { return pool_ != nullptr; }
 
-    /**
-     * @brief 返回当前槽位对象的可写引用。
-     * @brief Return a writable reference to the current slot object.
-     * @return 当前槽位对象引用。 Reference to the current slot object.
-     */
-    [[nodiscard]] Data& Get()
+    /// @brief 按句柄权限访问负载，句柄必须有效。 Access payload; requires a valid handle.
+    [[nodiscard]] AccessType& Get()
     {
-      ASSERT(pool_ != nullptr);
-      return pool_->slots_[index_];
+      ASSERT(Valid());
+      return pool_->UnsafeAt(index_);
     }
 
-    /**
-     * @brief 返回当前槽位对象的只读引用。
-     * @brief Return a read-only reference to the current slot object.
-     * @return 当前槽位对象常量引用。 Const reference to the current slot object.
-     */
+    /// @brief 保留旧接口的 const 只读访问。 Preserve const-qualified read-only access.
     [[nodiscard]] const Data& Get() const
     {
-      ASSERT(pool_ != nullptr);
-      return pool_->slots_[index_];
+      ASSERT(Valid());
+      return pool_->UnsafeAt(index_);
     }
 
-    /**
-     * @brief 以指针形式访问当前槽位对象。
-     * @brief Access the current slot object as a pointer.
-     * @return 指向当前槽位对象的指针。 Pointer to the current slot object.
-     */
-    [[nodiscard]] Data* operator->() { return &Get(); }
-
-    /**
-     * @brief 以只读指针形式访问当前槽位对象。
-     * @brief Access the current slot object as a const pointer.
-     * @return 指向当前槽位对象的只读指针。 Const pointer to the current slot object.
-     */
+    /// @brief 按句柄权限返回负载指针。 Return an access-qualified payload pointer.
+    [[nodiscard]] AccessType* operator->() { return &Get(); }
+    /// @brief 返回只读负载指针。 Return a read-only payload pointer.
     [[nodiscard]] const Data* operator->() const { return &Get(); }
-
-    /**
-     * @brief 解引用当前槽位对象。
-     * @brief Dereference the current slot object.
-     * @return 当前槽位对象引用。 Reference to the current slot object.
-     */
-    [[nodiscard]] Data& operator*() { return Get(); }
-
-    /**
-     * @brief 只读解引用当前槽位对象。
-     * @brief Dereference the current slot object as const.
-     * @return 当前槽位对象常量引用。 Const reference to the current slot object.
-     */
+    /// @brief 按句柄权限解引用。 Dereference with this handle's access qualification.
+    [[nodiscard]] AccessType& operator*() { return Get(); }
+    /// @brief 只读解引用。 Dereference read-only.
     [[nodiscard]] const Data& operator*() const { return Get(); }
 
-    /**
-     * @brief 返回当前持有的槽位索引。
-     * @brief Return the currently owned slot index.
-     * @return 当前槽位索引。 Current slot index.
-     */
+    /// @brief 返回有效句柄的槽索引。 Return the slot index of a valid handle.
     [[nodiscard]] IndexType Index() const
     {
-      ASSERT(pool_ != nullptr);
+      ASSERT(Valid());
       return index_;
     }
 
-    /**
-     * @brief 主动归还当前槽位，并使 handle 失效。
-     * @brief Return the current slot explicitly and invalidate the handle.
-     */
+    /// @brief 清空句柄并释放引用；空句柄无操作。 Empty and release; empty handles are a
+    /// no-op.
     void Reset()
     {
-      if (pool_ == nullptr)
+      BasicObjectPool* pool = std::exchange(pool_, nullptr);
+      const IndexType index = std::exchange(index_, IndexType{});
+      if (pool != nullptr)
       {
-        return;
+        pool->Release(index);
       }
-
-      [[maybe_unused]] const ErrorCode ec = pool_->Release(index_);
-      DEV_ASSERT(ec == ErrorCode::OK);
-      pool_ = nullptr;
-      index_ = IndexType{};
     }
 
    private:
-    BasicObjectPool* pool_ = nullptr;  ///< 所属对象池。 Owning object pool.
-    IndexType index_ = {};             ///< 当前槽位索引。 Current slot index.
+    friend class BasicObjectPool;
+    template <bool>
+    friend class BasicHandle;
+
+    BasicHandle(BasicObjectPool* pool, IndexType index) : pool_(pool), index_(index) {}
+
+    void Retain() noexcept
+    {
+      if (pool_ != nullptr)
+      {
+        pool_->Retain(index_);
+      }
+    }
+
+    void Swap(BasicHandle& other) noexcept
+    {
+      std::swap(pool_, other.pool_);
+      std::swap(index_, other.index_);
+    }
+
+    BasicObjectPool* pool_ = nullptr;
+    IndexType index_ = {};
   };
+
+ public:
+  /// @brief 可复制的可写共享句柄。 Copyable mutable shared handle.
+  using Handle = BasicHandle<false>;
+  /// @brief 可复制的只读共享句柄，只接受可写到只读转换。
+  ///        Copyable read-only shared handle; conversion is mutable-to-const only.
+  using ConstHandle = BasicHandle<true>;
 
   /**
    * @brief 用内部 queue 和内部 slots 构造 pool。
@@ -248,11 +303,11 @@ class BasicObjectPool
    * @param slot_count 槽位数量。 Number of slots.
    * @param slots 外部槽数组。 Caller-provided slot storage.
    *
-   * @note 调用方必须保证 `slots` 指向至少 `slot_count` 个 `Data` 槽位。
+   * @note 调用方必须保证 `slots` 指向至少 `slot_count` 个 `Slot` 槽位。
    *       The caller must ensure that `slots` points to at least `slot_count`
-   *       `Data` slots.
+   *       `Slot` slots.
    */
-  BasicObjectPool(size_t slot_count, Data* slots) : slot_count_(slot_count), slots_(slots)
+  BasicObjectPool(size_t slot_count, Slot* slots) : slot_count_(slot_count), slots_(slots)
   {
     ASSERT(slot_count_ > 0);
     ASSERT(slots_ != nullptr);
@@ -293,11 +348,11 @@ class BasicObjectPool
    *       The caller-provided `free_queue` must be empty and dedicated to this pool.
    * @note 调用方必须保证 `free_queue` 的容量至少为 `slot_count`。
    *       The caller must ensure that `free_queue` capacity is at least `slot_count`.
-   * @note 调用方必须保证 `slots` 指向至少 `slot_count` 个 `Data` 槽位。
+   * @note 调用方必须保证 `slots` 指向至少 `slot_count` 个 `Slot` 槽位。
    *       The caller must ensure that `slots` points to at least `slot_count`
-   *       `Data` slots.
+   *       `Slot` slots.
    */
-  BasicObjectPool(FreeQueue& free_queue, size_t slot_count, Data* slots)
+  BasicObjectPool(FreeQueue& free_queue, size_t slot_count, Slot* slots)
       : free_queue_(&free_queue), slot_count_(slot_count), slots_(slots)
   {
     ASSERT(slot_count_ > 0);
@@ -354,6 +409,8 @@ class BasicObjectPool
     }
 
     DEV_ASSERT(static_cast<size_t>(index) < slot_count_);
+    DEV_ASSERT(slots_[index].references_.load(std::memory_order_relaxed) == 0U);
+    slots_[index].references_.store(1U, std::memory_order_relaxed);
     handle = Handle(this, index);
     return ErrorCode::OK;
   }
@@ -387,7 +444,7 @@ class BasicObjectPool
   [[nodiscard]] Data& UnsafeAt(size_t index)
   {
     ASSERT(index < slot_count_);
-    return slots_[index];
+    return slots_[index].data_;
   }
 
   /**
@@ -405,20 +462,35 @@ class BasicObjectPool
   [[nodiscard]] const Data& UnsafeAt(size_t index) const
   {
     ASSERT(index < slot_count_);
-    return slots_[index];
+    return slots_[index].data_;
   }
 
  private:
-  /**
-   * @brief 把指定槽位索引归还到空闲队列。
-   * @brief Return the given slot index back to the free queue.
-   * @param index 待归还的槽位索引。 Slot index to return.
-   * @return 底层空闲队列返回的结果码。 Result code returned by the underlying free queue.
-   */
-  ErrorCode Release(IndexType index)
+  /// @brief 保留已存活的引用，禁止引用数溢出。 Retain a live reference without overflow.
+  void Retain(IndexType index) noexcept
   {
     DEV_ASSERT(static_cast<size_t>(index) < slot_count_);
-    return free_queue_->Push(index);
+    [[maybe_unused]] const uint32_t previous =
+        slots_[index].references_.fetch_add(1U, std::memory_order_relaxed);
+    DEV_ASSERT(previous > 0U);
+    ASSERT(previous < std::numeric_limits<uint32_t>::max());
+  }
+
+  /// @brief 释放引用，只有最后一个引用归还索引。 Only the final release returns the
+  /// index.
+  void Release(IndexType index)
+  {
+    DEV_ASSERT(static_cast<size_t>(index) < slot_count_);
+    const uint32_t previous =
+        slots_[index].references_.fetch_sub(1U, std::memory_order_acq_rel);
+    DEV_ASSERT(previous > 0U);
+    if (previous == 1U)
+    {
+      // 归还发布后可能立即复用；此后不能再访问槽位。
+      // Publication permits immediate reuse; do not access the slot afterward.
+      [[maybe_unused]] const ErrorCode ec = free_queue_->Push(index);
+      DEV_ASSERT(ec == ErrorCode::OK);
+    }
   }
 
   /**
@@ -439,7 +511,7 @@ class BasicObjectPool
    */
   void AllocateOwnedSlots()
   {
-    slots_ = new Data[slot_count_];
+    slots_ = new Slot[slot_count_];
     owns_slots_ = true;
   }
 
@@ -465,7 +537,7 @@ class BasicObjectPool
   FreeQueue* free_queue_ =
       nullptr;               ///< 空闲索引队列指针。 Pointer to the free-index queue.
   const size_t slot_count_;  ///< 槽位总数。 Total slot count.
-  Data* slots_ = nullptr;    ///< 槽数组指针。 Pointer to slot storage.
+  Slot* slots_ = nullptr;    ///< 槽数组指针。 Pointer to slot storage.
   bool owns_free_queue_ =
       false;  ///< 是否拥有内部 queue。 Whether this pool owns the free queue.
   bool owns_slots_ =

--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -466,7 +466,9 @@ class BasicObjectPool
   }
 
  private:
-  /// @brief 保留已存活的引用，禁止引用数溢出。 Retain a live reference without overflow.
+  /// @brief 保留已存活的引用。 Retain an existing live reference.
+  /// @pre 调用方须保证新增引用不会使计数溢出；断言不是运行时溢出防护。
+  ///      The caller must prevent count overflow; assertions are not a runtime guard.
   void Retain(IndexType index) noexcept
   {
     DEV_ASSERT(static_cast<size_t>(index) < slot_count_);

--- a/test/README.md
+++ b/test/README.md
@@ -30,12 +30,12 @@ CTest runs the registered automatic tests. It uses `script` to provide the pseud
 Use `--case` to run one group. For example:
 
 ```sh
-script -q -e -c './build/test/test --case lockfree_list' /dev/null
+script -q -e -c './build/test/libxr_test --case lockfree_list' /dev/null
 ```
 
-名称列在 [automatic/main.cpp](automatic/main.cpp) 中。可执行文件为 `build/test/test`，对应的 CMake 目标名为 `libxr_test`。需要查看完整输出时使用：
+名称列在 [automatic/main.cpp](automatic/main.cpp) 中。可执行文件为 `build/test/libxr_test`，对应的 CMake 目标名为 `libxr_test`。需要查看完整输出时使用：
 
-Case names are listed in [automatic/main.cpp](automatic/main.cpp). The executable is `build/test/test`, and its CMake target is `libxr_test`. To see the full output, run:
+Case names are listed in [automatic/main.cpp](automatic/main.cpp). The executable is `build/test/libxr_test`, and its CMake target is `libxr_test`. To see the full output, run:
 
 ```sh
 ctest --test-dir build -V -R '^libxr_automatic$' --no-tests=error

--- a/test/automatic/CMakeLists.txt
+++ b/test/automatic/CMakeLists.txt
@@ -137,7 +137,6 @@ add_executable(
   utils/transform/test_transform.cpp
   utils/transform/test_transform_euler_orders.cpp
 )
-set_target_properties(libxr_test PROPERTIES OUTPUT_NAME test)
 target_link_libraries(libxr_test PRIVATE xr)
 target_include_directories(
   libxr_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/.."

--- a/test/automatic/core/assert/libxr_assert/assert_disabled_headers.cpp
+++ b/test/automatic/core/assert/libxr_assert/assert_disabled_headers.cpp
@@ -21,6 +21,13 @@ void ExercisePool()
   Pool pool(4);
   typename Pool::Handle handle;
   (void)pool.Acquire(handle);
+  typename Pool::Handle copy = handle;
+  typename Pool::ConstHandle reader = copy;
+  reader = std::move(handle);
+  typename Pool::ConstHandle reader_copy(reader);
+  copy.Reset();
+  reader.Reset();
+  reader_copy.Reset();
   handle.Reset();
 }
 

--- a/test/automatic/driver/timebase/README.md
+++ b/test/automatic/driver/timebase/README.md
@@ -17,5 +17,5 @@ Integer time conversions discard fractional parts. The test allows 2 μs for mic
 After building with the [test instructions](../../../README.md), run from the repository root:
 
 ```sh
-script -q -e -c './build/test/test --case timebase' /dev/null
+script -q -e -c './build/test/libxr_test --case timebase' /dev/null
 ```

--- a/test/automatic/structure/object_pool/test_object_pool.cpp
+++ b/test/automatic/structure/object_pool/test_object_pool.cpp
@@ -245,6 +245,66 @@ void RunResidentStorageChecks()
   TEST_ASSERT(destructions == 2);
 }
 
+template <size_t WorkerCount>
+void RunSameSlotReleaseChecks()
+{
+  using Pool = LibXR::MPMCObjectPool<Payload>;
+  constexpr size_t rounds = 64;
+  Pool pool(2);
+  Pool::Handle held_slot;
+  TEST_ASSERT(pool.Acquire(held_slot) == LibXR::ErrorCode::OK);
+  std::array<Pool::ConstHandle, WorkerCount> readers;
+  std::array<std::thread, WorkerCount> workers;
+  std::barrier start(static_cast<std::ptrdiff_t>(WorkerCount + 1U));
+  std::barrier done(static_cast<std::ptrdiff_t>(WorkerCount + 1U));
+
+  for (size_t i = 0; i < WorkerCount; ++i)
+  {
+    workers[i] = std::thread(
+        [&, i]()
+        {
+          for (size_t round = 0; round < rounds; ++round)
+          {
+            start.arrive_and_wait();
+            readers[i].Reset();
+            done.arrive_and_wait();
+          }
+        });
+  }
+
+  for (size_t round = 0; round < rounds; ++round)
+  {
+    Pool::Handle owner;
+    TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+    const auto index = owner.Index();
+    TEST_ASSERT(index != held_slot.Index());
+    owner->value = static_cast<int>(round);
+    for (auto& reader : readers) reader = owner;
+    owner.Reset();
+    TEST_ASSERT(pool.EmptySize() == 0U);
+
+    // All workers now decrement the same counter, without ordering their releases.
+    start.arrive_and_wait();
+    done.arrive_and_wait();
+
+    for (const auto& reader : readers) TEST_ASSERT(!reader.Valid());
+    TEST_ASSERT(pool.EmptySize() == 1U);
+    Pool::Handle returned;
+    TEST_ASSERT(pool.Acquire(returned) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(returned.Index() == index);
+    TEST_ASSERT(returned->value == static_cast<int>(round));
+    Pool::Handle duplicate;
+    TEST_ASSERT(pool.Acquire(duplicate) == LibXR::ErrorCode::EMPTY);
+    TEST_ASSERT(!duplicate.Valid());
+    returned.Reset();
+  }
+
+  for (auto& worker : workers) worker.join();
+  TEST_ASSERT(pool.EmptySize() == 1U);
+  held_slot.Reset();
+  TEST_ASSERT(pool.EmptySize() == 2U);
+}
+
 void RunConcurrentReturnChecks()
 {
   using Pool = LibXR::MPMCObjectPool<Payload>;
@@ -316,6 +376,8 @@ void test_object_pool()
   RunSharedHandleChecks<LibXR::SPSCObjectPool<Payload>>();
   RunSharedHandleChecks<LibXR::MPMCObjectPool<Payload>>();
   RunResidentStorageChecks();
+  RunSameSlotReleaseChecks<8>();
+  RunSameSlotReleaseChecks<32>();
   RunConcurrentReturnChecks();
   // Basic acquire/release using the ordinary FIFO queue as free-index storage.
   {

--- a/test/automatic/structure/object_pool/test_object_pool.cpp
+++ b/test/automatic/structure/object_pool/test_object_pool.cpp
@@ -1,11 +1,18 @@
 /**
  * @file test_object_pool.cpp
- * @brief 检查对象池分配、耗尽、回收和句柄移动。 /
- * Tests object-pool allocation, exhaustion, release and handle moves.
+ * @brief 检查共享对象池的所有权、只读转换、外部存储和并发归还。 /
+ * Tests shared ownership, const conversion, external slots and concurrent returns.
  *
  * 检查三种空闲队列，以及外部队列、外部存储和析构自动回收。
  * Checks three free-slot queues, external storage and automatic handle release.
  */
+
+#include <array>
+#include <barrier>
+#include <chrono>
+#include <thread>
+#include <type_traits>
+#include <utility>
 
 #include "libxr.hpp"
 #include "test.hpp"
@@ -40,31 +47,276 @@ void RunExternalQueueChecks()
 template <typename QueueType>
 void RunExternalSlotChecks()
 {
-  Payload slots[3] = {};
-  LibXR::BasicObjectPool<Payload, QueueType> pool(3, slots);
+  using Pool = LibXR::BasicObjectPool<Payload, QueueType>;
+  typename Pool::Slot slots[3] = {};
+  Pool pool(3, slots);
 
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle handle;
   TEST_ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
   handle->value = 123;
-  TEST_ASSERT(slots[handle.Index()].value == 123);
+  TEST_ASSERT(pool.UnsafeAt(handle.Index()).value == 123);
+  const auto address = reinterpret_cast<uintptr_t>(&handle.Get());
+  const auto slot_address = reinterpret_cast<uintptr_t>(&slots[handle.Index()]);
+  TEST_ASSERT(address >= slot_address && address < slot_address + sizeof(slots[0]));
 }
 
 template <typename QueueType>
 void RunExternalQueueAndSlotChecks()
 {
   QueueType free_queue(3);
-  Payload slots[3] = {};
-  LibXR::BasicObjectPool<Payload, QueueType> pool(free_queue, 3, slots);
+  using Pool = LibXR::BasicObjectPool<Payload, QueueType>;
+  typename Pool::Slot slots[3] = {};
+  Pool pool(free_queue, 3, slots);
 
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle handle;
   TEST_ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
   handle->value = 456;
-  TEST_ASSERT(slots[handle.Index()].value == 456);
+  TEST_ASSERT(pool.UnsafeAt(handle.Index()).value == 456);
+  const auto address = reinterpret_cast<uintptr_t>(&handle.Get());
+  const auto slot_address = reinterpret_cast<uintptr_t>(&slots[handle.Index()]);
+  TEST_ASSERT(address >= slot_address && address < slot_address + sizeof(slots[0]));
+}
+
+template <typename Pool>
+void RunSharedHandleChecks()
+{
+  using Handle = typename Pool::Handle;
+  using ConstHandle = typename Pool::ConstHandle;
+  static_assert(std::is_copy_constructible_v<Handle>);
+  static_assert(std::is_copy_assignable_v<ConstHandle>);
+  static_assert(std::is_convertible_v<Handle, ConstHandle>);
+  static_assert(!std::is_constructible_v<Handle, ConstHandle>);
+  static_assert(!std::is_assignable_v<Handle&, const ConstHandle&>);
+  static_assert(!std::is_assignable_v<Handle&, ConstHandle&&>);
+  static_assert(!std::is_constructible_v<Handle, Pool*, typename Pool::IndexType>);
+  static_assert(!std::is_constructible_v<ConstHandle, Pool*, typename Pool::IndexType>);
+  static_assert(!std::is_copy_constructible_v<typename Pool::Slot>);
+  static_assert(!std::is_move_constructible_v<typename Pool::Slot>);
+  static_assert(std::is_same_v<decltype(std::declval<Handle&>().Get()), Payload&>);
+  static_assert(
+      std::is_same_v<decltype(std::declval<const Handle&>().Get()), const Payload&>);
+  static_assert(
+      std::is_same_v<decltype(std::declval<ConstHandle&>().Get()), const Payload&>);
+  static_assert(std::is_same_v<decltype(std::declval<ConstHandle&>().operator->()),
+                               const Payload*>);
+
+  Pool pool(2);
+  Handle owner;
+  TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+  owner->value = 123;
+  const auto index = owner.Index();
+  const Payload* address = &owner.Get();
+  Handle copy = owner;
+  ConstHandle reader = owner;
+  owner.Reset();
+  copy.Reset();
+  TEST_ASSERT(pool.EmptySize() == 1U);
+  TEST_ASSERT(reader.Index() == index && &reader.Get() == address);
+  TEST_ASSERT(reader->value == 123);
+
+  ConstHandle reader_copy(reader);
+  reader.Reset();
+  Handle other;
+  TEST_ASSERT(pool.Acquire(other) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(other.Index() != index);
+  Handle exhausted;
+  TEST_ASSERT(pool.Acquire(exhausted) == LibXR::ErrorCode::EMPTY);
+  TEST_ASSERT(!exhausted.Valid());
+  ConstHandle moved(std::move(reader_copy));
+  TEST_ASSERT(!reader_copy.Valid() && moved.Valid());
+  reader_copy.Reset();
+  TEST_ASSERT(pool.EmptySize() == 0U);
+  moved.Reset();
+  other.Reset();
+  TEST_ASSERT(pool.EmptySize() == 2U);
+
+  // Self-assignment and same-slot aliases must not lose the final reference.
+  TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+  auto& self = owner;
+  owner = self;
+  owner = std::move(self);
+  copy = owner;
+  owner = copy;
+  copy = std::move(owner);
+  TEST_ASSERT(!owner.Valid() && copy.Valid());
+  reader = copy;
+  reader = copy;
+  reader = std::move(copy);
+  TEST_ASSERT(!copy.Valid() && reader.Valid());
+  auto& reader_self = reader;
+  reader = reader_self;
+  reader = std::move(reader_self);
+  TEST_ASSERT(pool.EmptySize() == 1U);
+  reader.Reset();
+  TEST_ASSERT(pool.EmptySize() == 2U);
+
+  // Cross-pool assignment releases the old destination, not the source's slot.
+  Pool second_pool(2);
+  TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(second_pool.Acquire(copy) == LibXR::ErrorCode::OK);
+  owner = copy;
+  TEST_ASSERT(pool.EmptySize() == 2U && second_pool.EmptySize() == 1U);
+  copy.Reset();
+  TEST_ASSERT(second_pool.EmptySize() == 1U);
+  owner = Handle{};
+  TEST_ASSERT(second_pool.EmptySize() == 2U);
+
+  TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+  TEST_ASSERT(second_pool.Acquire(copy) == LibXR::ErrorCode::OK);
+  reader = owner;
+  reader = std::move(copy);
+  TEST_ASSERT(!copy.Valid());
+  owner.Reset();
+  TEST_ASSERT(pool.EmptySize() == 2U && second_pool.EmptySize() == 1U);
+  ConstHandle empty;
+  reader = empty;
+  TEST_ASSERT(second_pool.EmptySize() == 2U);
+  Handle empty_owner;
+  ConstHandle empty_copy(empty_owner);
+  ConstHandle empty_move(std::move(empty_owner));
+  TEST_ASSERT(!empty_copy.Valid() && !empty_move.Valid());
+}
+
+struct LifetimePayload
+{
+  inline static int constructions = 0;
+  inline static int destructions = 0;
+  int value = 0;
+  LifetimePayload() { ++constructions; }
+  ~LifetimePayload() { ++destructions; }
+};
+
+struct alignas(64) InPlacePayload
+{
+  int value;
+  int* destructions;
+  InPlacePayload(int initial, int& destroyed) : value(initial), destructions(&destroyed)
+  {
+  }
+  ~InPlacePayload() { ++*destructions; }
+  InPlacePayload(const InPlacePayload&) = delete;
+  InPlacePayload& operator=(const InPlacePayload&) = delete;
+};
+
+void RunResidentStorageChecks()
+{
+  LifetimePayload::constructions = 0;
+  LifetimePayload::destructions = 0;
+  {
+    LibXR::ObjectPool<LifetimePayload> pool(1);
+    TEST_ASSERT(LifetimePayload::constructions == 1);
+    decltype(pool)::Handle owner;
+    TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+    owner->value = 321;
+    {
+      decltype(pool)::ConstHandle reader = std::move(owner);
+      auto second_reader = reader;
+      TEST_ASSERT(second_reader->value == 321);
+    }
+    TEST_ASSERT(LifetimePayload::destructions == 0);
+    TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+    TEST_ASSERT(owner->value == 321);
+    owner.Reset();
+    TEST_ASSERT(LifetimePayload::constructions == 1);
+  }
+  TEST_ASSERT(LifetimePayload::destructions == 1);
+
+  using Pool = LibXR::MPMCObjectPool<InPlacePayload>;
+  static_assert(!std::is_default_constructible_v<Pool::Slot>);
+  static_assert(!std::is_constructible_v<Pool, size_t>);
+  static_assert(alignof(Pool::Slot) >= alignof(InPlacePayload));
+  int destructions = 0;
+  {
+    Pool::Slot slots[] = {Pool::Slot(std::in_place, 17, destructions),
+                          Pool::Slot(std::in_place, 29, destructions)};
+    LibXR::MPMCQueue<uint32_t> queue(2);
+    {
+      Pool pool(queue, 2, slots);
+      Pool::Handle owner;
+      TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+      TEST_ASSERT(owner->value == 17);
+      TEST_ASSERT(reinterpret_cast<uintptr_t>(&owner.Get()) % 64U == 0U);
+      Pool::ConstHandle reader = std::move(owner);
+      reader.Reset();
+      TEST_ASSERT(destructions == 0);
+    }
+    TEST_ASSERT(destructions == 0);
+  }
+  TEST_ASSERT(destructions == 2);
+}
+
+void RunConcurrentReturnChecks()
+{
+  using Pool = LibXR::MPMCObjectPool<Payload>;
+  constexpr size_t count = 8;
+  Pool pool(count);
+  std::array<Pool::ConstHandle, count> first;
+  std::array<Pool::ConstHandle, count> second;
+  std::array<Pool::Handle, count> reacquired;
+  for (size_t i = 0; i < count; ++i)
+  {
+    Pool::Handle owner;
+    TEST_ASSERT(pool.Acquire(owner) == LibXR::ErrorCode::OK);
+    owner->value = static_cast<int>(owner.Index());
+    first[i] = owner;
+    second[i] = std::move(owner);
+  }
+
+  // Phase one leaves even-slot final returns to worker1 and odd ones to worker2.
+  std::barrier phase(2);
+  std::thread worker1(
+      [&]()
+      {
+        for (size_t i = 1; i < count; i += 2) first[i].Reset();
+        phase.arrive_and_wait();
+        for (size_t i = 0; i < count; i += 2) first[i].Reset();
+      });
+  std::thread worker2(
+      [&]()
+      {
+        for (size_t i = 0; i < count; i += 2) second[i].Reset();
+        phase.arrive_and_wait();
+        for (size_t i = 1; i < count; i += 2) second[i].Reset();
+      });
+  std::array<bool, count> seen{};
+  size_t acquired = 0;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (acquired < count && std::chrono::steady_clock::now() < deadline)
+  {
+    const auto result = pool.Acquire(reacquired[acquired]);
+    if (result == LibXR::ErrorCode::EMPTY)
+    {
+      std::this_thread::yield();
+      continue;
+    }
+    TEST_ASSERT(result == LibXR::ErrorCode::OK);
+    const auto index = reacquired[acquired].Index();
+    TEST_ASSERT(index < count && !seen[index]);
+    TEST_ASSERT(reacquired[acquired]->value == static_cast<int>(index));
+    seen[index] = true;
+    reacquired[acquired]->value = static_cast<int>(index + 1000U);
+    ++acquired;
+  }
+  TEST_ASSERT(acquired == count);
+  worker1.join();
+  worker2.join();
+  TEST_ASSERT(pool.EmptySize() == 0U);
+  for (auto& handle : reacquired)
+  {
+    TEST_ASSERT(handle->value == static_cast<int>(handle.Index() + 1000U));
+    handle.Reset();
+  }
+  TEST_ASSERT(pool.EmptySize() == count);
 }
 }  // namespace
 
 void test_object_pool()
 {
+  RunSharedHandleChecks<LibXR::ObjectPool<Payload>>();
+  RunSharedHandleChecks<LibXR::SPSCObjectPool<Payload>>();
+  RunSharedHandleChecks<LibXR::MPMCObjectPool<Payload>>();
+  RunResidentStorageChecks();
+  RunConcurrentReturnChecks();
   // Basic acquire/release using the ordinary FIFO queue as free-index storage.
   {
     LibXR::ObjectPool<Payload> pool(3);
@@ -181,7 +433,7 @@ void test_object_pool()
     TEST_ASSERT(pool.EmptySize() == 2);
   }
 
-  // Move-only handle ownership should transfer the return responsibility.
+  // Moving the only handle transfers the final-return responsibility.
   {
     LibXR::ObjectPool<Payload> pool(1);
 

--- a/test/automatic/system/async/README.md
+++ b/test/automatic/system/async/README.md
@@ -17,7 +17,7 @@ This entry does not use a separate process. ASync has a permanent worker, so the
 After building with the [test instructions](../../../README.md), run from the repository root:
 
 ```sh
-script -q -e -c './build/test/test --case async' /dev/null
+script -q -e -c './build/test/libxr_test --case async' /dev/null
 ```
 
 `test_async_cooperative` 是另一个独立测试程序，编译实际裸机后端并控制时间推进，检查 Timer 延后执行、任务完整发布和重复使用。它通过根 CTest 运行，不使用硬件中断。

--- a/test/automatic/system/timer/README.md
+++ b/test/automatic/system/timer/README.md
@@ -14,6 +14,6 @@ Timer has two groups, each run in a fresh process so timers or scheduler threads
 After building with the [test instructions](../../../README.md), run from the repository root:
 
 ```sh
-script -q -e -c './build/test/test --case timer_semantics' /dev/null
-script -q -e -c './build/test/test --case timer_scheduler' /dev/null
+script -q -e -c './build/test/libxr_test --case timer_semantics' /dev/null
+script -q -e -c './build/test/libxr_test --case timer_scheduler' /dev/null
 ```


### PR DESCRIPTION
## Summary

本 PR 包含三个可分别审阅的提交：

1. 修复 Ninja 测试目标冲突：取消 `OUTPUT_NAME=test`，让测试程序使用 `libxr_test` 名称，更新直接运行的文档路径。CMake 目标名和 CTest 注册保持不变。
2. 将现有 `BasicObjectPool` 升级为共享所有权：统一 `Slot` 存储、32 位原子引用计数、可写 `Handle` 与只读 `ConstHandle`。
3. 按审阅意见补充同一槽位的并发释放测试，并澄清溢出是调用方前提，不改变引用计数算法。

## API / compatibility changes

- Handle 可复制；复制保留引用，移动转移引用。可写句柄可复制/移动为只读句柄，不能反向转换。
- 外部存储参数从 `T*` 改为 `Pool::Slot*`；Slot 支持原地构造负载。底层计数不另行分配。
- `Handle(pool, index)` 构造变为私有，所有权由 `Acquire`、已有句柄复制/移动和只读转换建立。
- 最后一个引用只把索引归还空闲队列，不清空或析构常驻负载。外部节点仍由调用方拥有；池/节点必须比所有句柄活得更久。
- 保留 `Get()` 返回引用及 `const Handle` 的只读访问行为。引用计数不提供负载读写同步。
- 直接运行测试的新路径为 `build/test/libxr_test`，不再生成 `build/test/test` 程序；构建目标仍为 `libxr_test`。

## Concurrency boundary

同一个池的 `Acquire` 不得并发或重入。普通队列需要外部串行化队列访问；SPSC 只有一个最终归还方；MPMC 支持多个最终归还方。这里没有更换队列算法，也不宣称修复无限制多申请者使用下的预占槽位问题。

`Reset` 先清空本句柄，再原子减计数；只有观察到旧计数为 1 的释放者归还索引，发布后不再访问槽位。调用方必须保证引用数不超过 `UINT32_MAX`；断言不是运行时溢出防护，本次没有增加 CAS 或改变原子操作。

## Validation

- 本地 Docker：Ninja Debug、Make Debug、Make Release 均完整构建并通过 **6/6 CTest**；主测试程序每轮完成 **65 项**。
- `--case object_pool` 单项通过；包含共享延寿、空句柄、同槽/跨池赋值、只读转换、私有构造、外部 Slot、原地构造、对齐与一个申请方/多个槽位并发归还。
- 外部存储建池及 1000 次共享句柄循环观察到 **0 次堆分配**。
- 审阅后新增同槽测试：实际两槽 MPMC 池始终占用另一槽，让 **8/32 个线程各运行 64 轮**同槽 `Reset()`，验证只归还一次、一次重新申请成功、第二次必须 `EMPTY`。新增用例在 Debug/Release 单项及两轮 **6/6 CTest** 中通过。
- 裸机证据从重定位链接补到完整可执行 ELF：ARM GNU 14.2 Cortex-M0+/M4、WCH GCC 15.2 CH32 Zaamo，链接实际 Pool/Queue/MPMC/FastCopy、既有原子兼容层和工具链运行库；三个静态 `ET_EXEC` 均无未解析符号、无动态解释器或 RWX LOAD 段。
- 裸机验证文件明确提供初始化、16 KiB 有界 `_sbrk` 堆及 8 KiB 栈。组件以 `-fno-exceptions/-fno-rtti` 编译，不代表预编译运行库没有相关支持。ARM `nosys` 未实现 I/O 的警告如实保留；没有执行这些 ELF。
- clang-format 21.1.8、cmakelang 0.6.13 与 `git diff --check` 通过。

初版对齐 `dev@f523d1f4` 并保留了上游手工测试说明；本次补充在原 PR head `ed54c51d` 上完成本地验证。独立只读复核覆盖新增同槽用例、溢出注释及最终 ELF 证据，没有新增阻塞。最终提交的 CI 状态以 GitHub 检查为准；Sourcery 因预算跳过，不计为完成的代码审阅。

## Limits / follow-up

- 完成的是代表性最小裸机程序完整链接，不是正式板级 BSP 或实际 ISR、NMI、硬件验收，也不证明固定最坏耗时或全平台无锁。
- 默认建池仍依赖初始化期分配及相应运行库；只提供外部 Slot 不代表底层队列也完全静态。完全外部模式须同时提供不自行分配的队列存储。
- 同槽并发递减已补充，属于有界调度采样，不保证物理同时执行或穷尽交错；并发复制/释放的混合压力用例仍可补充。
- 相机、CameraBase 私有池迁移、新帧格式、BSP、控制接口、底层队列和驱动没有混入本次修改。

## Sourcery 摘要

将对象池升级为共享槽位所有权，同时修正生成的测试可执行文件名称及其文档中的调用路径。

新功能：
- 将对象池升级为共享所有权句柄，支持可复制的可变句柄和只读的 const 句柄。
- 添加常驻槽位存储和外部提供的槽位存储，支持原地构造载荷并持久化载荷生命周期。

错误修复：
- 修正 Ninja 测试可执行文件命名，保留 `libxr_test` 输出名称，并更新直接运行文档。

增强功能：
- 添加每个槽位的原子引用计数，并根据底层队列的并发模型支持并发最终释放。

构建：
- 移除将测试可执行文件生成为 `test` 的 CMake 输出名称覆盖设置。

文档：
- 更新手动测试命令，以使用 `build/test/libxr_test`。

测试：
- 扩展对象池测试覆盖范围，包括共享所有权、const 转换、外部存储和原地存储、生命周期保持、对齐以及并发归还。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

升级对象池所有权语义，并修正生成的测试可执行文件路径。

新功能：
- 将对象池句柄升级为共享所有权，支持可复制的可变句柄，以及从可变句柄转换为只读 const 句柄。
- 添加常驻存储和调用方提供的槽位存储，支持原地构造负载并保持负载生命周期。

错误修复：
- 修正 Ninja 测试可执行文件名称，并将手动测试命令更新为使用 `build/test/libxr_test`。

增强功能：
- 为每个槽位添加原子引用计数，并根据底层队列的并发模型支持并发的最终释放。

构建：
- 移除将测试可执行文件生成为 `test` 的 CMake 输出名称覆盖设置。

文档：
- 更新手动测试文档，以引用 `libxr_test` 可执行文件路径。

测试：
- 扩展对象池测试范围，覆盖共享所有权、const 转换、存储选项、原地构造、生命周期保持、对齐以及并发释放。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade object-pool ownership semantics and correct the generated test executable path.

New Features:
- Upgrade object-pool handles to shared ownership with copyable mutable handles and mutable-to-read-only const handles.
- Add resident and caller-provided slot storage with in-place payload construction and persistent payload lifetimes.

Bug Fixes:
- Fix the Ninja test executable name and update manual test commands to use `build/test/libxr_test`.

Enhancements:
- Add per-slot atomic reference counting and support concurrent final releases according to the underlying queue's concurrency model.

Build:
- Remove the CMake output-name override that generated the test executable as `test`.

Documentation:
- Update manual test documentation to reference the `libxr_test` executable path.

Tests:
- Expand object-pool coverage for shared ownership, const conversion, storage options, in-place construction, lifetime preservation, alignment, and concurrent releases.

</details>

</details>
