### PR TITLE
fix(stm32): reset I2C peripheral when changing timing

### DIFF
--- a/driver/st/stm32_i2c.cpp
+++ b/driver/st/stm32_i2c.cpp
@@ -151,6 +151,43 @@ static inline ErrorCode WaitBlockResultAndRecoverTimeout(STM32I2C* i2c, uint32_t
   return ans;
 }
 
+static bool ResetI2CPeripheral(I2C_TypeDef* instance)
+{
+#if defined(I2C1) && defined(__HAL_RCC_I2C1_FORCE_RESET) && \
+    defined(__HAL_RCC_I2C1_RELEASE_RESET)
+  if (instance == I2C1)
+  {
+    __HAL_RCC_I2C1_FORCE_RESET();
+    __NOP();
+    __HAL_RCC_I2C1_RELEASE_RESET();
+    return true;
+  }
+#endif
+
+#if defined(I2C2) && defined(__HAL_RCC_I2C2_FORCE_RESET) && \
+    defined(__HAL_RCC_I2C2_RELEASE_RESET)
+  if (instance == I2C2)
+  {
+    __HAL_RCC_I2C2_FORCE_RESET();
+    __NOP();
+    __HAL_RCC_I2C2_RELEASE_RESET();
+    return true;
+  }
+#endif
+
+#if defined(I2C3) && defined(__HAL_RCC_I2C3_FORCE_RESET) && \
+    defined(__HAL_RCC_I2C3_RELEASE_RESET)
+  if (instance == I2C3)
+  {
+    __HAL_RCC_I2C3_FORCE_RESET();
+    __NOP();
+    __HAL_RCC_I2C3_RELEASE_RESET();
+    return true;
+  }
+#endif
+  return false;
+}
+
 }  // namespace
 
 STM32I2C::STM32I2C(I2C_HandleTypeDef* hi2c, RawData dma_buff,
@@ -409,17 +446,29 @@ ErrorCode STM32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
 
 ErrorCode STM32I2C::SetConfig(Configuration config)
 {
-  if (HasClockSpeed<decltype(i2c_handle_)>::value)
-  {
-    SetClockSpeed<decltype(i2c_handle_)>(i2c_handle_, config);
-  }
-  else
+  if (!HasClockSpeed<decltype(i2c_handle_)>::value)
   {
     return ErrorCode::NOT_SUPPORT;
   }
+  if (i2c_handle_->State != HAL_I2C_STATE_READY)
+  {
+    return ErrorCode::BUSY;
+  }
 
+  const auto old_init = i2c_handle_->Init;
+  SetClockSpeed<decltype(i2c_handle_)>(i2c_handle_, config);
+  if (!ResetI2CPeripheral(i2c_handle_->Instance))
+  {
+    i2c_handle_->Init = old_init;
+    return ErrorCode::NOT_SUPPORT;
+  }
   if (HAL_I2C_Init(i2c_handle_) != HAL_OK)
   {
+    i2c_handle_->Init = old_init;
+    if (ResetI2CPeripheral(i2c_handle_->Instance))
+    {
+      (void)HAL_I2C_Init(i2c_handle_);
+    }
     return ErrorCode::INIT_ERR;
   }
   return ErrorCode::OK;


### PR DESCRIPTION
PR #302 is superseded. HAL_I2C_DeInit() tears down GPIO/NVIC/MSP and is not suitable for a live driver configuration change. This PR checks that the HAL handle is idle, updates supported ClockSpeed configurations, resets only the matching I2C peripheral through the RCC force/release reset macros, and then calls HAL_I2C_Init(). Unsupported Timing-based HALs remain NOT_SUPPORT. On Init failure the old configuration is restored and retried after a peripheral-only reset. F407 real-HAL complete Debug firmware compilation passed. The C-board IST8310 evidence reproduced 100 kHz to 400 kHz BUSY locking and confirmed the peripheral-reset sequence recovers the controller; the final candidate evidence reports 500 cycles, active-DMA BUSY rejection, and subsequent WHO_AM_I communication passing. No board was reflashed for this candidate; the board remains restored. One commit, one product source file; no test/BSP files included.

## Sourcery 摘要

通过仅重置外设并从初始化失败中恢复，安全地重新配置 STM32 I2C 时钟速度。

错误修复：
- 更改受支持的时钟速度配置时，重置选定的 STM32 I2C 外设，以在不拆除正在运行的驱动程序的情况下恢复外设状态。
- 在 I2C HAL 句柄处于活动状态时拒绝配置更改，并在重新初始化失败时恢复之前的配置。

增强功能：
- 在仅重置外设后重试初始化时，保留不支持基于 ClockSpeed 配置的 HAL 的原有行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过仅重置外设并从初始化失败中恢复，安全地重新配置 STM32 I2C 时钟速度。

错误修复：
- 更改受支持的时钟速度配置时，仅重置选定的 STM32 I2C 外设，以恢复控制器，而无需拆除正在运行的驱动程序。
- 当 I2C HAL 句柄处于活动状态时拒绝配置更改，并在重新初始化失败时恢复之前的配置。

增强功能：
- 对不支持基于 ClockSpeed 配置的 HAL 实现保留 NOT_SUPPORT 行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

更改受支持的时钟速度配置时，安全地重置并重新初始化 STM32 I2C 外设。

错误修复：
- 通过在重新初始化前仅重置选定的外设，安全地重新配置受支持的 STM32 I2C 时钟速度。
- 当 I2C HAL 句柄处于活动状态时拒绝配置更改，并在重新初始化失败时恢复之前的配置。

增强功能：
- 对不支持基于 ClockSpeed 配置的 HAL 实现保留 NOT_SUPPORT 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Safely reset and reinitialize STM32 I2C peripherals when changing supported clock-speed configurations.

Bug Fixes:
- Safely reconfigure supported STM32 I2C clock speeds by resetting only the selected peripheral before reinitialization.
- Reject configuration changes while the I2C HAL handle is active and restore the previous configuration when reinitialization fails.

Enhancements:
- Preserve NOT_SUPPORT behavior for HAL implementations without ClockSpeed-based configuration.

</details>

</details>

</details>