### PR TITLE
fix(mspm0): restore UART, SysTick and peripheral paths

### DIFF
--- a/driver/mspm0/CMakeLists.txt
+++ b/driver/mspm0/CMakeLists.txt
@@ -3,6 +3,8 @@ set(_xr_mspm0_driver_sources
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_gpio.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_pwm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_timebase.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mspm0_spi.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mspm0_i2c.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_uart.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_atomic_shim.c
 )

--- a/driver/mspm0/mspm0_i2c.cpp
+++ b/driver/mspm0/mspm0_i2c.cpp
@@ -19,8 +19,23 @@ constexpr uint32_t MSPM0_I2C_MEMREAD_FALLBACK_ATTEMPTS = 3;
 
 constexpr uint16_t MSPM0_I2C_MAX_TRANSFER_SIZE = 0x0FFF;
 
-#if !defined(DMA_CH_TX_CHAN_ID) || !defined(DMA_CH_RX_CHAN_ID)
-#error "MSPM0I2C requires SysConfig DMA channels (DMA_CH_TX_CHAN_ID/DMA_CH_RX_CHAN_ID)."
+// 两个 DMA 绑定都存在时才启用 DMA；未绑定时保留轮询 I2C。
+// Enable DMA only when both channels are bound; otherwise retain polling I2C.
+#if defined(DMA_CH_TX_CHAN_ID) != defined(DMA_CH_RX_CHAN_ID)
+#error "MSPM0I2C requires both TX and RX DMA bindings, or neither."
+#endif
+#if defined(DMA_CH_TX_CHAN_ID) && defined(DMA_CH_RX_CHAN_ID)
+constexpr bool I2C_DMA_CONFIGURED = true;
+constexpr uint8_t I2C_DMA_TX_CHANNEL = DMA_CH_TX_CHAN_ID;
+constexpr uint8_t I2C_DMA_RX_CHANNEL = DMA_CH_RX_CHAN_ID;
+static_assert(DMA_CH_TX_CHAN_ID < DMA_SYS_N_DMA_CHANNEL);
+static_assert(DMA_CH_RX_CHAN_ID < DMA_SYS_N_DMA_CHANNEL);
+static_assert(DMA_CH_TX_CHAN_ID != DMA_CH_RX_CHAN_ID);
+#else
+constexpr bool I2C_DMA_CONFIGURED = false;
+// Unused placeholders: no DMA register may be accessed in polling-only mode.
+constexpr uint8_t I2C_DMA_TX_CHANNEL = 0U;
+constexpr uint8_t I2C_DMA_RX_CHANNEL = 0U;
 #endif
 
 constexpr DL_DMA_Config MSPM0_I2C_DMA_TX_CONFIG_BASE = {
@@ -220,6 +235,7 @@ ErrorCode MSPM0I2C::SetConfig(Configuration config)
   uint8_t dma_tx_trigger = 0U;
   uint8_t dma_rx_trigger = 0U;
   const bool USE_DMA =
+      I2C_DMA_CONFIGURED &&
       mspm0_i2c_resolve_dma_triggers(res_.instance, dma_tx_trigger, dma_rx_trigger);
   dma_enabled_ = USE_DMA;
 
@@ -238,10 +254,13 @@ ErrorCode MSPM0I2C::SetConfig(Configuration config)
                          DL_I2C_DMA_INTERRUPT_CONTROLLER_TXFIFO_TRIGGER);
   DL_I2C_disableDMAEvent(res_.instance, DL_I2C_EVENT_ROUTE_2,
                          DL_I2C_DMA_INTERRUPT_CONTROLLER_RXFIFO_TRIGGER);
-  DL_DMA_disableChannel(DMA, DMA_CH_TX_CHAN_ID);
-  DL_DMA_disableChannel(DMA, DMA_CH_RX_CHAN_ID);
-  DL_DMA_clearInterruptStatus(DMA, mspm0_i2c_dma_channel_mask(DMA_CH_TX_CHAN_ID) |
-                                       mspm0_i2c_dma_channel_mask(DMA_CH_RX_CHAN_ID));
+  if (USE_DMA)
+  {
+    DL_DMA_disableChannel(DMA, I2C_DMA_TX_CHANNEL);
+    DL_DMA_disableChannel(DMA, I2C_DMA_RX_CHANNEL);
+    DL_DMA_clearInterruptStatus(DMA, mspm0_i2c_dma_channel_mask(I2C_DMA_TX_CHANNEL) |
+                                         mspm0_i2c_dma_channel_mask(I2C_DMA_RX_CHANNEL));
+  }
 
   if (USE_DMA)
   {
@@ -254,8 +273,8 @@ ErrorCode MSPM0I2C::SetConfig(Configuration config)
                           DL_I2C_DMA_INTERRUPT_CONTROLLER_TXFIFO_TRIGGER);
     DL_I2C_enableDMAEvent(res_.instance, DL_I2C_EVENT_ROUTE_2,
                           DL_I2C_DMA_INTERRUPT_CONTROLLER_RXFIFO_TRIGGER);
-    DL_DMA_initChannel(DMA, DMA_CH_TX_CHAN_ID, &dma_tx_config);
-    DL_DMA_initChannel(DMA, DMA_CH_RX_CHAN_ID, &dma_rx_config);
+    DL_DMA_initChannel(DMA, I2C_DMA_TX_CHANNEL, &dma_tx_config);
+    DL_DMA_initChannel(DMA, I2C_DMA_RX_CHANNEL, &dma_rx_config);
   }
 
   DL_I2C_enableController(res_.instance);
@@ -430,8 +449,8 @@ ErrorCode MSPM0I2C::DmaWrite7(uint16_t addr7, ConstRawData write_data)
 
   auto stop_dma = [&]()
   {
-    const uint32_t DMA_TX_MASK = mspm0_i2c_dma_channel_mask(DMA_CH_TX_CHAN_ID);
-    DL_DMA_disableChannel(DMA, DMA_CH_TX_CHAN_ID);
+    const uint32_t DMA_TX_MASK = mspm0_i2c_dma_channel_mask(I2C_DMA_TX_CHANNEL);
+    DL_DMA_disableChannel(DMA, I2C_DMA_TX_CHANNEL);
     DL_DMA_clearInterruptStatus(DMA, DMA_TX_MASK);
   };
 
@@ -446,23 +465,23 @@ ErrorCode MSPM0I2C::DmaWrite7(uint16_t addr7, ConstRawData write_data)
     DL_I2C_disableInterrupt(res_.instance, 0xFFFFFFFFU);
     DL_I2C_clearInterruptStatus(res_.instance, 0xFFFFFFFFU);
 
-    const uint32_t DMA_TX_MASK = mspm0_i2c_dma_channel_mask(DMA_CH_TX_CHAN_ID);
-    DL_DMA_disableChannel(DMA, DMA_CH_TX_CHAN_ID);
+    const uint32_t DMA_TX_MASK = mspm0_i2c_dma_channel_mask(I2C_DMA_TX_CHANNEL);
+    DL_DMA_disableChannel(DMA, I2C_DMA_TX_CHANNEL);
     DL_DMA_clearInterruptStatus(DMA, DMA_TX_MASK);
     DL_DMA_setSrcAddr(
-        DMA, DMA_CH_TX_CHAN_ID,
+        DMA, I2C_DMA_TX_CHANNEL,
         static_cast<uint32_t>(reinterpret_cast<uintptr_t>(write_data.addr_)));
-    DL_DMA_setDestAddr(DMA, DMA_CH_TX_CHAN_ID,
+    DL_DMA_setDestAddr(DMA, I2C_DMA_TX_CHANNEL,
                        static_cast<uint32_t>(
                            reinterpret_cast<uintptr_t>(&res_.instance->MASTER.MTXDATA)));
-    DL_DMA_setTransferSize(DMA, DMA_CH_TX_CHAN_ID,
+    DL_DMA_setTransferSize(DMA, I2C_DMA_TX_CHANNEL,
                            static_cast<uint16_t>(write_data.size_));
-    DL_DMA_enableChannel(DMA, DMA_CH_TX_CHAN_ID);
+    DL_DMA_enableChannel(DMA, I2C_DMA_TX_CHANNEL);
 
     DL_I2C_startControllerTransfer(res_.instance, addr7, DL_I2C_CONTROLLER_DIRECTION_TX,
                                    static_cast<uint16_t>(write_data.size_));
 
-    ans = WaitDmaTransferDone(DMA_CH_TX_CHAN_ID);
+    ans = WaitDmaTransferDone(I2C_DMA_TX_CHANNEL);
     if (ans != ErrorCode::OK)
     {
       stop_dma();
@@ -514,8 +533,8 @@ ErrorCode MSPM0I2C::DmaRead7(uint16_t addr7, RawData read_data)
 
   auto stop_dma = [&]()
   {
-    const uint32_t DMA_RX_MASK = mspm0_i2c_dma_channel_mask(DMA_CH_RX_CHAN_ID);
-    DL_DMA_disableChannel(DMA, DMA_CH_RX_CHAN_ID);
+    const uint32_t DMA_RX_MASK = mspm0_i2c_dma_channel_mask(I2C_DMA_RX_CHANNEL);
+    DL_DMA_disableChannel(DMA, I2C_DMA_RX_CHANNEL);
     DL_DMA_clearInterruptStatus(DMA, DMA_RX_MASK);
   };
 
@@ -530,23 +549,23 @@ ErrorCode MSPM0I2C::DmaRead7(uint16_t addr7, RawData read_data)
     DL_I2C_disableInterrupt(res_.instance, 0xFFFFFFFFU);
     DL_I2C_clearInterruptStatus(res_.instance, 0xFFFFFFFFU);
 
-    const uint32_t DMA_RX_MASK = mspm0_i2c_dma_channel_mask(DMA_CH_RX_CHAN_ID);
-    DL_DMA_disableChannel(DMA, DMA_CH_RX_CHAN_ID);
+    const uint32_t DMA_RX_MASK = mspm0_i2c_dma_channel_mask(I2C_DMA_RX_CHANNEL);
+    DL_DMA_disableChannel(DMA, I2C_DMA_RX_CHANNEL);
     DL_DMA_clearInterruptStatus(DMA, DMA_RX_MASK);
-    DL_DMA_setSrcAddr(DMA, DMA_CH_RX_CHAN_ID,
+    DL_DMA_setSrcAddr(DMA, I2C_DMA_RX_CHANNEL,
                       static_cast<uint32_t>(
                           reinterpret_cast<uintptr_t>(&res_.instance->MASTER.MRXDATA)));
     DL_DMA_setDestAddr(
-        DMA, DMA_CH_RX_CHAN_ID,
+        DMA, I2C_DMA_RX_CHANNEL,
         static_cast<uint32_t>(reinterpret_cast<uintptr_t>(read_data.addr_)));
-    DL_DMA_setTransferSize(DMA, DMA_CH_RX_CHAN_ID,
+    DL_DMA_setTransferSize(DMA, I2C_DMA_RX_CHANNEL,
                            static_cast<uint16_t>(read_data.size_));
-    DL_DMA_enableChannel(DMA, DMA_CH_RX_CHAN_ID);
+    DL_DMA_enableChannel(DMA, I2C_DMA_RX_CHANNEL);
 
     DL_I2C_startControllerTransfer(res_.instance, addr7, DL_I2C_CONTROLLER_DIRECTION_RX,
                                    static_cast<uint16_t>(read_data.size_));
 
-    ans = WaitDmaTransferDone(DMA_CH_RX_CHAN_ID);
+    ans = WaitDmaTransferDone(I2C_DMA_RX_CHANNEL);
     if (ans != ErrorCode::OK)
     {
       stop_dma();

--- a/driver/mspm0/mspm0_timebase.cpp
+++ b/driver/mspm0/mspm0_timebase.cpp
@@ -8,41 +8,57 @@ MSPM0Timebase::MSPM0Timebase()
   SetReady();
 }
 
-MicrosecondTimestamp Timebase::GetMicroseconds()
+namespace
 {
+struct SysTickSnapshot
+{
+  uint32_t milliseconds;
+  uint32_t period;
+  uint32_t value;
+};
+
+// 只在快照期间屏蔽中断；不读取会清除 COUNTFLAG 的 CTRL。
+// Mask IRQs only for the snapshot; do not read CTRL and consume COUNTFLAG.
+// BSP 必须在下一次回绕前处理 SysTick；一个 pending 位不能记录多次回绕。
+// The BSP must service SysTick before another wrap; one pending bit is not a counter.
+SysTickSnapshot ReadSysTickSnapshot()
+{
+  const uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+
+  SysTickSnapshot snapshot{MSPM0Timebase::sys_tick_ms, DL_SYSTICK_getPeriod(), 0U};
+  uint32_t pending_before;
+  uint32_t pending_after;
   do
   {
-    uint32_t tick_old = MSPM0Timebase::sys_tick_ms;
-    uint32_t val_old = DL_SYSTICK_getValue();
-    uint32_t tick_new = MSPM0Timebase::sys_tick_ms;
-    uint32_t val_new = DL_SYSTICK_getValue();
+    pending_before = SCB->ICSR & SCB_ICSR_PENDSTSET_Msk;
+    snapshot.value = DL_SYSTICK_getValue();
+    pending_after = SCB->ICSR & SCB_ICSR_PENDSTSET_Msk;
+  } while (pending_before != pending_after);
 
-    auto tick_diff = tick_new - tick_old;
+  if (pending_after != 0U)
+  {
+    ++snapshot.milliseconds;
+  }
+  __set_PRIMASK(primask);
+  return snapshot;
+}
+}  // namespace
 
-    uint32_t cycles_per_ms = DL_SYSTICK_getPeriod();
-
-    switch (tick_diff)
-    {
-      case 0:
-        return MicrosecondTimestamp(
-            static_cast<uint64_t>(tick_new) * 1000 +
-            static_cast<uint64_t>(DL_SYSTICK_getPeriod() - val_old) * 1000 /
-                cycles_per_ms);
-      case 1:
-        /* 中断发生在两次读取之间 / Interrupt happened between two reads */
-        return MicrosecondTimestamp(
-            static_cast<uint64_t>(tick_new) * 1000 +
-            static_cast<uint64_t>(DL_SYSTICK_getPeriod() - val_new) * 1000 /
-                cycles_per_ms);
-      default:
-        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more
-         * than 1ms, an error case */
-        continue;
-    }
-  } while (true);
+MicrosecondTimestamp Timebase::GetMicroseconds()
+{
+  const auto snapshot = ReadSysTickSnapshot();
+  // VAL == 0 是回绕/初次装载边界，不再叠加一个完整周期。
+  // VAL == 0 is the wrap/initial-load boundary, not an additional full period.
+  const uint32_t elapsed = snapshot.value == 0U ? 0U : snapshot.period - snapshot.value;
+  return MicrosecondTimestamp(static_cast<uint64_t>(snapshot.milliseconds) * 1000ULL +
+                              static_cast<uint64_t>(elapsed) * 1000ULL / snapshot.period);
 }
 
-MillisecondTimestamp Timebase::GetMilliseconds() { return MSPM0Timebase::sys_tick_ms; }
+MillisecondTimestamp Timebase::GetMilliseconds()
+{
+  return ReadSysTickSnapshot().milliseconds;
+}
 void MSPM0Timebase::OnSysTickInterrupt() { MSPM0Timebase::sys_tick_ms++; }
 void MSPM0Timebase::Sync(uint32_t ticks) { MSPM0Timebase::sys_tick_ms = ticks; }
 

--- a/driver/mspm0/mspm0_uart.cpp
+++ b/driver/mspm0/mspm0_uart.cpp
@@ -626,7 +626,13 @@ void MSPM0UART::ConfigureRxDma()
 
 void MSPM0UART::ApplyConfig(UART::Configuration config)
 {
-  DL_UART_changeConfig(res_.instance);
+  // 配置路径已等待空闲；保留 FEN，避免反复切换 FIFO 暴露旧的 RX 内容。
+  // The configuration path has reached idle. Keep FEN unchanged: toggling FIFO
+  // mode on G3507 can expose previously consumed RX bytes.
+  DL_UART_disable(res_.instance);
+  while (DL_UART_isBusy(res_.instance))
+  {
+  }
 
   DL_UART_WORD_LENGTH word_length = DL_UART_WORD_LENGTH_8_BITS;
   switch (config.data_bits)


### PR DESCRIPTION
This PR contains the four MSPM0 fixes validated by the G3507 hardware campaign. Each change is one commit:

- `b25b7bb` preserves the UART FIFO state across an idle reconfiguration. Repeated FIFO disable/enable could make consumed RX bytes visible again; the new path disables the UART, waits for idle, changes the configuration, and leaves FIFO enabled.
- `2289398` reads a consistent SysTick snapshot with interrupts masked, accounts for a pending wrap, and restores PRIMASK. This removes the microsecond timestamp regression when the counter has wrapped but the handler has not run.
- `6617c1a` makes I2C DMA conditional on both TX and RX DMA bindings. A binding-free MSPM0 I2C build now keeps the polling path; a one-sided binding is rejected at compile time.
- `00b30a1` adds the MSPM0 SPI and I2C implementations to the driver source list so complete MSPM0 builds do not silently omit them.

The PR contains only the four product source changes. Board fixtures, SysConfig files, probes, and evidence remain outside the repository.

Validation:

- MSPM0G3507 real hardware, Debug and Release: Main and Extend UART reconfiguration, DMA/backpressure/timeout/error recovery, GPIO, PWM, SPI, ADC, and I2C device tests passed. I2C used both DMA and polling configurations and completed 100 kHz -> 400 kHz -> 100 kHz cycles for three devices.
- SysTick pending-window and 32-bit wrap checks passed in Debug and Release, including 100 pending-window repetitions and interrupt-state restoration checks.
- The candidate source was compiled and linked with the TI MSPM0 SDK and real G3507 resources; the evidence report records that the full CMake integration build was not run in that campaign.
- The original 128 KiB main Flash and 1 KiB NONMAIN region were restored byte-for-byte. The board is not part of this PR's CI path.

One known performance boundary remains outside this PR: Debug dual-UART at 115200 baud does not meet the real-overlap criterion, although the data is correct. The I2C open-drain issue from the campaign was a BSP configuration error and is not changed here.

## Sourcery 摘要

恢复可靠的 MSPM0 UART、SysTick、I2C、SPI 和外设构建行为，并已在 G3507 硬件上完成验证。

Bug 修复：
- 保留 MSPM0 UART 接收 FIFO 在空闲重新配置期间的状态，防止之前已读取的字节再次出现。
- 修复待处理 SysTick 中断和计数器回绕期间的 MSPM0 微秒和毫秒时间戳，同时保留中断状态。
- 当 DMA 未配置时恢复仅轮询的 MSPM0 I2C 操作，并拒绝不完整的 DMA 绑定。
- 将 MSPM0 SPI 和 I2C 驱动包含在完整驱动构建中。

构建：
- 将 MSPM0 SPI 和 I2C 实现添加到驱动源文件列表中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore reliable MSPM0 UART, SysTick, I2C, SPI, and peripheral build behavior validated on G3507 hardware.

Bug Fixes:
- Preserve MSPM0 UART receive FIFO state during idle reconfiguration to prevent previously consumed bytes from reappearing.
- Fix MSPM0 microsecond and millisecond timestamps around pending SysTick interrupts and counter wrap, while preserving interrupt state.
- Restore polling-only MSPM0 I2C operation when DMA is unconfigured and reject incomplete DMA bindings.
- Include the MSPM0 SPI and I2C drivers in complete driver builds.

Build:
- Add MSPM0 SPI and I2C implementations to the driver source list.

</details>