### PR TITLE
fix(stm32): reset I2C controller when changing timing

### DIFF
--- a/driver/st/stm32_i2c.cpp
+++ b/driver/st/stm32_i2c.cpp
@@ -409,17 +409,33 @@ ErrorCode STM32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
 
 ErrorCode STM32I2C::SetConfig(Configuration config)
 {
-  if (HasClockSpeed<decltype(i2c_handle_)>::value)
+  if (i2c_handle_->State != HAL_I2C_STATE_READY)
   {
-    SetClockSpeed<decltype(i2c_handle_)>(i2c_handle_, config);
+    return ErrorCode::BUSY;
   }
-  else
+
+  if (!HasClockSpeed<decltype(i2c_handle_)>::value)
   {
     return ErrorCode::NOT_SUPPORT;
   }
 
+  const auto old_init = i2c_handle_->Init;
+  SetClockSpeed<decltype(i2c_handle_)>(i2c_handle_, config);
+
+  // Reinitialization clears a controller BUSY state left by the previous timing.
+  // 重新初始化会清除旧时序留下的控制器 BUSY 状态。
+  if (HAL_I2C_DeInit(i2c_handle_) != HAL_OK)
+  {
+    i2c_handle_->Init = old_init;
+    return ErrorCode::INIT_ERR;
+  }
   if (HAL_I2C_Init(i2c_handle_) != HAL_OK)
   {
+    // Keep the previous usable configuration when the new one is rejected.
+    // 新配置被 HAL 拒绝时恢复之前可用的配置。
+    (void)HAL_I2C_DeInit(i2c_handle_);
+    i2c_handle_->Init = old_init;
+    (void)HAL_I2C_Init(i2c_handle_);
     return ErrorCode::INIT_ERR;
   }
   return ErrorCode::OK;

--- a/driver/st/stm32_i2c.hpp
+++ b/driver/st/stm32_i2c.hpp
@@ -93,6 +93,14 @@ class STM32I2C : public I2C
     i2c_handle->Init.ClockSpeed = config.clock_speed;
   }
 
+  /**
+   * @brief 重新配置 I2C 时序 / Reconfigure I2C timing
+   * @pre 总线空闲，且调用方已将配置与读写操作串行化。
+   *      The bus must be idle, and the caller must serialize configuration with I2C
+   * transfers.
+   * @return 配置结果；活动事务返回 BUSY / Configuration result; BUSY for an active
+   * transfer.
+   */
   ErrorCode SetConfig(Configuration config) override;
 
   stm32_i2c_id_t id_;


### PR DESCRIPTION
`STM32I2C::SetConfig()` previously changed `ClockSpeed` and called `HAL_I2C_Init()` directly. On the F407 C board, changing 100 kHz to 400 kHz returned `OK`, but the next transaction timed out while the controller stayed `BUSY`; `HAL_I2C_DeInit()` followed by `HAL_I2C_Init()` restored the bus.

This PR keeps the I2C configuration contract explicit: the bus must be idle and the caller must serialize configuration with transfers. An active HAL transaction now returns `BUSY`. For a supported clock-speed HAL, configuration uses `DeInit()` then `Init()` to clear stale controller state. If reinitialization fails, the previous `Init` structure is restored and the old configuration is attempted again; the call still returns `INIT_ERR`. Timing-only HALs such as H5/G0 remain `NOT_SUPPORT` in this API and are unchanged.

Validation:

- F407 C-board Debug firmware build with the real STM32F4 HAL: PASS; `stm32_i2c.cpp` compiled and linked in the complete firmware.
- Existing F407 physical evidence reproduced the failure and showed manual `HAL_I2C_DeInit()` + `HAL_I2C_Init()` recovery on I2C3/IST8310 (100 kHz to 400 kHz).
- The patch is limited to `driver/st/stm32_i2c.cpp` and its `SetConfig()` contract comment in `driver/st/stm32_i2c.hpp`.
- No board was reflashed for this candidate; the board remains restored to its pre-test firmware.

## Sourcery 总结

安全地重新初始化 STM32 I2C 控制器以应用时序变更，同时保护正在进行的传输，并在失败时保留之前的配置。

错误修复：
- 更改时钟时序时重置受支持的 STM32 I2C 控制器，以清除过时的 BUSY 状态并防止后续传输超时。
- 应用新配置失败时，恢复之前可用的 I2C 配置。

增强功能：
- 拒绝在 HAL 事务进行期间更改配置，并记录总线空闲和调用方串行化要求。
- 对不支持可配置时钟速度的 HAL 保持原有的不支持行为。

测试：
- 通过完整的 STM32F4 固件构建以及现有的实体 I2C 故障/恢复验证来确认修复有效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make STM32 I2C timing changes safely reinitialize the controller while protecting active transfers and preserving the previous configuration on failure.

Bug Fixes:
- Reset supported STM32 I2C controllers when changing clock timing to clear stale BUSY state and prevent subsequent transfer timeouts.
- Restore the previous usable I2C configuration when applying the new configuration fails.

Enhancements:
- Reject configuration changes during active HAL transactions and document the idle-bus and caller-serialization requirements.
- Preserve unsupported behavior for HALs without configurable clock-speed support.

Tests:
- Validate the fix with a complete STM32F4 firmware build and existing physical I2C failure/recovery evidence.

</details>