### PR TITLE
fix(threadx): preserve LibXR priority ordering

### DIFF
--- a/system/threadx/thread.hpp
+++ b/system/threadx/thread.hpp
@@ -4,7 +4,7 @@
 #include "libxr_time.hpp"
 #include "tx_api.h"
 
-#define LIBXR_PRIORITY_STEP ((TX_MAX_PRIORITIES - 1) / 5)
+#define LIBXR_PRIORITY_STEP ((TX_MAX_PRIORITIES - 1U) / 5U)
 
 namespace LibXR
 {
@@ -16,17 +16,17 @@ class Thread
 {
  public:
   /**
-   * @brief  线程优先级枚举
-   *         Enumeration for thread priorities
+   * @brief 线程优先级枚举（ThreadX 数值越小优先级越高）
+   *         Thread priority levels; ThreadX uses smaller values for higher priority
    */
-  enum class Priority : uint8_t
+  enum class Priority : UINT
   {
-    IDLE = 1,                            ///< 空闲优先级 Idle priority
-    LOW = LIBXR_PRIORITY_STEP * 1,       ///< 低优先级 Low priority
-    MEDIUM = LIBXR_PRIORITY_STEP * 2,    ///< 中等优先级 Medium priority
-    HIGH = LIBXR_PRIORITY_STEP * 3,      ///< 高优先级 High priority
-    REALTIME = LIBXR_PRIORITY_STEP * 4,  ///< 实时优先级 Realtime priority
-    NUMBER = 5                           ///< 优先级数量 Number of priority levels
+    IDLE = LIBXR_PRIORITY_STEP * 4U,    ///< 空闲优先级 Idle priority
+    LOW = LIBXR_PRIORITY_STEP * 3U,     ///< 低优先级 Low priority
+    MEDIUM = LIBXR_PRIORITY_STEP * 2U,  ///< 中等优先级 Medium priority
+    HIGH = LIBXR_PRIORITY_STEP * 1U,    ///< 高优先级 High priority
+    REALTIME = 1U,                      ///< 实时优先级 Realtime priority
+    NUMBER = 5                          ///< 优先级数量 Number of priority levels
   };
 
   /**


### PR DESCRIPTION
ThreadX uses smaller numeric values for higher priority, but LibXR’s five `Thread::Priority` values were passed through in the opposite order. On the C board, releasing IDLE and REALTIME together consistently ran IDLE first.

This changes only `system/threadx/thread.hpp`:

- keep the existing `TX_MAX_PRIORITIES`-derived five-step scale;
- map `REALTIME` to 1, then `HIGH`, `MEDIUM`, `LOW`, and `IDLE` at increasing values;
- use ThreadX `UINT` as the enum underlying type so supported configurations up to 1024 priorities are representable.

For the default `TX_MAX_PRIORITIES=32`, the values are `REALTIME=1`, `HIGH=6`, `MEDIUM=12`, `LOW=18`, `IDLE=24`. `Thread::Create()` still passes the selected value directly to ThreadX, preserving the existing native-priority path and preemption-threshold behavior.

Validation:

- Real STM32F407 C-board ThreadX Debug minimal competition: `REALTIME` native priority 1, `IDLE` native priority 24, actual first completion REALTIME; PASS.
- Target ThreadX/F407 Debug build and link with the current `dev` source: PASS, 74,704-byte Flash image.
- C-board ThreadX delay, SleepUntil, semaphore, mutex, ASync, timer, rollover and UART evidence from the preceding campaign remains unchanged; this PR only addresses the separately identified priority defect.
- The board was restored from the pre-test full Flash backup; pre/post SHA256 `33804e58751acdf6f354d441fc320361816916e5a69ba6b775c30cf795c9205b`, option bytes unchanged, core running without fault.

The priority defect already exists in `master`; this PR fixes it on top of `dev` without changing the previously accepted ThreadX delay/rollover semantics. Hardware fixture sources and logs remain outside the product commit.

## Sourcery 摘要

创建 ThreadX 线程时保留 LibXR 的优先级顺序。

Bug 修复：
- 修正 LibXR 到 ThreadX 的线程优先级映射，确保 REALTIME 线程优先于较低优先级的线程运行。

增强功能：
- 使用与 ThreadX 兼容的优先级类型，并在受支持的配置中保留现有的五级优先级体系。

测试：
- 通过真实的 STM32F407 ThreadX 运行和成功的目标构建，验证修正后的优先级顺序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve LibXR priority ordering when creating ThreadX threads.

Bug Fixes:
- Correct LibXR thread priority mapping for ThreadX so REALTIME threads run ahead of lower-priority threads.

Enhancements:
- Use a ThreadX-compatible priority type and preserve the existing five-level priority scale across supported configurations.

Tests:
- Validate the corrected ordering with a real STM32F407 ThreadX run and successful target build.

</details>