### PR TITLE
fix(stm32): account for H7 timer kernel clocks in PWM

### DIFF
--- a/driver/st/stm32_pwm.cpp
+++ b/driver/st/stm32_pwm.cpp
@@ -21,6 +21,23 @@ uint32_t GetH5TimerClock(uint32_t peripheral_clock, uint32_t apb_prescaler)
 }  // namespace
 #endif
 
+#if defined(STM32H7)
+namespace
+{
+uint32_t GetH7TimerClock(uint32_t peripheral_clock)
+{
+  const uint32_t hclk = HAL_RCC_GetHCLKFreq();
+  const uint32_t multiplier = (RCC->CFGR & RCC_CFGR_TIMPRE) != 0U ? 4U : 2U;
+  // APB 分频为 1/2/4/8/16；TIMPRE 倍频后的时钟不超过 HCLK。
+  // APB divisors are 1/2/4/8/16; the TIMPRE multiplier is capped at HCLK.
+  // 使用 HAL 解析 PCLK，兼容 D2CFGR 和 CDCFGR 的 H7 型号。
+  // Let HAL resolve PCLK for both D2CFGR and CDCFGR H7 variants.
+  const uint32_t timer_clock = peripheral_clock * multiplier;
+  return timer_clock < hclk ? timer_clock : hclk;
+}
+}  // namespace
+#endif
+
 STM32PWM::STM32PWM(TIM_HandleTypeDef* htim, uint32_t channel, bool complementary)
     : htim_(htim), channel_(channel), complementary_(complementary)
 {
@@ -92,6 +109,8 @@ ErrorCode STM32PWM::SetConfig(Configuration config)
 #if defined(STM32H5)
     clock_freq = GetH5TimerClock(clock_freq,
                                  (RCC->CFGR2 & RCC_CFGR2_PPRE2) >> RCC_CFGR2_PPRE2_Pos);
+#elif defined(STM32H7)
+    clock_freq = GetH7TimerClock(clock_freq);
 #elif defined(RCC_CFGR_PPRE2)
     if ((RCC->CFGR & RCC_CFGR_PPRE2) != RCC_CFGR_PPRE2_DIV1)
     {
@@ -133,6 +152,8 @@ ErrorCode STM32PWM::SetConfig(Configuration config)
 #if defined(STM32H5)
     clock_freq = GetH5TimerClock(clock_freq,
                                  (RCC->CFGR2 & RCC_CFGR2_PPRE1) >> RCC_CFGR2_PPRE1_Pos);
+#elif defined(STM32H7)
+    clock_freq = GetH7TimerClock(clock_freq);
 #elif defined(RCC_CFGR_PPRE1)
     if ((RCC->CFGR & RCC_CFGR_PPRE1) != RCC_CFGR_PPRE1_DIV1)
     {


### PR DESCRIPTION
H7 的 PWM 原先直接使用 PCLK 计算 PSC/ARR，遗漏 TIMPRE 对定时器内核时钟的影响。在 H723 上，请求 1 kHz 会实际输出约 2 kHz 或 4 kHz。

增加 H7 专用时钟计算：依据 TIMPRE 对 HAL 返回的 PCLK 乘 2 或 4，并以 HCLK 为上限，分别用于 APB1/APB2 定时器。使用 HAL 解析的时钟值，兼容 D2CFGR/CDCFGR 两类 H7 寄存器布局。本 PR 只有一个提交、一个产品文件，增加 21 行，内容与已实测补丁逐字节一致。

验证记录：
- MC02/H723：原固件相同夹具得到 12 个频率失败点；补丁后同 12 点及原 48 项占空比/启停检查通过。
- 额外 40 个实机频率点通过：TIM1/APB2、TIM2/APB1，APB÷1/2/4/8/16，TIMPRE=0/1，1/4 kHz。独立矩阵将 HCLK 降至 137.5 MHz，保证 APB÷1 安全。
- H723、H743、H7A3、H7B3 的真实 CMSIS/HAL 头文件编译通过；实际 helper 的 40 项计算回归通过。H743/H7A3/H7B3 仅编译验证，未作实机声明。
- 正常固件的 FreeRTOS 系统、UART、USB 基础收发及设备接收侧背压回归通过。
- 固定 clang-format 21.1.8、git diff --check 和基线补丁检查通过。

实测依据 CNT/DWT 计数，不是外部示波器校准。沿用已验证的相同源码及留存证据，本次 PR 打包未重新烧录。测试夹具、BSP、日志与取证文件均留在产品仓库外。

## Sourcery 摘要

通过在配置 PWM 时序时使用有效的定时器内核时钟，修复 STM32H7 PWM 频率精度问题。

错误修复：
- 修正 STM32H7 PWM 定时器时钟计算，确保配置的输出频率能够考虑 TIMPRE 和 APB 定时器时钟行为。

测试：
- 在支持的 STM32H7 系列、定时器总线、APB 预分频器和 TIMPRE 设置下验证 PWM 频率计算，并覆盖硬件测试和编译测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix STM32H7 PWM frequency accuracy by using the effective timer kernel clock when configuring PWM timing.

Bug Fixes:
- Correct STM32H7 PWM timer clock calculations so configured output frequencies account for TIMPRE and APB timer-clock behavior.

Tests:
- Validate PWM frequency calculations across supported STM32H7 families, timer buses, APB prescalers, and TIMPRE settings, with hardware and compilation coverage.

</details>