### PR TITLE
fix(ch32): install CAN1 handlers on shared USB IRQs

### DIFF
--- a/driver/ch/ch32_can.cpp
+++ b/driver/ch/ch32_can.cpp
@@ -6,7 +6,7 @@ using namespace LibXR;
 
 CH32CAN* CH32CAN::map[CH32_CAN_NUMBER] = {nullptr};
 
-#if defined(CAN1) && !defined(CAN2)
+#if defined(CAN1) && defined(RCC_APB1Periph_USB)
 static void can1_rx0_thunk()
 {
   if (auto* can = LibXR::CH32CAN::map[CH32_CAN1])
@@ -205,12 +205,15 @@ ErrorCode CH32CAN::Init()
   // Enable NVIC for this CAN instance.
   ch32_can_enable_nvic(id_, fifo_);
 
-  if constexpr (LibXR::CH32UsbCanShared::usb_can_share_enabled())
+  if constexpr (LibXR::CH32UsbCanShared::usb_can_irq_share_enabled())
   {
-#if defined(CAN1) && !defined(CAN2)
-    LibXR::CH32UsbCanShared::register_can1_rx0(&can1_rx0_thunk);
-    LibXR::CH32UsbCanShared::register_can1_tx(&can1_tx_thunk);
-    LibXR::CH32UsbCanShared::can1_inited.store(true, std::memory_order_release);
+#if defined(CAN1) && defined(RCC_APB1Periph_USB)
+    if (id_ == CH32_CAN1)
+    {
+      LibXR::CH32UsbCanShared::register_can1_rx0(&can1_rx0_thunk);
+      LibXR::CH32UsbCanShared::register_can1_tx(&can1_tx_thunk);
+      LibXR::CH32UsbCanShared::can1_inited.store(true, std::memory_order_release);
+    }
 #endif
   }
 

--- a/driver/ch/ch32_usbcan_shared.cpp
+++ b/driver/ch/ch32_usbcan_shared.cpp
@@ -1,6 +1,6 @@
 #include "ch32_usbcan_shared.hpp"
 
-#if defined(RCC_APB1Periph_USB) && defined(CAN1) && !defined(CAN2)
+#if defined(RCC_APB1Periph_USB) && defined(CAN1)
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void

--- a/driver/ch/ch32_usbcan_shared.hpp
+++ b/driver/ch/ch32_usbcan_shared.hpp
@@ -39,8 +39,14 @@ inline constexpr bool K_HAS_CAN2 = false;
 #endif
 
 inline constexpr bool K_SINGLE_CAN1 = K_HAS_CAN1 && !K_HAS_CAN2;
+// CAN1 uses the USB-named IRQ vectors even on dual-CAN devices.
+// CAN1 在双 CAN 器件上仍使用 USB 命名的共享中断向量。
+inline constexpr bool K_USB_CAN_IRQ_SHARE = K_HAS_USB_DEV_FS && K_HAS_CAN1;
+// PMA/resource sharing is limited to the original single-CAN topology.
+// PMA/资源共享仍只适用于原来的单 CAN 拓扑。
 inline constexpr bool K_USB_CAN_SHARE = K_HAS_USB_DEV_FS && K_SINGLE_CAN1;
 
+inline constexpr bool usb_can_irq_share_enabled() { return K_USB_CAN_IRQ_SHARE; }
 inline constexpr bool usb_can_share_enabled() { return K_USB_CAN_SHARE; }
 
 inline uint16_t usb_pma_limit_bytes()
@@ -65,7 +71,7 @@ inline void register_usb_irq(IrqFn fn)
 
 inline void register_can1_rx0(IrqFn fn)
 {
-  if constexpr (K_USB_CAN_SHARE)
+  if constexpr (K_USB_CAN_IRQ_SHARE)
   {
     can1_rx0_cb.store(fn, std::memory_order_release);
   }
@@ -77,7 +83,7 @@ inline void register_can1_rx0(IrqFn fn)
 
 inline void register_can1_tx(IrqFn fn)
 {
-  if constexpr (K_USB_CAN_SHARE)
+  if constexpr (K_USB_CAN_IRQ_SHARE)
   {
     can1_tx_cb.store(fn, std::memory_order_release);
   }
@@ -89,7 +95,7 @@ inline void register_can1_tx(IrqFn fn)
 
 inline bool can1_active()
 {
-  if constexpr (!K_USB_CAN_SHARE)
+  if constexpr (!K_USB_CAN_IRQ_SHARE)
   {
     return false;
   }


### PR DESCRIPTION
CH32V307 has CAN1 and CAN2, but CAN1 TX/RX0 still use the USB-named shared IRQ vectors. The previous condition required CAN1 without CAN2, so the CAN1 shared handlers were omitted on dual-CAN V307 devices even though their NVIC lines were enabled; CAN1 loopback then produced no callbacks.\n\nThis one-commit PR separates the IRQ topology flag from the existing USB/CAN PMA resource-sharing flag. CAN1/USB shared IRQ handlers and CAN1 callback registration now apply whenever the USB peripheral and CAN1 exist, including dual-CAN devices. The PMA/resource policy remains restricted to the original single-CAN topology.\n\nValidation: CH32V307 Debug and Release hardware evidence reproduced the missing CAN1 callbacks and passed after an equivalent ISR shim: CAN1 internal loopback 18/18, CAN2 18/18, error-state counters clear. The same campaign passed GPIO, EXTI, PWM, UART7, SPI3, I2C2 and timebase checks. Source candidate patch apply-check passed; formatting and diff checks pass. The full target build/CI is left to this PR. No board firmware or BSP files are included.

## Sourcery 总结

在保留现有单 CAN 资源共享策略的同时，恢复 USB 共享向量上的 CAN1 中断处理。

错误修复：
- 为双 CAN CH32V307 设备恢复 USB 共享 IRQ 上的 CAN1 回调。
- 确保 CAN1 IRQ 注册和分发覆盖所有同时具备 USB 和 CAN1 外设的设备。

增强功能：
- 将 USB/CAN IRQ 拓扑检测与单 CAN PMA 及资源共享策略分离。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在保留现有单 CAN 资源共享行为的同时，恢复 USB 共享 IRQ 上的 CAN1 回调。

错误修复：
- 为双 CAN CH32V307 设备恢复 USB 共享 IRQ 向量上的 CAN1 中断处理和回调。

增强功能：
- 将共享 IRQ 拓扑检测与单 CAN PMA 及资源共享策略分离。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore CAN1 callbacks on USB-shared IRQs while preserving the existing single-CAN resource-sharing behavior.

Bug Fixes:
- Restore CAN1 interrupt handling and callbacks on USB-shared IRQ vectors for dual-CAN CH32V307 devices.

Enhancements:
- Separate shared IRQ topology detection from the single-CAN PMA and resource-sharing policy.

</details>

</details>