### PR TITLE
test: stress UART configuration during I/O

### DIFF
--- a/test/manual/driver/uart/README.md
+++ b/test/manual/driver/uart/README.md
@@ -96,3 +96,46 @@ Call with A, A, B, A to check repeated setup and switching back. Wait for line i
 耗时不能区分所有帧格式。例如 8E1 与 8N2 都是每字节 11 位。回环数据和耗时检查可发现部分错误配置，但不能代替独立接收端或逻辑分析仪对校验位、停止位和线路速率的确认。
 
 Timing cannot distinguish every frame format: 8E1 and 8N2 both use 11 bits per byte. Loopback data and timing can detect some configuration errors but do not replace an independent receiver or logic analyzer for verifying parity, stop bits and line rate.
+
+## 并发配置压力 / Concurrent configuration stress
+
+`TestUARTConfigStress()` 检查反复改配置是否会让驱动无法继续工作。切换期间允许接收数据丢失、内容改变或读取超时；停止干扰后，仍使用同一个 UART 对象恢复固定配置并验证完整回环。
+
+`TestUARTConfigStress()` checks whether repeated configuration changes leave the driver usable. During switching, received data may be lost or changed and reads may time out. After interference stops, the same UART object returns to a fixed configuration and must pass full loopback checks.
+
+仅用于明确支持配置与收发重叠的后端。独占串口，初始没有在途请求和接收残留；TX 接 RX，工作缓冲区独立、等长且不超过两个端口的容量。调用方提供一个独占的、处于 READY 状态的 `ASync`，从普通任务调用。
+
+Use only a backend that explicitly supports configuration overlapping I/O. Reserve the UART with no initial in-flight requests or receive residue. Wire TX to RX and supply separate, equal-size work buffers within both port capacities. Borrow an exclusive READY `ASync` from the caller and invoke the test from a normal task.
+
+```cpp
+#include "uart/test_uart_config_stress.hpp"
+
+LibXR::Test::UARTConfigStressResult CheckUARTStress(
+    LibXR::UART& uart, LibXR::ASync& worker, LibXR::RawData tx, LibXR::RawData rx,
+    std::initializer_list<LibXR::UART::Configuration> configs,
+    LibXR::UART::Configuration stable_config, uint32_t quiet_ms)
+{
+  return LibXR::Test::TestUARTConfigStress(uart, worker, tx, rx, configs,
+                                           stable_config, quiet_ms);
+}
+```
+
+每轮先提交一次回调方式的发送，再让 ASync 按列表尝试配置，同时进行一次阻塞读取。每轮从列表的下一项开始，避免总由同一配置占住待处理槽。配置尝试相隔 1 ms；任务次数有限，不等待调用线程发出停止信号。最后两个可选参数为 `timeout_ms`（默认 1000 ms）和 `iterations`（默认 100 轮）。每个读取和收敛等待分别使用这个超时，不是整个测试的总时限。
+
+Each round submits a callback write, starts an ASync job that tries the configuration list, and performs one blocking read. Rotate the starting entry so the same configuration does not always claim the pending slot. Attempts are 1 ms apart. The finite job does not wait for a stop signal from its caller. The final optional arguments are `timeout_ms` (1000 ms) and `iterations` (100 rounds). Each read and convergence wait has its own timeout; this is not a whole-test deadline.
+
+配置只允许返回 `OK` 或 `BUSY`，发送提交允许 `OK`、`BUSY` 或 `FULL`。已接纳发送必须完成，回调结果允许 `OK` 或 `FAILED`，但不能重复通知；读取允许 `OK` 或 `TIMEOUT`，压力阶段不比较接收内容。返回统计包含这些结果，并要求至少接纳一次发送、一次配置，且观测到配置尝试发生在读取调用期间。
+
+Configuration returns must be `OK` or `BUSY`; write submission may return `OK`, `BUSY` or `FULL`. Every accepted write must complete with callback result `OK` or `FAILED`, without duplicate notifications. Reads may return `OK` or `TIMEOUT`; stress-phase payloads are not compared. Returned counts include these outcomes. At least one write and configuration must be accepted, and configuration attempts must be observed during a read call.
+
+发送完成只代表后端接纳，线路可能还在发送。所有配置任务和发送通知结束后，测试在有限时间内提交固定配置，等待调用方指定的 `quiet_ms`，再清理一次接收残留。这个等待须覆盖后端缓冲区按最慢配置发完及配置生效的时间。之后用固定 8 位配置检查阻塞、轮询、回调三种回环，保留该配置；恢复阶段不接受乱码或超时。
+
+TX completion means backend acceptance; bytes may remain on the wire. After configuration jobs and TX notifications finish, the test submits the fixed configuration within a bounded wait, waits `quiet_ms`, then discards receive residue once. Choose this delay to cover backend buffers draining at the slowest configuration and configuration application. It then checks blocking, polling and callback loopback using the fixed 8-bit configuration, which remains active. Corruption or timeouts fail the recovery phase.
+
+有线程的平台由 ASync 工作线程制造交错；裸机通过普通上下文的 Timer 推进任务，可与正在运行的 DMA／中断交错。统计中的 `during_read` 只表示读取调用区间重叠，不独立证明硬件当时仍在发送。具体板级验证应另记录 DMA 或线路忙状态。
+
+Threaded systems use the ASync worker; bare-metal systems advance the job through a Timer in normal context, overlapping active DMA/interrupts. `during_read` records overlap with the read-call interval, not independent proof of active hardware transmission. Board-specific validation should also record DMA or line-busy state.
+
+测试保留通知对象到配置任务和发送完成，结束后再交还 ASync。它检查已观测的重复通知，不能保证返回后任意时刻都没有错误回调。若驱动卡死在同步调用中，函数内的超时无法强行打断，板级程序或外部测试工具还需设置整体执行上限。
+
+Notification objects remain alive until configuration jobs and TX finish, then the ASync is returned to the caller. The test checks observed duplicate notifications, not the absence of faulty callbacks at arbitrary times after return. Internal timeouts cannot preempt a driver stuck inside a synchronous call; the board application or external test tool also needs an overall execution limit.

--- a/test/manual/driver/uart/test_uart_config_stress.hpp
+++ b/test/manual/driver/uart/test_uart_config_stress.hpp
@@ -1,0 +1,192 @@
+/**
+ * @file test_uart_config_stress.hpp
+ * @brief UART 并发配置压力测试 / UART concurrent configuration stress test.
+ *
+ * 收发期间借用 ASync 反复提交配置，检查请求完成及停止干扰后的恢复。
+ * Use a borrowed ASync to submit configurations during I/O; check completion and
+ * recovery afterward. Payload loss or corruption during switching is allowed.
+ */
+#pragma once
+
+#include "async.hpp"
+#include "test_uart.hpp"
+
+namespace LibXR::Test
+{
+/** @brief 压力阶段的观测计数 / Observed counts from the stress phase. */
+struct UARTConfigStressResult
+{
+  uint32_t config_ok = 0;    ///< 已接纳配置 / Accepted configurations.
+  uint32_t config_busy = 0;  ///< 配置忙时拒绝 / Busy configuration submissions.
+  uint32_t during_read =
+      0;  ///< 读取调用期间的配置尝试 / Config attempts during a read call.
+  uint32_t write_ok = 0;        ///< 已接纳发送 / Accepted writes.
+  uint32_t write_rejected = 0;  ///< BUSY 或 FULL 拒绝 / Writes rejected as BUSY or FULL.
+  uint32_t write_failed = 0;    ///< 已完成但失败的发送 / Writes completed with failure.
+  uint32_t read_ok = 0;  ///< 完成的读取，不校验内容 / Completed reads, payload unchecked.
+  uint32_t read_timeout = 0;  ///< 读取超时 / Read timeouts.
+};
+
+/**
+ * @brief 检查并发配置后的 UART 恢复 / Check UART recovery after concurrent configuration.
+ * @pre 后端支持配置与收发重叠；TX 接 RX，独占端口，初始无遗留请求或接收数据。
+ *      The backend must support configuration overlapping I/O. Wire TX to RX and
+ *      reserve both ports, initially with no pending requests or received bytes.
+ * @pre tx/rx 为独立等长工作 RAM，满足后端要求且各自不超过两个端口容量。
+ *      tx/rx are separate equal-size work RAM meeting backend requirements and both
+ *      port capacities. They must not overlap active backend buffers.
+ * @param uart 已初始化的串口 / Initialized UART.
+ * @param worker 独占借用的 READY 状态 ASync / Exclusively borrowed READY ASync.
+ * @param tx 发送工作区，其大小为每包长度 / TX work buffer; its size is the packet length.
+ * @param rx 接收工作区 / RX work buffer.
+ * @param configs 每轮轮换起点的合法配置列表，尝试间隔 1 ms / Legal configurations tried
+ * 1 ms apart, rotating the starting entry each round.
+ * @param stable_config 开始及结束时的固定配置，须为 8 位数据 / Initial and final
+ * configuration, with 8 data bits.
+ * @param quiet_ms 停止干扰后留给线路排空和配置生效的时间，由调用方确定 /
+ *        Caller-chosen time for wire drain and configuration application after
+ * interference.
+ * @param timeout_ms 每次读及各收敛等待的上限，不强制中断同步后端调用 /
+ *        Timeout for each read and convergence wait; cannot preempt synchronous backend
+ * calls.
+ * @param iterations 压力轮数 / Stress rounds.
+ * @return 压力阶段统计；返回前已通过固定配置回环 / Stress counts; fixed-config loopback
+ * passes before return.
+ */
+inline UARTConfigStressResult TestUARTConfigStress(
+    UART& uart, ASync& worker, RawData tx, RawData rx,
+    std::initializer_list<UART::Configuration> configs, UART::Configuration stable_config,
+    uint32_t quiet_ms, uint32_t timeout_ms = 1000, uint32_t iterations = 100)
+{
+  TEST_ASSERT(worker.GetStatus() == ASync::Status::READY);
+  TEST_ASSERT(iterations > 0 && configs.size() > 0 &&
+              configs.size() <= UINT32_MAX / iterations);
+  TEST_ASSERT(timeout_ms > 0 && timeout_ms < UINT32_MAX / 2U);
+  TEST_ASSERT(quiet_ms > 0 && quiet_ms < UINT32_MAX / 2U && stable_config.data_bits == 8);
+  TEST_ASSERT(uart.read_port_ && uart.write_port_);
+  TEST_ASSERT(uart.read_port_->Readable() && uart.write_port_->Writable());
+  TEST_ASSERT(tx.addr_ && rx.addr_ && tx.size_ > 0 && tx.size_ == rx.size_);
+  TEST_ASSERT(tx.size_ <= uart.read_port_->Capacity() &&
+              tx.size_ <= uart.write_port_->Capacity());
+  const auto tx_begin = reinterpret_cast<uintptr_t>(tx.addr_);
+  const auto rx_begin = reinterpret_cast<uintptr_t>(rx.addr_);
+  TEST_ASSERT(tx_begin >= rx_begin ? tx_begin - rx_begin >= rx.size_
+                                   : rx_begin - tx_begin >= tx.size_);
+  TEST_ASSERT(uart.read_port_->Size() == 0);
+  TEST_ASSERT(uart.SetConfig(stable_config) == ErrorCode::OK);
+  Thread::Sleep(quiet_ms);
+
+  struct Context
+  {
+    UART& uart;
+    std::initializer_list<UART::Configuration> configs;
+    UARTConfigStressResult result;
+    size_t first_config = 0;
+    std::atomic<uint32_t> reading{0}, tx_calls{0}, tx_failed{0}, bad_result{0};
+  } context{uart, configs, {}};
+  auto config_job = ASync::Job::Create(
+      [](bool, Context* self, ASync*)
+      {
+        // 有限任务独立结束；裸机 Timer 中不能等调用线程发出停止信号。
+        // Finish independently; a cooperative Timer job cannot wait for its caller.
+        size_t index = self->first_config;
+        for (size_t i = 0; i < self->configs.size(); ++i)
+        {
+          const bool reading = self->reading.load(std::memory_order_acquire) != 0;
+          const auto ec = self->uart.SetConfig(self->configs.begin()[index]);
+          TEST_ASSERT(ec == ErrorCode::OK || ec == ErrorCode::BUSY);
+          if (ec == ErrorCode::OK)
+            ++self->result.config_ok;
+          else
+            ++self->result.config_busy;
+          if (reading && self->reading.load(std::memory_order_acquire) != 0)
+            ++self->result.during_read;
+          if (++index == self->configs.size()) index = 0;
+          Thread::Sleep(1);
+        }
+      },
+      &context);
+  auto callback = WriteOperation::Callback::Create(
+      [](bool, Context* self, ErrorCode ec)
+      {
+        if (ec == ErrorCode::FAILED)
+          self->tx_failed.fetch_add(1, std::memory_order_relaxed);
+        else if (ec != ErrorCode::OK)
+          self->bad_result.store(1, std::memory_order_relaxed);
+        // 最后一次访问上下文才发布计数，ISR 不打印或断言。
+        // Publish on the last context access; no logging or assertions in ISR.
+        self->tx_calls.fetch_add(1, std::memory_order_release);
+      },
+      &context);
+  WriteOperation write(callback);
+  Semaphore read_sem;
+  ReadOperation read(read_sem, timeout_ms);
+  auto wait_until = [&](auto finished)
+  {
+    const uint32_t start = Thread::GetTime();
+    while (!finished())
+    {
+      TEST_ASSERT(Thread::GetTime() - start < timeout_ms);
+      Thread::Sleep(1);
+    }
+  };
+  auto check_tx = [&]()
+  {
+    const uint32_t calls = context.tx_calls.load(std::memory_order_acquire);
+    TEST_ASSERT(calls <= context.result.write_ok);
+    TEST_ASSERT(context.bad_result.load(std::memory_order_relaxed) == 0);
+    return calls == context.result.write_ok;
+  };
+  for (uint32_t round = 0; round < iterations; ++round)
+  {
+    auto* sent = static_cast<uint8_t*>(tx.addr_);
+    for (size_t i = 0; i < tx.size_; ++i) sent[i] = (i * 37U + round) & 0x7FU;
+    const auto written = uart.Write({tx.addr_, tx.size_}, write);
+    TEST_ASSERT(written == ErrorCode::OK || written == ErrorCode::BUSY ||
+                written == ErrorCode::FULL);
+    if (written == ErrorCode::OK)
+      ++context.result.write_ok;
+    else
+      ++context.result.write_rejected;
+    // 轮换起点，避免总由同一配置占住唯一待处理槽。
+    // Rotate the first attempt so the same configuration does not always claim the slot.
+    context.first_config = round % configs.size();
+    TEST_ASSERT(worker.AssignJob(config_job) == ErrorCode::OK);
+    context.reading.store(1, std::memory_order_release);
+    const auto received = uart.Read(rx, read);
+    context.reading.store(0, std::memory_order_release);
+    TEST_ASSERT(received == ErrorCode::OK || received == ErrorCode::TIMEOUT);
+    if (received == ErrorCode::OK)
+      ++context.result.read_ok;
+    else
+      ++context.result.read_timeout;
+    wait_until(
+        [&]()
+        {
+          const auto status = worker.GetStatus();
+          TEST_ASSERT(status == ASync::Status::BUSY || status == ASync::Status::DONE);
+          return status == ASync::Status::DONE;
+        });
+    // 发送用回调跟踪到终态；不把 BLOCK Write 超时误当作请求退出。
+    // Track TX to terminal completion instead of treating BLOCK timeout as retirement.
+    wait_until(check_tx);
+  }
+  TEST_ASSERT(context.result.config_ok > 0 && context.result.during_read > 0 &&
+              context.result.write_ok > 0);
+  wait_until(
+      [&]()
+      {
+        const auto ec = uart.SetConfig(stable_config);
+        TEST_ASSERT(ec == ErrorCode::OK || ec == ErrorCode::BUSY);
+        return ec == ErrorCode::OK;
+      });
+  // 所有请求已结束，再等线路排空，最后丢弃切换期间的接收残留。
+  // After request completion, wait for wire drain before discarding switching residue.
+  Thread::Sleep(quiet_ms);
+  TEST_ASSERT(uart.read_port_->ClearQueuedData() == ErrorCode::OK);
+  TestUARTLoopback(uart, tx, rx, {tx.size_}, timeout_ms, 1);
+  TEST_ASSERT(check_tx());
+  context.result.write_failed = context.tx_failed.load(std::memory_order_relaxed);
+  return context.result;
+}
+}  // namespace LibXR::Test


### PR DESCRIPTION
新增 `TestUARTConfigStress()`：借用调用方的 ASync，在收发期间按有限列表反复提交配置。每轮轮换配置起点，避免总由同一项占住待处理槽。停止干扰后，等待任务和发送通知结束，恢复固定配置、等待调用方指定的线路排空时间，再清理一次接收残留，用同一个 UART 对象检查阻塞、轮询、回调三种回环。

压力阶段允许接收内容变化、丢失及 Read TIMEOUT；配置允许 OK/BUSY，发送提交允许 OK/BUSY/FULL，已接纳发送必须完成且没有观测到重复通知。发送使用回调跟踪到终态，避免把 BLOCK Write 超时误当成请求退出。恢复阶段要求正确数据和正常完成。返回各类结果的计数。

一个提交、两个文件：独立测试头文件及 UART README。产品代码、现有测试和共用辅助未修改；板级程序、模拟后端及反例验证留在仓库外。

验证：
- Linux GNU13.3 Release / DEV_ASSERT=OFF：14项预期结果通过，包含正常交错、压力期间乱码/丢包/发送失败仍可恢复，以及发送不结束、配置永久BUSY、无效配置、恢复后损坏和参数错误的拒绝。
- 外部源码副本中将实际 WritePort 的完成通知故意改为两次，新测试在回调计数检查处 SIGABRT。反例后已恢复该副本并重建正常程序，产品仓库未改。
- 独立只读语义复核、clang-format21.1.8和差异检查通过。ARM GNU14.2.1 Debug / DEV_ASSERT=ON完整G0B1固件编译链接通过。
- G0B1实机PB6→PA10，RX/TX DMA各256字节，独立工作区各128字节，借用裸机ASync。20轮，每轮尝试9600 8N1、57600 7E1、38400 8O1、115200 8N1，轮换首项。
- 80次配置尝试均观测到读取调用正在进行，板级另用UART TC和DMAT位确认这80次都撞到了活动发送。20次配置接纳（四种各5次），60次BUSY；20次发送均接纳并完成，发送失败0；20次压力读取均TIMEOUT。
- 随后用同一个UART恢复115200 8N1，等待500ms排空、Clear一次，再做三种完成方式的128字节回环，全部通过。全程约11.040秒，结果0x600D600D，错误日志为空。

`during_read` 本身只表示读取调用区间重叠，硬件活跃证据来自外部板级记录。裸机ASync通过普通上下文Timer推进，不宣称CPU双核并行验证。未证明所有交错、任意迟到回调或其他芯片；同步调用内部死锁依赖外部整体执行上限。默认100轮，可由调用方调整。

主机保留已有libxr_string.hpp:658 missing-field-initializers非致命例外；板级快照有HAL PCD volatile及未用初始化函数告警。板子保留UART压力测试固件，CPU停在完成位置，最终1152008N1、RX DMA启用，选项字节不变。PR保持草稿，待用户审核后合并dev。

## Sourcery 摘要

添加 UART 配置压力测试，用于验证请求完成情况，以及并发配置变更后的可靠回环恢复能力。

新功能：
- 添加可复用的 UART 并发压力测试，在发送和接收操作期间反复更改配置，报告各类结果的计数，并通过阻塞式、轮询式和回调式回环验证恢复能力。

增强功能：
- 记录并发 UART 配置压力测试的前置条件、时序、结果预期、恢复要求和限制。

文档：
- 在 UART 手册中记录如何调用和解读并发 UART 配置压力测试。

测试：
- 增加对已接受和被拒绝的配置及传输请求、回调完成完整性、读取超时、重叠情况观测以及压力测试后 UART 恢复能力的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a UART configuration stress test that validates request completion and reliable loopback recovery after concurrent configuration changes.

New Features:
- Add a reusable UART concurrency stress test that repeatedly changes configuration during transmit and receive operations, reports outcome counts, and verifies recovery with blocking, polling, and callback loopback.

Enhancements:
- Document prerequisites, timing, result expectations, recovery requirements, and limitations for concurrent UART configuration stress testing.

Documentation:
- Document how to invoke and interpret the concurrent UART configuration stress test in the UART manual.

Tests:
- Add coverage for accepted and rejected configuration and transmission requests, callback completion integrity, read timeouts, overlap observation, and post-stress UART recovery.

</details>