### PR TITLE
test: add I2C configuration timing checks

### DIFF
--- a/test/manual/driver/i2c/README.md
+++ b/test/manual/driver/i2c/README.md
@@ -4,6 +4,10 @@
 
 Two tests cover fixed-register reads and write/readback of writable registers. Both use blocking, polling and callback completion, starting the next operation only after the current one completes.
 
+另有 `TestI2CConfig()`，通过固定寄存器读数和耗时检查时钟配置。
+
+`TestI2CConfig()` separately checks clock configuration through fixed-register data and read duration.
+
 ## 准备设备 / Prepare the device
 
 调用方初始化 I2C 总线、从机、系统时间基和中断／DMA 资源，并独占总线。确认供电、共地和 SDA/SCL 上拉电平符合两端要求。
@@ -66,6 +70,40 @@ The final three arguments are `settle_ms`, `timeout_ms` and `iterations`, defaul
 
 Success leaves the second pattern in place. If old values must be preserved, the calling application saves them before testing, then restores and verifies them after success. Failure stops immediately; restoration after a failed test is not guaranteed.
 
+## 配置和耗时 / Configuration and timing
+
+`TestI2CConfig()` 应用调用方指定的时钟配置，使用 BLOCK `MemRead()` 反复读取固定寄存器，检查数据和总耗时。寄存器、预期值及缓冲区沿用固定读取测试的要求。它不写寄存器数据，已有的写入回读测试仍单独调用。
+
+`TestI2CConfig()` applies a caller-supplied clock configuration, repeatedly reads a fixed register with BLOCK `MemRead()`, and checks data and total duration. Use the same register, expected-byte and buffer requirements as the fixed-read test. It does not write register data; call the existing write/readback test separately.
+
+```cpp
+uint64_t CheckI2CConfig(LibXR::I2C& bus, LibXR::I2C::Configuration config,
+                        uint16_t device, uint16_t reg,
+                        LibXR::I2C::MemAddrLength address_length,
+                        LibXR::ConstRawData expected, LibXR::RawData buffer,
+                        uint64_t min_us, uint64_t max_us)
+{
+  return LibXR::Test::TestI2CConfig(bus, config, device, reg, address_length,
+                                   expected, buffer, min_us, max_us);
+}
+```
+
+调用前总线须空闲，微秒时间基须已初始化且分辨率足够。后端和从机都必须支持所选时钟；不支持配置会触发测试断言，不会跳过后当作成功。
+
+Start with an idle bus and a ready microsecond timebase of sufficient resolution. Both backend and slave must support the selected clock. An unsupported configuration fails the test rather than being skipped as a success.
+
+每次从 `MemRead()` 前计时到完整读取返回，最后累加这些区间。接收区预填和数据核对都在计时外，不添加逐次休眠。最后两个可选参数是 `iterations`（默认 100 次读取）和 `timeout_ms`（传给每次 BLOCK 操作，默认 1000 ms）。后端内部同步调用的超时行为以其实现为准。函数返回实测总微秒数，并保留新配置。
+
+Measure each interval from before `MemRead()` through its completed return, then sum the intervals. Receive-buffer preparation and data checks stay outside; no per-read sleep is added. The final optional arguments are `iterations` (100 reads by default) and `timeout_ms` (passed to each BLOCK operation, default 1000 ms). Timeout handling inside synchronous backend calls depends on their implementation. The function returns measured total microseconds and retains the new configuration.
+
+上下限由调用方在运行前给出，计算时包含从机和寄存器寻址、ACK/NACK、起停条件，以及器件时钟拉伸和软件开销。不能只用有效数据长度除以时钟频率，也不能从实测结果反推范围。选择能区分快慢设置的范围，按 A、A、B、A 调用即可检查重复设置、切换和恢复。
+
+Set bounds before running, accounting for slave/register addressing, ACK/NACK, start/stop conditions, device clock stretching and software overhead. Payload length divided by clock frequency alone is insufficient; do not derive limits from the observed result. Choose windows that distinguish the selected speeds and call with A, A, B, A to check repeated setup, switching and restoration.
+
+固定寄存器短读适合检查常用控制路径，但不能由此宣称长包 DMA 已验证。传输耗时包含器件和软件延迟，不是精确的 SCL 频率测量。
+
+Short fixed-register reads check the exercised control path, not long-transfer DMA. Duration includes device and software delays and is not a precise SCL frequency measurement.
+
 ## 检查内容 / Checks
 
 每次读取前，接收区填入预期值的反码，防止未复制数据却误通过。阻塞方式检查调用结果；轮询方式等待 `DONE` 并拒绝 `ERROR`；回调方式检查成功结果及观测到的回调次数。最后逐字节比较数据，任何错误都立即触发始终生效的 `TEST_ASSERT`，不重试。
@@ -76,6 +114,6 @@ Before each read, fill the receive area with inverted expected bytes so missing 
 
 Callbacks may run inline during submission or later in a task or ISR. The test does not assume one callback context; callbacks only update atomic counts and an error flag, while diagnostics run in the calling thread. A callback is created once and reused across rounds; no threads or notification objects are created in the loop. A failed test stops rather than returning with an operation pending.
 
-CI 不自动运行这项设备测试。寄存器读写通过，只证明相应路径；它不代表长包 DMA、普通 `Read/Write`、总线速率或异常恢复已经验证。设备型号、具体地址、寄存器与接线留在调用工程中。
+CI 不自动运行这些设备测试。`TestI2CMemRead()` 和 `TestI2CMemWriteRead()` 通过，只证明相应读写路径；它们不检查总线速率。所有结果都不能直接推广到未执行的长包 DMA、普通 `Read/Write` 或异常恢复。设备型号、具体地址、寄存器与接线留在调用工程中。
 
-CI does not run this device test automatically. Passing register read/write checks only validates the exercised paths; it does not establish long-transfer DMA, plain `Read/Write`, bus speed or error recovery. Keep device models, addresses, registers and wiring in the calling project.
+CI does not run these device tests automatically. `TestI2CMemRead()` and `TestI2CMemWriteRead()` validate the exercised read/write paths, not bus speed. Results do not extend to untested long-transfer DMA, plain `Read/Write` or error recovery. Keep device models, addresses, registers and wiring in the calling project.

--- a/test/manual/driver/i2c/test_i2c.hpp
+++ b/test/manual/driver/i2c/test_i2c.hpp
@@ -5,6 +5,8 @@
  * 用阻塞、轮询和回调方式检查固定寄存器，以及两组调用方数据的写入回读。
  * Check fixed registers and write/readback of two caller-supplied patterns in
  * blocking, polling and callback modes. Device-specific values belong to the caller.
+ * 配置测试另检查固定寄存器读数及传输耗时。
+ * A separate configuration test checks fixed-register data and transfer time.
  */
 #pragma once
 
@@ -13,6 +15,7 @@
 #include "i2c.hpp"
 #include "test_assert.hpp"
 #include "thread.hpp"
+#include "timebase.hpp"
 #include "transfer_wait.hpp"
 
 namespace LibXR::Test
@@ -169,5 +172,67 @@ inline void TestI2CMemWriteRead(I2C& i2c, uint16_t slave_addr, uint16_t mem_addr
       }
     }
   }
+}
+/**
+ * @brief 检查配置后的寄存器读数和耗时 / Check register data and timing after
+ * configuration.
+ * @pre 沿用固定寄存器读取的设备、缓冲区和地址要求。从普通任务调用，总线空闲，
+ *      微秒时间基已初始化，后端支持所选配置。
+ *      Use the same device, buffer and address requirements as the fixed-read test.
+ *      Call from a normal task with an idle bus, a ready microsecond timebase and a
+ *      configuration supported by the backend.
+ * @param i2c 已初始化并独占的总线 / Initialized, exclusively reserved bus.
+ * @param config 后端和从机均支持的时钟配置 / Clock configuration supported by backend and
+ * slave.
+ * @param slave_addr 不带 R/W 位的从机地址 / Slave address without the R/W bit.
+ * @param mem_addr 起始寄存器地址 / Starting register address.
+ * @param addr_length 寄存器地址长度 / Register address width.
+ * @param expected 固定预期字节，决定单次读取长度 / Fixed expected bytes defining each
+ * read length.
+ * @param buffer 独立接收区，容量至少为 expected 大小 / Separate receive storage, at least
+ * expected size.
+ * @param min_elapsed_us 所有读取耗时之和的下限，单位微秒 / Lower bound on summed read
+ * time in microseconds.
+ * @param max_elapsed_us 总耗时上限，包含协议、调用及调度开销 / Upper bound including
+ * protocol, call and scheduling overhead.
+ * @param iterations 读取次数 / Number of reads.
+ * @param timeout_ms 传给每次 BLOCK 操作的超时参数 / Timeout passed to each BLOCK
+ * operation.
+ * @return 实测读取耗时之和，单位微秒 / Measured sum of read times in microseconds.
+ * @note 正常返回后保留新配置；重复调用可检查同配置重设和 A-B-A 切换。
+ *       时钟拉伸和软件间隙也计入测量时间。
+ *       Retains the new configuration. Repeat calls for same-config setup and A-B-A
+ *       switching. Clock stretching and software gaps are part of the measured time.
+ */
+inline uint64_t TestI2CConfig(I2C& i2c, I2C::Configuration config, uint16_t slave_addr,
+                              uint16_t mem_addr, I2C::MemAddrLength addr_length,
+                              ConstRawData expected, RawData buffer,
+                              uint64_t min_elapsed_us, uint64_t max_elapsed_us,
+                              uint32_t iterations = 100, uint32_t timeout_ms = 1000)
+{
+  Detail::CheckI2CRegister(slave_addr, mem_addr, addr_length);
+  Detail::CheckI2CBuffers(expected, buffer);
+  TEST_ASSERT(Timebase::IsReady() && iterations > 0);
+  TEST_ASSERT(min_elapsed_us > 0 && max_elapsed_us >= min_elapsed_us);
+  TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
+  Semaphore semaphore;
+  ReadOperation operation(semaphore, timeout_ms);
+  const RawData read_buffer{buffer.addr_, expected.size_};
+  TEST_ASSERT(i2c.SetConfig(config) == ErrorCode::OK);
+  uint64_t elapsed_us = 0;
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    Detail::PoisonI2CBuffer(expected, read_buffer);
+    // 地址阶段、数据传输和完成等待都计时；预填和核对放在区间外。
+    // Include addressing, data transfer and completion wait; prepare and check outside.
+    const auto start = Timebase::GetMicroseconds();
+    TEST_ASSERT(i2c.MemRead(slave_addr, mem_addr, read_buffer, operation, addr_length,
+                            false) == ErrorCode::OK);
+    elapsed_us += (Timebase::GetMicroseconds() - start).ToMicrosecond();
+    TEST_ASSERT(elapsed_us <= max_elapsed_us);
+    Detail::CheckI2CData(expected, read_buffer);
+  }
+  TEST_ASSERT(elapsed_us >= min_elapsed_us);
+  return elapsed_us;
 }
 }  // namespace LibXR::Test


### PR DESCRIPTION
新增 `TestI2CConfig()`：设置调用方提供的时钟配置，用 BLOCK `MemRead()` 重复读取固定寄存器，逐字节核对数据，并检查所有读取耗时之和是否落在预先指定的范围内。计时包含寻址、数据和完成等待；预填及核对在外，无逐次休眠、重试或自动调整阈值。

复用已有寄存器地址和缓冲区检查，保留原三种完成方式读写测试。配置测试不写寄存器数据；调用方可按A-A-B-A重复调用，并为地址、ACK/NACK、时钟拉伸及软件开销设置合理范围。正常返回后保留新配置。只改I²C测试头文件及对应双语README，一个提交、两个文件；产品驱动、共用辅助和CI配置不变。

验证：
- Linux GNU13.3 Release / DEV_ASSERT=OFF：配置25项预期结果通过，包含同步/延后完成、地址透传、配置被忽略、速率过快/过慢、读数错误、未完成及非法参数；`NOT_SUPPORT` 必须触发失败，不会跳过假通过。
- 原I²C读测试23项、写入回读15项回归通过。
- 独立只读语义复核、clang-format21.1.8、差异检查通过。复核后的超时措辞调整仅涉及注释，最终头文件再次完成主机和目标编译。
- ARM GNU14.2.1 Debug / DEV_ASSERT=ON完整G0B1固件编译链接通过；测试入口保留在ELF中，静态断言确认 `HasClockSpeed<I2C_HandleTypeDef*>` 为false。

**本次未做I²C配置切换实机验证。** 当前STM32后端仅支持HAL的ClockSpeed字段，G0B1使用Timing字段，`SetConfig()`明确返回NOT_SUPPORT。其动态调速支持是另一项产品驱动工作，未在本PR中实现。板子继续保留上一轮SPI测试固件，未烧录或操作I²C设备。

主机严格告警对已有libxr_string.hpp:658 missing-field-initializers保留非致命例外；板级快照的HAL PCD volatile及未用初始化函数告警未改动。耗时不是精确SCL频率测量，也不证明未执行的长包DMA、普通Read/Write、异常恢复或其他平台。主机模拟与板级工程留在仓库外，PR待用户审核后合并dev。

## Sourcery 摘要

新增 I²C 时钟配置验证，包括固定寄存器数据检查和有界聚合读取时序。

新功能：
- 添加 `TestI2CConfig()`，通过重复读取固定寄存器并检查聚合时序边界，验证调用方提供的时钟配置。
- 在双语手动测试指南中记录新的 I²C 配置及时序测试。

增强功能：
- 复用现有的 I²C 寄存器、缓冲区和数据验证检查，同时保留现有的阻塞式、轮询式和回调式读写测试。
- 确保不受支持的配置会导致测试失败，而不会被视为成功跳过；并在测试成功后保留受支持的配置。

文档：
- 明确时序覆盖范围、调用方定义的边界、配置切换检查以及时序测量的局限性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add I²C clock-configuration validation with fixed-register data checks and bounded aggregate read timing.

New Features:
- Add `TestI2CConfig()` to validate caller-supplied clock configurations using repeated fixed-register reads and aggregate timing bounds.
- Document the new I²C configuration and timing test in bilingual manual-test guidance.

Enhancements:
- Reuse existing I²C register, buffer, and data validation checks while retaining the existing blocking, polling, and callback read/write tests.
- Ensure unsupported configurations fail the test instead of being treated as successful skips, and preserve supported configurations after a successful test.

Documentation:
- Clarify timing coverage, caller-defined bounds, configuration switching checks, and the limitations of the timing measurement.

</details>