### PR TITLE
fix(stm32): maintain Flash cache coherency across erase and program

### DIFF
--- a/driver/st/stm32_flash.cpp
+++ b/driver/st/stm32_flash.cpp
@@ -4,6 +4,85 @@
 
 using namespace LibXR;
 
+namespace
+{
+/** @brief Flash 擦写期间的缓存状态与写锁管理 / Cache state and write lock for Flash
+ * operations. */
+class FlashOperationGuard
+{
+ public:
+  FlashOperationGuard()
+  {
+#if defined(ICACHE) && defined(ICACHE_CR_EN) && defined(ICACHE_SR_BUSYF)
+    standalone_enabled_ = (ICACHE->CR & ICACHE_CR_EN) != 0U;
+    if (standalone_enabled_)
+    {
+      // 关闭独立 ICACHE 会自动失效；等硬件空闲，不消费共享的完成标志。
+      // Disabling standalone ICACHE invalidates it; wait for idle without consuming
+      // the shared completion flag.
+      CLEAR_BIT(ICACHE->CR, ICACHE_CR_EN);
+      __DSB();
+      __ISB();
+      const uint32_t start = HAL_GetTick();
+      while ((ICACHE->CR & ICACHE_CR_EN) != 0U || (ICACHE->SR & ICACHE_SR_BUSYF) != 0U)
+      {
+        if (static_cast<uint32_t>(HAL_GetTick() - start) > 1U)
+        {
+          // 抢占期间可能已完成，超时报错前重新确认。
+          // Completion may occur during preemption; recheck before failing.
+          REQUIRE((ICACHE->CR & ICACHE_CR_EN) == 0U &&
+                  (ICACHE->SR & ICACHE_SR_BUSYF) == 0U);
+        }
+      }
+    }
+#endif
+#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    i_cache_enabled_ = (SCB->CCR & SCB_CCR_IC_Msk) != 0U;
+    if (i_cache_enabled_) SCB_DisableICache();
+#endif
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    d_cache_enabled_ = (SCB->CCR & SCB_CCR_DC_Msk) != 0U;
+    if (d_cache_enabled_) SCB_DisableDCache();
+#endif
+    HAL_FLASH_Unlock();
+  }
+
+  ~FlashOperationGuard()
+  {
+    HAL_FLASH_Lock();
+#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    if (i_cache_enabled_) SCB_EnableICache();
+#endif
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if (d_cache_enabled_) SCB_EnableDCache();
+#endif
+#if defined(ICACHE) && defined(ICACHE_CR_EN) && defined(ICACHE_SR_BUSYF)
+    if (standalone_enabled_)
+    {
+      __DSB();
+      SET_BIT(ICACHE->CR, ICACHE_CR_EN);
+      __DSB();
+      __ISB();
+    }
+#endif
+  }
+
+  FlashOperationGuard(const FlashOperationGuard&) = delete;
+  FlashOperationGuard& operator=(const FlashOperationGuard&) = delete;
+
+ private:
+#if defined(ICACHE) && defined(ICACHE_CR_EN) && defined(ICACHE_SR_BUSYF)
+  bool standalone_enabled_ = false;
+#endif
+#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+  bool i_cache_enabled_ = false;
+#endif
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+  bool d_cache_enabled_ = false;
+#endif
+};
+}  // namespace
+
 STM32Flash::STM32Flash(const FlashSector* sectors, size_t sector_count,
                        size_t start_sector)
     : Flash(sectors[start_sector - 1].size, DetermineMinWriteSize(),
@@ -27,23 +106,7 @@ ErrorCode STM32Flash::Erase(size_t offset, size_t size)
   uint32_t start_addr = base_address_ + offset;
   uint32_t end_addr = start_addr + size;
 
-#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
-  bool i_cache_enabled = ((SCB->CCR & SCB_CCR_IC_Msk) != 0U);
-  if (i_cache_enabled)
-  {
-    SCB_DisableICache();
-  }
-#endif
-
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  bool d_cache_enabled = ((SCB->CCR & SCB_CCR_DC_Msk) != 0U);
-  if (d_cache_enabled)
-  {
-    SCB_DisableDCache();
-  }
-#endif
-
-  HAL_FLASH_Unlock();
+  FlashOperationGuard operation;
 
   for (size_t i = 0; i < sector_count_; ++i)
   {
@@ -87,27 +150,9 @@ ErrorCode STM32Flash::Erase(size_t offset, size_t size)
     HAL_StatusTypeDef status = HAL_FLASHEx_Erase(&erase_init, &error);
     if (status != HAL_OK || error != 0xFFFFFFFFU)
     {
-      HAL_FLASH_Lock();
       return ErrorCode::FAILED;
     }
   }
-
-  HAL_FLASH_Lock();
-
-#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
-  if (i_cache_enabled)
-  {
-    SCB_EnableICache();
-  }
-#endif
-
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-
-  if (d_cache_enabled)
-  {
-    SCB_EnableDCache();
-  }
-#endif
 
   return ErrorCode::OK;
 }
@@ -125,23 +170,7 @@ ErrorCode STM32Flash::Write(size_t offset, ConstRawData data)
     return ErrorCode::OUT_OF_RANGE;
   }
 
-#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
-  bool i_cache_enabled = ((SCB->CCR & SCB_CCR_IC_Msk) != 0U);
-  if (i_cache_enabled)
-  {
-    SCB_DisableICache();
-  }
-#endif
-
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  bool d_cache_enabled = ((SCB->CCR & SCB_CCR_DC_Msk) != 0U);
-  if (d_cache_enabled)
-  {
-    SCB_DisableDCache();
-  }
-#endif
-
-  HAL_FLASH_Unlock();
+  FlashOperationGuard operation;
 
   const uint8_t* src = reinterpret_cast<const uint8_t*>(data.addr_);
   size_t written = 0;
@@ -166,7 +195,6 @@ ErrorCode STM32Flash::Write(size_t offset, ConstRawData data)
     if (HAL_FLASH_Program(program_type_, addr + written,
                           reinterpret_cast<uint32_t>(flash_word_buffer)) != HAL_OK)
     {
-      HAL_FLASH_Lock();
       return ErrorCode::FAILED;
     }
 
@@ -190,27 +218,10 @@ ErrorCode STM32Flash::Write(size_t offset, ConstRawData data)
 
     if (HAL_FLASH_Program(program_type_, addr + written, word) != HAL_OK)
     {
-      HAL_FLASH_Lock();
       return ErrorCode::FAILED;
     }
 
     written += chunk_size;
-  }
-#endif
-
-  HAL_FLASH_Lock();
-
-#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
-  if (i_cache_enabled)
-  {
-    SCB_EnableICache();
-  }
-#endif
-
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  if (d_cache_enabled)
-  {
-    SCB_EnableDCache();
   }
 #endif
 

--- a/driver/st/stm32_flash.hpp
+++ b/driver/st/stm32_flash.hpp
@@ -102,6 +102,13 @@ typename std::enable_if<HasFlashBank<T>::value>::type SetBanks(T& init, uint32_t
 
 /**
  * @brief STM32 闪存驱动实现 / STM32 flash driver implementation
+ * @pre 擦写调用及相关缓存控制由调用方串行化；等待期间 HAL tick 必须能推进。
+ *      The caller serializes erase/program calls and related cache control; the HAL
+ *      tick must advance during waits.
+ * @note 擦写期间暂时关闭相关缓存；进入擦写流程后，成功或失败返回均恢复缓存开关并锁定
+ * Flash。 Related caches are temporarily disabled during erase/program operations. Once
+ * the operation starts, success and failure returns restore the original cache enable
+ * state and lock Flash.
  */
 class STM32Flash : public Flash
 {


### PR DESCRIPTION
STM32H503 在独立 ICACHE 开启时，Flash 写入返回 OK 后立即回读仍可能得到旧值。例如写入 `0x12345678` 后读到 `0xFFFFFFFF`，额外失效缓存才得到正确内容。

擦写前保存并关闭相关缓存，等待独立 ICACHE 自动失效完成，再比较旧内容、擦除或编程；作用域退出时锁定 Flash 并恢复原缓存开关。也补齐原 SCB 缓存在 HAL 失败等早退路径上的恢复。独立 ICACHE 使用寄存器能力判断，不要求 BSP 启用 ICACHE HAL 模块。

调用方需串行安排 Flash 擦写和相关缓存控制，等待期间 HAL tick 必须推进。此次没有新增并发锁或修改 MPU 配置。

验证：
- H503 FreeRTOS 实机 Debug / Release：原默认缓存失败用例、三轮擦写及同值重写、缓存关闭对照均通过；第一次回读已正确，不依赖测试末尾额外失效。
- 两种构建各验证缓存原本开/关时注入 HAL 编程和擦除失败，返回失败后恢复缓存、锁回 Flash，随后正常写入回读通过。
- 两种构建各 8 轮在 USART1 DMA 活动时擦写，16 次 HAL 擦写入口命中活动 DMA；256 字节回环数据一致，Timer 回调推进，最终状态恢复。此项不保证任意负载下的实时延迟。
- 实际源码主机检查：无缓存、独立 ICACHE、SCB I/D-cache 三条路径通过；永久 BUSY 被停止在 Flash 操作前，旧源码负对照失败。
- H503、H563、F401、H743 的真实 CMSIS/HAL 头文件对象编译通过；clang-format 21.1.8 和差异检查通过。

PR 仅含 Flash 实现与类契约注释。板级夹具、失败注入和实验记录未加入产品仓库。尚未在 H563/F401/H743 实机验证本次修改。

## Sourcery 摘要

在整个擦除和编程操作期间维护 STM32 Flash 缓存一致性，并确保在所有退出路径上可靠地恢复硬件状态。

错误修复：
- 通过维护独立 ICACHE 和 SCB 指令/数据缓存之间的一致性，确保 STM32 Flash 擦除和编程操作返回最新数据。
- 无论操作成功还是失败，都恢复原始缓存状态并重新锁定 Flash。

增强功能：
- 使用 RAII 守卫统一管理 Flash 操作的准备和清理流程，包括独立 ICACHE 功能检测和完成处理。
- 记录调用方要求：串行化 Flash/缓存访问，并允许 HAL tick 持续推进。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Maintain STM32 Flash cache coherency throughout erase and program operations while reliably restoring hardware state on every exit path.

Bug Fixes:
- Ensure STM32 Flash erase and program operations return fresh data by maintaining coherency across standalone ICACHE and SCB instruction/data caches.
- Restore the original cache state and relock Flash on both successful and failed operations.

Enhancements:
- Centralize Flash operation setup and cleanup in an RAII guard, including standalone ICACHE capability detection and completion handling.
- Document the caller requirements for serializing Flash/cache access and allowing the HAL tick to progress.

</details>