### PR TITLE
fix(esp): correct FreeRTOS stack, RWDT and GPIO ownership

### DIFF
--- a/driver/esp/esp_gpio.hpp
+++ b/driver/esp/esp_gpio.hpp
@@ -148,10 +148,12 @@ class ESP32GPIO : public GPIO
         break;
       case Direction::OUTPUT_PUSH_PULL:
         gpio_hal_input_disable(&hal, gpio_num_);
+        gpio_hal_matrix_out_default(&hal, gpio_num_);
         gpio_hal_output_enable(&hal, gpio_num_);
         break;
       case Direction::OUTPUT_OPEN_DRAIN:
         gpio_hal_input_enable(&hal, gpio_num_);
+        gpio_hal_matrix_out_default(&hal, gpio_num_);
         gpio_hal_output_enable(&hal, gpio_num_);
         gpio_hal_od_enable(&hal, gpio_num_);
         break;

--- a/driver/esp/esp_watchdog.cpp
+++ b/driver/esp/esp_watchdog.cpp
@@ -5,14 +5,15 @@
 #include "esp_private/periph_ctrl.h"
 #include "hal/mwdt_ll.h"
 #include "hal/timer_ll.h"
+#include "soc/rtc.h"
 
 namespace LibXR
 {
 namespace
 {
 
-constexpr uint32_t WDT_TICK_US = 500;
-constexpr uint32_t WDT_TICKS_PER_MS = 1000 / WDT_TICK_US;
+constexpr uint32_t MWDT_TICK_US = 500;
+constexpr uint32_t MWDT_TICKS_PER_MS = 1000 / MWDT_TICK_US;
 
 bool GetMwdtGroupInfo(wdt_inst_t instance, int* group_id, periph_module_t* periph)
 {
@@ -104,7 +105,20 @@ ErrorCode ESP32Watchdog::ApplyConfiguration()
     return ErrorCode::INIT_ERR;
   }
 
-  const uint64_t ticks64 = static_cast<uint64_t>(timeout_ms_) * WDT_TICKS_PER_MS;
+  uint64_t ticks64 = 0U;
+  if (instance_ == WDT_RWDT)
+  {
+    const uint32_t slow_clock_hz = rtc_clk_slow_freq_get_hz();
+    if (slow_clock_hz == 0U)
+    {
+      return ErrorCode::INIT_ERR;
+    }
+    ticks64 = static_cast<uint64_t>(timeout_ms_) * slow_clock_hz / 1000U;
+  }
+  else
+  {
+    ticks64 = static_cast<uint64_t>(timeout_ms_) * MWDT_TICKS_PER_MS;
+  }
   if ((ticks64 == 0) || (ticks64 > UINT32_MAX))
   {
     return ErrorCode::NOT_SUPPORT;

--- a/system/freertos/thread.hpp
+++ b/system/freertos/thread.hpp
@@ -85,11 +85,15 @@ class Thread
 
     auto block = new ThreadBlock(function, arg);
 
-    uint32_t stack_size = stack_depth / 4;
-
-    if (stack_depth % 4 != 0)
+    // LibXR 栈深度使用字节；xTaskCreate() 接收 StackType_t 个数。
+    // LibXR stack depth is in bytes; xTaskCreate() consumes StackType_t units.
+    // ESP-IDF 将 StackType_t 定义为 uint8_t，因此同一换算自然保留字节语义。
+    // ESP-IDF defines StackType_t as uint8_t, so the same conversion preserves byte
+    // units.
+    uint32_t stack_size = static_cast<uint32_t>(stack_depth / sizeof(StackType_t));
+    if ((stack_depth % sizeof(StackType_t)) != 0U)
     {
-      stack_size += 1;
+      stack_size += 1U;
     }
 
     auto ans = xTaskCreate(block->Port, name, stack_size, block,


### PR DESCRIPTION
This PR contains the three scoped fixes already validated against the ESP32-S3 evidence:

1. `system/freertos/thread.hpp` converts LibXR byte stack sizes with `sizeof(StackType_t)` and rounds up. ESP-IDF defines `StackType_t` as one byte, while vanilla FreeRTOS ports retain their native stack-unit size; no ESP-specific branch is needed.
2. `driver/esp/esp_watchdog.cpp` keeps the existing 500-us MWDT conversion and computes RWDT stage-0 ticks from `rtc_clk_slow_freq_get_hz()`. A zero slow-clock result remains an initialization error.
3. `driver/esp/esp_gpio.hpp` clears the GPIO output-matrix route when taking ownership of a pin as push-pull or open-drain output, so a previous LEDC/peripheral route cannot keep driving the pin.

The changes are three separate commits in one draft PR. Product tests, BSPs and test harnesses are not included.

Validation:

- ESP-IDF v5.5.2, ESP32-S3, dual-core Debug full build: PASS; image generated successfully.
- ESP-IDF v5.5.2, ESP32-S3, single-core Release / `LIBXR_SINGLE_CORE`: PASS; image generated successfully.
- Independent read-only review of ESP-IDF Xtensa/RISC-V `StackType_t`, RWDT HAL/LL prescaling and GPIO matrix ownership: no blocking finding.
- Existing S3 hardware evidence recorded the pre-fix defects: stack depth 8192 reached the task API as 2048, RWDT timeout used the MWDT tick conversion, and peripheral output-matrix ownership could override GPIO output. This PR does not claim a new post-fix hardware run.

The S3 USB CDC TX re-entry assertion remains a separate P0 issue and is outside this PR.

## Sourcery 总结

修复 ESP32 FreeRTOS 栈大小、看门狗超时计算以及 GPIO 输出所有权问题。

错误修复：
- 通过将 LibXR 字节大小转换为以 StackType_t 为单位的值并进行舍入，修正跨不同端口的 FreeRTOS 栈深度转换。
- 根据 RTC 低速时钟频率计算 RWDT 超时，同时保留现有的 MWDT 时序转换和初始化验证。
- 防止之前的外设输出路由覆盖 GPIO 推挽或开漏输出所有权。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix ESP32 FreeRTOS stack sizing, watchdog timeout calculations, and GPIO output ownership.

Bug Fixes:
- Correct FreeRTOS stack-depth conversion across ports by expressing LibXR byte sizes in StackType_t units with rounding.
- Calculate RWDT timeouts from the RTC slow-clock frequency while retaining the existing MWDT timing conversion and initialization validation.
- Prevent prior peripheral output routing from overriding GPIO push-pull or open-drain ownership.

</details>