### PR TITLE
fix(ch32): map V203/V208 UART4 DMA to DMA1

### DIFF
--- a/.github/workflows/ch32.yml
+++ b/.github/workflows/ch32.yml
@@ -1,0 +1,33 @@
+name: CH32 contracts
+
+on:
+  push:
+    branches: ["master", "dev"]
+  pull_request:
+
+jobs:
+  uart-mapping:
+    name: UART DMA family matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: openwch/ch32v20x
+          ref: 77eea7caa1b802268857486af5fafa20f3844dfb
+          path: .sdk/ch32v20x
+          sparse-checkout: |
+            EVT/EXAM/SRC
+            EVT/EXAM/USART/USART_DMA/User
+      - uses: actions/checkout@v4
+        with:
+          repository: openwch/ch32v307
+          ref: 080af2e52055334eaa6af0f7ad7df527b4ef5a66
+          path: .sdk/ch32v307
+          sparse-checkout: |
+            EVT/EXAM/SRC
+            EVT/EXAM/USART/USART_DMA/User
+      - name: Check all UART table entries and V20x DMA2-symbol isolation
+        run: >-
+          python3 tools/check_ch32_uart_mapping.py --repo .
+          --v20-sdk .sdk/ch32v20x --v30-sdk .sdk/ch32v307

--- a/driver/ch/ch32_uart_def.hpp
+++ b/driver/ch/ch32_uart_def.hpp
@@ -252,10 +252,11 @@ static constexpr uint32_t CH32_UART_TX_DMA_IT_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_IT_TC5)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_IT_TC5)
     DMA2_IT_TC5,
 #else
-    DMA1_IT_TC1
+    DMA1_IT_TC1,
 #endif
 #endif
 #if defined(UART5)
@@ -307,10 +308,11 @@ static constexpr uint32_t CH32_UART_RX_DMA_IT_TC_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_IT_TC3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_IT_TC3)
     DMA2_IT_TC3,
 #else
-    DMA1_IT_TC8
+    DMA1_IT_TC8,
 #endif
 #endif
 #if defined(UART5)
@@ -362,10 +364,11 @@ static constexpr uint32_t CH32_UART_RX_DMA_IT_HT_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_IT_HT3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_IT_HT3)
     DMA2_IT_HT3,
 #else
-    DMA1_IT_HT8
+    DMA1_IT_HT8,
 #endif
 #endif
 #if defined(UART5)
@@ -417,10 +420,11 @@ static DMA_Channel_TypeDef* const CH32_UART_TX_DMA_CHANNEL_MAP[] = {
     NULL,
 #endif
 #if defined(UART4)
-#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_Channel5)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_Channel5)
     DMA2_Channel5,
 #else
-    DMA1_Channel1
+    DMA1_Channel1,
 #endif
 #endif
 #if defined(UART5)
@@ -472,10 +476,11 @@ static DMA_Channel_TypeDef* const CH32_UART_RX_DMA_CHANNEL_MAP[] = {
     NULL,
 #endif
 #if defined(UART4)
-#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_Channel3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_Channel3)
     DMA2_Channel3,
 #else
-    DMA1_Channel8
+    DMA1_Channel8,
 #endif
 #endif
 #if defined(UART5)

--- a/driver/ch/ch32_uart_def.hpp
+++ b/driver/ch/ch32_uart_def.hpp
@@ -197,7 +197,11 @@ static constexpr uint32_t CH32_UART_RCC_PERIPH_MAP_DMA[] = {
     RCC_AHBPeriph_DMA2,
 #endif
 #if defined(UART4)
+#if defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+    RCC_AHBPeriph_DMA1,
+#else
     RCC_AHBPeriph_DMA2,
+#endif
 #endif
 #if defined(UART5)
     RCC_AHBPeriph_DMA2,
@@ -248,7 +252,7 @@ static constexpr uint32_t CH32_UART_TX_DMA_IT_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if defined(DMA2_IT_TC5)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_IT_TC5)
     DMA2_IT_TC5,
 #else
     DMA1_IT_TC1
@@ -303,7 +307,7 @@ static constexpr uint32_t CH32_UART_RX_DMA_IT_TC_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if defined(DMA2_IT_TC3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_IT_TC3)
     DMA2_IT_TC3,
 #else
     DMA1_IT_TC8
@@ -358,7 +362,7 @@ static constexpr uint32_t CH32_UART_RX_DMA_IT_HT_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if defined(DMA2_IT_HT3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_IT_HT3)
     DMA2_IT_HT3,
 #else
     DMA1_IT_HT8
@@ -413,7 +417,7 @@ static DMA_Channel_TypeDef* const CH32_UART_TX_DMA_CHANNEL_MAP[] = {
     NULL,
 #endif
 #if defined(UART4)
-#if defined(DMA2_Channel5)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_Channel5)
     DMA2_Channel5,
 #else
     DMA1_Channel1
@@ -468,7 +472,7 @@ static DMA_Channel_TypeDef* const CH32_UART_RX_DMA_CHANNEL_MAP[] = {
     NULL,
 #endif
 #if defined(UART4)
-#if defined(DMA2_Channel3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && defined(DMA2_Channel3)
     DMA2_Channel3,
 #else
     DMA1_Channel8

--- a/tools/check_ch32_uart_mapping.py
+++ b/tools/check_ch32_uart_mapping.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Check CH32 UART DMA tables against pinned WCH SDKs, without target hardware.
+
+The executable only compares peripheral addresses and constants. No MCU register
+is accessed. The SDK headers are real; only LibXR's unrelated umbrella is stubbed.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def run(command, **kwargs):
+    result = subprocess.run(command, text=True, capture_output=True, **kwargs)
+    if result.returncode:
+        raise RuntimeError(" ".join(map(str, command)) + "\n" + result.stdout + result.stderr)
+    return result.stdout
+
+
+SOURCE = r'''
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include "SDK_HEADER"
+#include "SDK_RCC"
+#include "SDK_DMA"
+// Adversarial SDK surface: unrelated DMA2 names must not select DMA2 on V20x.
+#ifdef TEST_DMA2_NAMES
+#define DMA2_Channel3 ((DMA_Channel_TypeDef*)0x40020430U)
+#define DMA2_Channel5 ((DMA_Channel_TypeDef*)0x40020458U)
+#define DMA2_IT_TC5 0x10020000U
+#define DMA2_IT_TC3 0x10000200U
+#define DMA2_IT_HT3 0x10000400U
+#endif
+#include "ch32_uart_def.hpp"
+
+#define CHECK(x) do { if (!(x)) { std::fprintf(stderr, "%d: %s\n", __LINE__, #x); return 1; } } while (0)
+#define ROW(id, bank, tx, rx, irq) do { \
+    CHECK(CH32_UART_RCC_PERIPH_MAP_DMA[id] == RCC_AHBPeriph_DMA##bank); \
+    CHECK(CH32_UART_TX_DMA_CHANNEL_MAP[id] == DMA##bank##_Channel##tx); \
+    CHECK(CH32_UART_RX_DMA_CHANNEL_MAP[id] == DMA##bank##_Channel##rx); \
+    CHECK(CH32_UART_TX_DMA_IT_MAP[id] == DMA##bank##_IT_TC##tx); \
+    CHECK(CH32_UART_RX_DMA_IT_TC_MAP[id] == DMA##bank##_IT_TC##rx); \
+    CHECK(CH32_UART_RX_DMA_IT_HT_MAP[id] == DMA##bank##_IT_HT##rx); \
+    CHECK(CH32_UART_IRQ_MAP[id] == irq); \
+    std::printf("%u %u %u %u %u\n", unsigned(id), bank, tx, rx, unsigned(irq)); \
+  } while (0)
+int main() {
+    constexpr unsigned N = CH32_UART_NUMBER;
+#define LENGTH(table) CHECK(sizeof(table)/sizeof(table[0]) == N)
+    LENGTH(CH32_UART_APB_MAP);
+    LENGTH(CH32_UART_RCC_PERIPH_MAP);
+    LENGTH(CH32_UART_RCC_PERIPH_MAP_DMA);
+    LENGTH(CH32_UART_TX_DMA_CHANNEL_MAP);
+    LENGTH(CH32_UART_RX_DMA_CHANNEL_MAP);
+    LENGTH(CH32_UART_TX_DMA_IT_MAP);
+    LENGTH(CH32_UART_RX_DMA_IT_TC_MAP);
+    LENGTH(CH32_UART_RX_DMA_IT_HT_MAP);
+    LENGTH(CH32_UART_IRQ_MAP);
+    ROW(CH32_USART1, 1, 4, 5, USART1_IRQn);
+    ROW(CH32_USART2, 1, 7, 6, USART2_IRQn);
+    ROW(CH32_USART3, 1, 2, 3, USART3_IRQn);
+#if defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+    CHECK(N == 4);
+    ROW(CH32_UART4, 1, 1, 8, UART4_IRQn);
+#ifdef CH32V20x_D6
+    CHECK(UART4_IRQn == 61 && DMA1_Channel8_IRQn == 62);
+#else
+    CHECK(UART4_IRQn == 66 && DMA1_Channel8_IRQn == 67);
+#endif
+#else
+    CHECK(N == 8);
+    ROW(CH32_UART4, 2, 5, 3, UART4_IRQn);
+    ROW(CH32_UART5, 2, 4, 2, UART5_IRQn);
+    ROW(CH32_UART6, 2, 6, 7, UART6_IRQn);
+    ROW(CH32_UART7, 2, 8, 9, UART7_IRQn);
+    ROW(CH32_UART8, 2, 10, 11, UART8_IRQn);
+#endif
+    // Unchanged peripheral clock domains must retain their original indices.
+    CHECK(CH32_UART_APB_MAP[CH32_USART1] == 2);
+    CHECK(CH32_UART_RCC_PERIPH_MAP[CH32_USART1] == RCC_APB2Periph_USART1);
+    CHECK(CH32_UART_RCC_PERIPH_MAP[CH32_USART2] == RCC_APB1Periph_USART2);
+    CHECK(CH32_UART_RCC_PERIPH_MAP[CH32_USART3] == RCC_APB1Periph_USART3);
+    CHECK(CH32_UART_RCC_PERIPH_MAP[CH32_UART4] == RCC_APB1Periph_UART4);
+    return 0;
+}
+'''
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--repo', type=Path, required=True)
+    parser.add_argument('--v20-sdk', type=Path, required=True)
+    parser.add_argument('--v30-sdk', type=Path, required=True)
+    parser.add_argument('--cxx', default=os.environ.get('CXX', 'g++'))
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    results = []
+    with tempfile.TemporaryDirectory(prefix='ch32-uart-mapping-') as tmp:
+        work = Path(tmp)
+        (work/'libxr.hpp').write_text('#pragma once\n#include <cstdint>\n#include <cstddef>\n#define XR_TEST_STR_(x) #x\n#define DEF2STR(x) XR_TEST_STR_(x)\n')
+        for family, sdk, tag in [('CH32V20x_D6',args.v20_sdk,'ch32v20x'),
+                                 ('CH32V20x_D8',args.v20_sdk,'ch32v20x'),
+                                 ('CH32V20x_D8W',args.v20_sdk,'ch32v20x'),
+                                 ('CH32V30x_D8',args.v30_sdk,'ch32v30x'),
+                                 ('CH32V30x_D8C',args.v30_sdk,'ch32v30x')]:
+            src = sdk/'EVT/EXAM/SRC'
+            source = SOURCE.replace('SDK_HEADER',tag+'.h').replace('SDK_RCC',tag+'_rcc.h').replace('SDK_DMA',tag+'_dma.h')
+            for adversarial in ([False,True] if tag=='ch32v20x' else [False]):
+                command=[args.cxx,'-std=c++20','-O2','-fpermissive','-Wno-volatile','-Wno-attributes',
+                         '-I'+str(work),'-I'+str(args.repo/'driver/ch'),
+                         '-I'+str(src/'Peripheral/inc'),'-I'+str(src/'Core'),'-I'+str(src/'Debug'),
+                         '-I'+str(sdk/'EVT/EXAM/USART/USART_DMA/User'),
+                         '-D'+family,'-DLIBXR_CH32_CONFIG_FILE='+tag+'.h']
+                if adversarial: command += ['-DTEST_DMA2_NAMES=1']
+                target=work/(family+('-extra-dma2' if adversarial else ''))
+                run(command+['-x','c++','-','-o',str(target)],input=source)
+                rows=run([str(target)]).strip().splitlines()
+                record={'family':family,'extra_dma2_names':adversarial,'uart_rows':[list(map(int,r.split())) for r in rows],'pass':True}
+                results.append(record)
+                print(json.dumps(record),flush=True)
+    summary={'pass':True,'cases':len(results),'results':results}
+    if args.output: args.output.write_text(json.dumps(summary,indent=2)+'\n')
+    return 0
+
+
+if __name__=='__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

CH32V203 UART4 uses DMA1 Channel 1 for TX and DMA1 Channel 8 for RX. The previous generic UART4 mapping could select DMA2 whenever DMA2 symbols were visible, enabling the wrong DMA clock and selecting the wrong interrupt/channel constants.

## Scope

This fix applies only to the legacy ch32v20x.h D6/D8/D8W resource family used by CH32V203 and CH32V208. The newer CH32V205 uses a separate ch32v205.h, dual DMA, and different RCC APIs; this PR does not claim or alter CH32V205 support.

CH32V30x UART4-8 keep their existing DMA2 mappings.

## Change

- Select DMA1 for UART4 on CH32V20x_D6, CH32V20x_D8, and CH32V20x_D8W.
- Keep UART4 TX on DMA1 Channel 1 and RX on DMA1 Channel 8 for those legacy V20 variants.
- Preserve the existing V30x DMA2 mappings.
- Add a pinned-SDK UART mapping matrix, including adversarial DMA2 symbol injection on legacy V20, so symbol visibility cannot silently switch UART4 back to DMA2.

## Validation

- V203 Debug and Release hardware regression passed with DMA1 initially disabled; UART4 transfer, configuration, timeout, recovery, and Config/I-O concurrency passed.
- UART DMA family matrix passes for CH32V20x_D6, D8, D8W and CH32V30x_D8, D8C against pinned WCH SDK revisions.
- Debug, Release with DEV_ASSERT on, Release with DEV_ASSERT off, clang-format, cmake-format, dependency, license, and security checks all pass.

## Related work

#305 fixed the shared-IRQ topology. The remaining static-archive ISR-retention and topology-aware PMA handling are addressed separately in #307.