### PR TITLE
fix(ch32): retain shared IRQs and reserve CAN PMA by topology

### DIFF
--- a/.github/workflows/ch32-shared-irq.yml
+++ b/.github/workflows/ch32-shared-irq.yml
@@ -1,0 +1,15 @@
+name: CH32 shared IRQ contracts
+
+on:
+  push:
+    branches: ["master", "dev"]
+  pull_request:
+
+jobs:
+  shared-irq:
+    name: Shared IRQ archive and callback matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check weak startup handlers, LTO, callbacks and PMA policy
+        run: python3 tools/check_ch32_shared_irq.py --repo .

--- a/driver/ch/README.md
+++ b/driver/ch/README.md
@@ -4,6 +4,19 @@
 `CH32USBOtgFS` or `CH32USBOtgHS`; those controllers use separate endpoint memory
 and do not participate in this PMA policy.
 
+The family rules in this directory are validated against WCH's legacy
+`ch32v20x.h` D6/D8/D8W resource model (CH32V203/CH32V208) and
+`ch32v30x.h` D8/D8C resource model (CH32V303/305/307/317). The newer
+CH32V205 uses a separate `ch32v205.h`, dual DMA and different RCC APIs; these
+legacy tables do not claim CH32V205 support merely because its product name also
+contains "V20x".
+
+WCH common headers are resource supersets. In particular, `CH32V30x_D8C`
+covers V305 together with V307/V317, while the exact parts expose different UART
+counts and packages expose different pins. A symbol in the common header is not
+by itself a promise that an application may instantiate that peripheral on every
+part/package in the macro family.
+
 ## Device capabilities
 
 The common WCH headers may declare resources that are absent on a selected
@@ -25,10 +38,19 @@ printed pages 353–354, specifies a shared 512-byte memory region:
 | No CAN | 512 bytes |
 | CAN1 | 384 bytes |
 | CAN1 and CAN2 | 256 bytes |
-| CAN2 without a CAN1 object | 256 bytes reserved, including the high filter banks |
+| CAN2 without a CAN1 object | 256 bytes (backend conservative reservation) |
 
 The budget includes the endpoint buffer descriptor table. It is checked on the
 first allocation, not only after a host bus reset.
+
+The manual explicitly describes the 384-byte CAN1 partition and the 256-byte
+dual-controller partition. It does not document "CAN2-only application objects"
+as a separate PMA mode. This backend still reserves 256 bytes whenever CAN2 is
+active: CAN2 uses the upper shared filter-bank partition through the CAN1 filter
+master, so treating it as the dual-controller footprint avoids allowing USB PMA
+to overlap a region whose safety is not documented. This is intentionally
+conservative rather than a claim that the manual specifies a separate CAN2-only
+partition.
 
 Construct every CAN object that the application will use **before** calling
 `CH32USBDeviceFS::Init()`, or otherwise configuring its endpoints. Creating a CAN
@@ -39,6 +61,10 @@ addresses across Stop/Start, so their allocation reservation remains active.
 This backend does not provide dynamic reallocation of PMA after adding CAN.
 Application initialization is expected to be serialized. The rule does not
 restrict applications that use only OTG FS/HS and CAN.
+
+PMA exhaustion is also a fatal invariant in both Debug and Release. Endpoint
+configuration must never continue with an address outside the topology-specific
+512/384/256-byte budget.
 
 ## Shared-vector lifetime
 

--- a/driver/ch/README.md
+++ b/driver/ch/README.md
@@ -1,0 +1,64 @@
+# CH32 CAN / FSDEV contracts
+
+`CH32USBDeviceFS` is the legacy PMA-backed USBD controller. It is not
+`CH32USBOtgFS` or `CH32USBOtgHS`; those controllers use separate endpoint memory
+and do not participate in this PMA policy.
+
+## Device capabilities
+
+The common WCH headers may declare resources that are absent on a selected
+family. `ch32_can_caps.hpp` treats CH32V20x D6/D8/D8W and CH32V30x D8 (V303) as
+single-CAN. CH32V30x D8C uses both CAN instances. This family-level distinction
+does not claim that every package exposes all peripheral pins.
+
+CAN1 TX and RX0 use the USB-named shared vectors on both single- and dual-CAN
+families. CAN2 has separate vectors. Creating only CAN2 must not register CAN1
+callbacks, but it must enable CAN1's clock for the shared filter registers.
+
+## PMA and initialization order
+
+The WCH *CH32F/V20x_V30x_V31x Reference Manual*, V2.5, section 21.3.3,
+printed pages 353–354, specifies a shared 512-byte memory region:
+
+| Configured CAN resources | FSDEV PMA budget |
+| --- | ---: |
+| No CAN | 512 bytes |
+| CAN1 | 384 bytes |
+| CAN1 and CAN2 | 256 bytes |
+| CAN2 without a CAN1 object | 256 bytes reserved, including the high filter banks |
+
+The budget includes the endpoint buffer descriptor table. It is checked on the
+first allocation, not only after a host bus reset.
+
+Construct every CAN object that the application will use **before** calling
+`CH32USBDeviceFS::Init()`, or otherwise configuring its endpoints. Creating a CAN
+object after PMA allocation fails through `REQUIRE` in both Debug and Release.
+Stopping USB is not a way around this requirement: endpoint objects retain PMA
+addresses across Stop/Start, so their allocation reservation remains active.
+
+This backend does not provide dynamic reallocation of PMA after adding CAN.
+Application initialization is expected to be serialized. The rule does not
+restrict applications that use only OTG FS/HS and CAN.
+
+## Shared-vector lifetime
+
+Callback registration is out of line in `ch32_usbcan_shared.cpp`, so a static
+archive link must retain the object containing both shared ISRs. A weak handler
+in the startup file must not satisfy the vectors in the final image.
+
+CAN publishes its callbacks before enabling its interrupt source. FSDEV prepares
+its endpoints and publishes its callback before enabling IRQs or the pull-up.
+FSDEV Stop masks its interrupt sources before unregistering the callback. It
+keeps the shared NVIC lines enabled while CAN1 uses them. CAN2-only operation
+does not keep CAN1's shared vectors active.
+
+## Regression checks
+
+`tools/check_ch32_shared_irq.py --repo .` checks real archive extraction against
+weak startup handlers, with and without LTO, callback dispatch, CAN2-only state,
+and 512/384/256-byte PMA policy. It removes only the WCH-specific interrupt
+attribute for host execution; it does not simulate bus traffic.
+
+Target compilation and physical USB/CAN traffic are separate acceptance steps.
+Passing these checks does not validate the generic `USB::CDCUart` queue, external
+CAN transceivers, or USB OTG controllers.

--- a/driver/ch/ch32_can.cpp
+++ b/driver/ch/ch32_can.cpp
@@ -53,7 +53,7 @@ static inline void ch32_can_enable_nvic(ch32_can_id_t id, uint8_t fifo)
       break;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     case CH32_CAN2:
       NVIC_EnableIRQ(CAN2_TX_IRQn);
       break;
@@ -74,7 +74,7 @@ static inline void ch32_can_enable_nvic(ch32_can_id_t id, uint8_t fifo)
         break;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
       case CH32_CAN2:
         NVIC_EnableIRQ(CAN2_RX0_IRQn);
         break;
@@ -93,7 +93,7 @@ static inline void ch32_can_enable_nvic(ch32_can_id_t id, uint8_t fifo)
         break;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
       case CH32_CAN2:
         NVIC_EnableIRQ(CAN2_RX1_IRQn);
         break;
@@ -114,7 +114,7 @@ static inline void ch32_can_enable_nvic(ch32_can_id_t id, uint8_t fifo)
       break;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     case CH32_CAN2:
       NVIC_EnableIRQ(CAN2_SCE_IRQn);
       break;
@@ -130,16 +130,12 @@ CH32CAN::CH32CAN(ch32_can_id_t id, uint32_t queue_size)
 {
   if constexpr (LibXR::CH32UsbCanShared::usb_can_share_enabled())
   {
-#if defined(CAN1) && !defined(CAN2)
-    const bool USB_ALREADY_INITED =
-        LibXR::CH32UsbCanShared::usb_inited.load(std::memory_order_acquire);
-    // 在 USB/CAN 共享中断拓扑下，CAN1 必须先于 USB 初始化。
-    // On shared USB/CAN interrupt configurations, CAN1 must initialize before USB.
-    ASSERT(USB_ALREADY_INITED == false);
-#endif
+    // 端点地址在 Stop 后仍有效，不能在分配 PMA 后扩大 CAN 过滤器占用。
+    // Endpoint addresses survive Stop; reserve CAN filters before allocating PMA.
+    REQUIRE(!LibXR::CH32UsbCanShared::usb_pma_configured.load(std::memory_order_acquire));
   }
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
   if (id == CH32_CAN1)
   {
     filter_bank_ = 0;
@@ -163,12 +159,20 @@ CH32CAN::CH32CAN(ch32_can_id_t id, uint32_t queue_size)
   // 打开外设时钟。
   // Enable the peripheral clock.
   RCC_APB1PeriphClockCmd(CH32_CAN_RCC_PERIPH_MAP[id_], ENABLE);
+#if LIBXR_CH32_HAS_CAN2
+  if (id_ == CH32_CAN2)
+  {
+    // CAN2 的共享过滤器寄存器位于 CAN1，不能依赖应用先创建 CAN1 对象。
+    // CAN2 filter registers belong to CAN1, even in a CAN2-only application.
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN1, ENABLE);
+  }
+#endif
 
   // 在调用 SetConfig() 之前，保持 CAN 处于初始化模式。
   // Keep CAN in initialization mode until SetConfig() is called.
   (void)CAN_OperatingModeRequest(instance_, CAN_OperatingMode_Initialization);
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
   // 在双 CAN 变体上，配置默认的共享过滤器分界点。
   // On dual-CAN variants, configure the default shared filter split point.
   CAN_SlaveStartBank(CH32_CAN_DEFAULT_SLAVE_START_BANK);
@@ -199,12 +203,8 @@ ErrorCode CH32CAN::Init()
 
   CAN_FilterInit(&f);
 
-  EnableIRQs();
-
-  // 为当前 CAN 实例打开 NVIC。
-  // Enable NVIC for this CAN instance.
-  ch32_can_enable_nvic(id_, fifo_);
-
+  // 在放行中断源之前发布回调，防止已有 pending 中断进入空分发器。
+  // Publish callbacks before enabling an interrupt source with pending events.
   if constexpr (LibXR::CH32UsbCanShared::usb_can_irq_share_enabled())
   {
 #if defined(CAN1) && defined(RCC_APB1Periph_USB)
@@ -214,8 +214,17 @@ ErrorCode CH32CAN::Init()
       LibXR::CH32UsbCanShared::register_can1_tx(&can1_tx_thunk);
       LibXR::CH32UsbCanShared::can1_inited.store(true, std::memory_order_release);
     }
+#if LIBXR_CH32_HAS_CAN2
+    else if (id_ == CH32_CAN2)
+    {
+      LibXR::CH32UsbCanShared::can2_inited.store(true, std::memory_order_release);
+    }
+#endif
 #endif
   }
+
+  EnableIRQs();
+  ch32_can_enable_nvic(id_, fifo_);
 
   return ErrorCode::OK;
 }
@@ -804,7 +813,7 @@ extern "C" void CAN1_SCE_IRQHandler(void)
 }
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" void CAN2_TX_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/driver/ch/ch32_can_caps.hpp
+++ b/driver/ch/ch32_can_caps.hpp
@@ -3,6 +3,10 @@
 #include "libxr_def.hpp"
 #include DEF2STR(LIBXR_CH32_CONFIG_FILE)
 
+// These macros belong to the legacy ch32v20x.h/ch32v30x.h SDK families.
+// Newer devices such as CH32V205 use a separate header/resource model and are not
+// identified by CH32V20x_D6/D8/D8W.
+// 这些宏对应旧版 ch32v20x.h/ch32v30x.h 资源族；CH32V205 使用独立资源模型。
 // The common WCH V30x header declares CAN2 even for single-CAN V303 devices.
 // WCH V30x 公共头文件也为单 CAN 的 V303 声明了 CAN2，不能只判断符号是否存在。
 #if defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W) || \

--- a/driver/ch/ch32_can_caps.hpp
+++ b/driver/ch/ch32_can_caps.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "libxr_def.hpp"
+#include DEF2STR(LIBXR_CH32_CONFIG_FILE)
+
+// The common WCH V30x header declares CAN2 even for single-CAN V303 devices.
+// WCH V30x 公共头文件也为单 CAN 的 V303 声明了 CAN2，不能只判断符号是否存在。
+#if defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W) || \
+    defined(CH32V30x_D8)
+#define LIBXR_CH32_HAS_CAN2 0
+#elif defined(CAN2)
+#define LIBXR_CH32_HAS_CAN2 1
+#else
+#define LIBXR_CH32_HAS_CAN2 0
+#endif

--- a/driver/ch/ch32_can_def.cpp
+++ b/driver/ch/ch32_can_def.cpp
@@ -14,7 +14,7 @@ ch32_can_id_t CH32_CAN_GetID(CAN_TypeDef* addr)
     return CH32_CAN1;
   }
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
   else if (addr == CAN2)
   {
     return CH32_CAN2;
@@ -32,7 +32,7 @@ CAN_TypeDef* CH32_CAN_GetInstanceID(ch32_can_id_t id)
     case CH32_CAN1:
       return CAN1;
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     case CH32_CAN2:
       return CAN2;
 #endif

--- a/driver/ch/ch32_can_def.hpp
+++ b/driver/ch/ch32_can_def.hpp
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
+#include "ch32_can_caps.hpp"
 #include "libxr.hpp"
-#include DEF2STR(LIBXR_CH32_CONFIG_FILE)
 
 /**
  * @brief CH32 CAN 实例编号 / CH32 CAN instance identifier
@@ -16,7 +16,7 @@ typedef enum
 #if defined(CAN1)
   CH32_CAN1,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
   CH32_CAN2,
 #endif
   CH32_CAN_NUMBER,
@@ -47,7 +47,7 @@ static constexpr uint32_t CH32_CAN_RCC_PERIPH_MAP[] = {
 #if defined(CAN1)
     RCC_APB1Periph_CAN1,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     RCC_APB1Periph_CAN2,
 #endif
 };
@@ -56,7 +56,7 @@ static constexpr IRQn_Type CH32_CAN_TX_IRQ_MAP[] = {
 #if defined(CAN1)
     USB_HP_CAN1_TX_IRQn,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     CAN2_TX_IRQn,
 #endif
 };
@@ -65,7 +65,7 @@ static constexpr IRQn_Type CH32_CAN_RX0_IRQ_MAP[] = {
 #if defined(CAN1)
     USB_LP_CAN1_RX0_IRQn,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     CAN2_RX0_IRQn,
 #endif
 };
@@ -74,7 +74,7 @@ static constexpr IRQn_Type CH32_CAN_RX1_IRQ_MAP[] = {
 #if defined(CAN1)
     CAN1_RX1_IRQn,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     CAN2_RX1_IRQn,
 #endif
 };
@@ -83,7 +83,7 @@ static constexpr IRQn_Type CH32_CAN_SCE_IRQ_MAP[] = {
 #if defined(CAN1)
     CAN1_SCE_IRQn,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     CAN2_SCE_IRQn,
 #endif
 };

--- a/driver/ch/ch32_usb_devfs.cpp
+++ b/driver/ch/ch32_usb_devfs.cpp
@@ -538,14 +538,6 @@ void CH32USBDeviceFS::Start(bool)
   EXTEN->EXTEN_CTR &= ~EXTEN_USBD_LS;
 #endif
 
-  NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
-  NVIC_EnableIRQ(USB_HP_CAN1_TX_IRQn);
-  NVIC_EnableIRQ(USBWakeUp_IRQn);
-
-#if defined(EXTEN_USBD_PU_EN)
-  EXTEN->EXTEN_CTR |= EXTEN_USBD_PU_EN;
-#endif
-
   *usbdev_daddr() = USB_DADDR_EF;
 
   CH32EndpointDevFs::SetEpTxStatus(0, USB_EP_TX_NAK);
@@ -575,10 +567,22 @@ void CH32USBDeviceFS::Start(bool)
   self_ = this;
   LibXR::CH32UsbCanShared::usb_inited.store(true, std::memory_order_release);
   LibXR::CH32UsbCanShared::register_usb_irq(&usb_irq_thunk);
+
+  // 回调与端点就绪后再放行中断和连接主机。
+  // Publish the handler and arm endpoints before enabling IRQs or the pull-up.
+  NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
+  NVIC_EnableIRQ(USB_HP_CAN1_TX_IRQn);
+  NVIC_EnableIRQ(USBWakeUp_IRQn);
+#if defined(EXTEN_USBD_PU_EN)
+  EXTEN->EXTEN_CTR |= EXTEN_USBD_PU_EN;
+#endif
 }
 
 void CH32USBDeviceFS::Stop(bool)
 {
+  // 先屏蔽 USB 中断源，再解除回调；共享 CAN 中断线可能仍然开启。
+  // Mask USB interrupt sources before unregistering from live shared CAN IRQs.
+  *usbdev_cntr() = USB_CNTR_FRES;
   LibXR::CH32UsbCanShared::register_usb_irq(nullptr);
   LibXR::CH32UsbCanShared::usb_inited.store(false, std::memory_order_release);
   self_ = nullptr;
@@ -593,8 +597,6 @@ void CH32USBDeviceFS::Stop(bool)
     NVIC_DisableIRQ(USB_HP_CAN1_TX_IRQn);
   }
   NVIC_DisableIRQ(USBWakeUp_IRQn);
-
-  *usbdev_cntr() = USB_CNTR_FRES;
 }
 
 #endif  // defined(RCC_APB1Periph_USB)

--- a/driver/ch/ch32_usb_endpoint_devfs.cpp
+++ b/driver/ch/ch32_usb_endpoint_devfs.cpp
@@ -282,6 +282,9 @@ void CH32EndpointDevFs::ResetPMAAllocator()
 
 static inline uint16_t alloc_pma(size_t bytes)
 {
+  // Init may allocate endpoints before the first USB bus reset.
+  // 首次 USB reset 前也可能分配端点，必须立即使用当前 CAN 预留后的上限。
+  g_pma_limit = LibXR::CH32UsbCanShared::usb_pma_limit_bytes();
   const uint16_t ADDR = g_pma_next;
   const uint16_t INC = static_cast<uint16_t>((bytes + 1U) & ~1U);
 
@@ -292,6 +295,7 @@ static inline uint16_t alloc_pma(size_t bytes)
     return 0;
   }
 
+  LibXR::CH32UsbCanShared::usb_pma_configured.store(true, std::memory_order_release);
   g_pma_next = static_cast<uint16_t>(END);
   return ADDR;
 }

--- a/driver/ch/ch32_usb_endpoint_devfs.cpp
+++ b/driver/ch/ch32_usb_endpoint_devfs.cpp
@@ -277,7 +277,7 @@ void CH32EndpointDevFs::ResetPMAAllocator()
 
   g_pma_next = PMA_ALLOC_BASE;
   g_pma_next = static_cast<uint16_t>((g_pma_next + 1U) & ~1U);
-  ASSERT(g_pma_next <= g_pma_limit);
+  REQUIRE(g_pma_next <= g_pma_limit);
 }
 
 static inline uint16_t alloc_pma(size_t bytes)
@@ -285,11 +285,19 @@ static inline uint16_t alloc_pma(size_t bytes)
   // Init may allocate endpoints before the first USB bus reset.
   // 首次 USB reset 前也可能分配端点，必须立即使用当前 CAN 预留后的上限。
   g_pma_limit = LibXR::CH32UsbCanShared::usb_pma_limit_bytes();
-  const uint16_t ADDR = g_pma_next;
-  const uint16_t INC = static_cast<uint16_t>((bytes + 1U) & ~1U);
+  // PMA is at most 512 bytes. Reject before narrowing the aligned size to uint16_t,
+  // so an oversized endpoint buffer cannot wrap the allocation increment.
+  // PMA 最大只有 512 字节；先拒绝超大缓冲，避免对齐长度收窄到 uint16_t 时回绕。
+  REQUIRE(bytes <= g_pma_limit);
+  if (bytes > g_pma_limit)
+  {
+    return 0;
+  }
 
-  const uint32_t END = static_cast<uint32_t>(ADDR) + static_cast<uint32_t>(INC);
-  ASSERT(END <= g_pma_limit);
+  const uint16_t ADDR = g_pma_next;
+  const uint32_t INC = (static_cast<uint32_t>(bytes) + 1U) & ~1U;
+  const uint32_t END = static_cast<uint32_t>(ADDR) + INC;
+  REQUIRE(END <= g_pma_limit);
   if (END > g_pma_limit)
   {
     return 0;
@@ -349,7 +357,7 @@ void CH32EndpointDevFs::Configure(const Config& cfg)
   if (pma_addr_ == 0 || pma_addr_ < PMA_ALLOC_BASE)
   {
     const uint16_t ADDR = alloc_pma(BUF.size_);
-    ASSERT(ADDR >= PMA_ALLOC_BASE);
+    REQUIRE(ADDR >= PMA_ALLOC_BASE);
     if (ADDR < PMA_ALLOC_BASE)
     {
       return;

--- a/driver/ch/ch32_usbcan_shared.cpp
+++ b/driver/ch/ch32_usbcan_shared.cpp
@@ -1,5 +1,34 @@
 #include "ch32_usbcan_shared.hpp"
 
+namespace LibXR::CH32UsbCanShared
+{
+void register_usb_irq(IrqFn fn) { usb_irq_cb.store(fn, std::memory_order_release); }
+
+void register_can1_rx0(IrqFn fn)
+{
+  if constexpr (K_USB_CAN_IRQ_SHARE)
+  {
+    can1_rx0_cb.store(fn, std::memory_order_release);
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+
+void register_can1_tx(IrqFn fn)
+{
+  if constexpr (K_USB_CAN_IRQ_SHARE)
+  {
+    can1_tx_cb.store(fn, std::memory_order_release);
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+}  // namespace LibXR::CH32UsbCanShared
+
 #if defined(RCC_APB1Periph_USB) && defined(CAN1)
 
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/driver/ch/ch32_usbcan_shared.hpp
+++ b/driver/ch/ch32_usbcan_shared.hpp
@@ -2,8 +2,7 @@
 #include <atomic>
 #include <cstdint>
 
-#include "libxr_def.hpp"
-#include DEF2STR(LIBXR_CH32_CONFIG_FILE)
+#include "ch32_can_caps.hpp"
 
 namespace LibXR::CH32UsbCanShared
 {
@@ -14,9 +13,14 @@ using IrqFn = void (*)();
 
 inline std::atomic_bool usb_inited{false};
 inline std::atomic_bool can1_inited{false};
+inline std::atomic_bool can2_inited{false};
+// Endpoint objects retain their PMA addresses across Stop/Start.
+// 端点对象在 Stop/Start 后仍保留 PMA 地址；分配后不能再增加 CAN 占用。
+inline std::atomic_bool usb_pma_configured{false};
 
 static constexpr uint16_t USBD_PMA_BYTES_SOLO = 512;
 static constexpr uint16_t USBD_PMA_BYTES_WITHCAN = 384;
+static constexpr uint16_t USBD_PMA_BYTES_WITHCAN2 = 256;
 
 // USB/CAN 共享中断拓扑的编译期能力标志。
 // Build-time capability flags for USB/CAN shared interrupt topology.
@@ -32,7 +36,7 @@ inline constexpr bool K_HAS_CAN1 = true;
 inline constexpr bool K_HAS_CAN1 = false;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
 inline constexpr bool K_HAS_CAN2 = true;
 #else
 inline constexpr bool K_HAS_CAN2 = false;
@@ -42,9 +46,9 @@ inline constexpr bool K_SINGLE_CAN1 = K_HAS_CAN1 && !K_HAS_CAN2;
 // CAN1 uses the USB-named IRQ vectors even on dual-CAN devices.
 // CAN1 在双 CAN 器件上仍使用 USB 命名的共享中断向量。
 inline constexpr bool K_USB_CAN_IRQ_SHARE = K_HAS_USB_DEV_FS && K_HAS_CAN1;
-// PMA/resource sharing is limited to the original single-CAN topology.
-// PMA/资源共享仍只适用于原来的单 CAN 拓扑。
-inline constexpr bool K_USB_CAN_SHARE = K_HAS_USB_DEV_FS && K_SINGLE_CAN1;
+// FSDEV shares PMA with CAN on both single- and dual-CAN devices.
+// 单 CAN、双 CAN 器件上的 FSDEV 都与 CAN 共享 PMA。
+inline constexpr bool K_USB_CAN_SHARE = K_HAS_USB_DEV_FS && K_HAS_CAN1;
 
 inline constexpr bool usb_can_irq_share_enabled() { return K_USB_CAN_IRQ_SHARE; }
 inline constexpr bool usb_can_share_enabled() { return K_USB_CAN_SHARE; }
@@ -56,6 +60,15 @@ inline uint16_t usb_pma_limit_bytes()
     return USBD_PMA_BYTES_SOLO;
   }
 
+  // CAN2 uses the upper filter banks, including when no CAN1 object was created.
+  // CAN2 使用高编号过滤器组，即使应用没有创建 CAN1 对象也必须预留。
+  if constexpr (K_HAS_CAN2)
+  {
+    if (can2_inited.load(std::memory_order_acquire))
+    {
+      return USBD_PMA_BYTES_WITHCAN2;
+    }
+  }
   return can1_inited.load(std::memory_order_acquire) ? USBD_PMA_BYTES_WITHCAN
                                                      : USBD_PMA_BYTES_SOLO;
 }
@@ -64,34 +77,11 @@ inline std::atomic<IrqFn> usb_irq_cb{nullptr};
 inline std::atomic<IrqFn> can1_rx0_cb{nullptr};
 inline std::atomic<IrqFn> can1_tx_cb{nullptr};
 
-inline void register_usb_irq(IrqFn fn)
-{
-  usb_irq_cb.store(fn, std::memory_order_release);
-}
-
-inline void register_can1_rx0(IrqFn fn)
-{
-  if constexpr (K_USB_CAN_IRQ_SHARE)
-  {
-    can1_rx0_cb.store(fn, std::memory_order_release);
-  }
-  else
-  {
-    (void)fn;
-  }
-}
-
-inline void register_can1_tx(IrqFn fn)
-{
-  if constexpr (K_USB_CAN_IRQ_SHARE)
-  {
-    can1_tx_cb.store(fn, std::memory_order_release);
-  }
-  else
-  {
-    (void)fn;
-  }
-}
+// Out-of-line registration retains the shared ISR object when linking libxr.a.
+// 非内联注册使静态库链接必须带入共享 ISR 所在的目标文件。
+void register_usb_irq(IrqFn fn);
+void register_can1_rx0(IrqFn fn);
+void register_can1_tx(IrqFn fn);
 
 inline bool can1_active()
 {

--- a/tools/check_ch32_shared_irq.py
+++ b/tools/check_ch32_shared_irq.py
@@ -52,7 +52,8 @@ int main() {
     CHECK(default_hits==0);
     CHECK(usb_hits==(USE_USB?2:0));
     CHECK(rx_hits==(USE_CAN1?1:0) && tx_hits==(USE_CAN1?1:0));
-    // Both CAN instances, or CAN2 alone, reserve the upper 256 PMA bytes.
+    // CAN2 conservatively selects the dual-controller 256-byte reservation;
+    // the manual does not specify a separate CAN2-only application-object mode.
     can2_inited.store(true);
     CHECK(usb_pma_limit_bytes()==(TEST_DUAL?256:USE_CAN1?384:512));
     can2_inited.store(USE_CAN2);
@@ -95,6 +96,22 @@ def main():
     ap.add_argument('--output',type=Path)
     args=ap.parse_args()
     results=[]
+
+    # PMA exhaustion is a runtime invariant, not a debug-only assertion. Keep a
+    # cheap source-contract check here because the allocator itself is target-MMIO
+    # code and is not executed by this host harness.
+    endpoint_source=(args.repo/'driver/ch/ch32_usb_endpoint_devfs.cpp').read_text()
+    release_guards=(
+        'REQUIRE(g_pma_next <= g_pma_limit);',
+        'REQUIRE(bytes <= g_pma_limit);',
+        'REQUIRE(END <= g_pma_limit);',
+        'REQUIRE(ADDR >= PMA_ALLOC_BASE);',
+    )
+    for guard in release_guards:
+        if guard not in endpoint_source:
+            raise RuntimeError('missing always-on PMA guard: '+guard)
+    results.append({'pma_release_guards':len(release_guards),'pass':True})
+
     source=(args.repo/'driver/ch/ch32_usbcan_shared.cpp').read_text()
     source=source.replace('__attribute__((interrupt("WCH-Interrupt-fast")))','')
     with tempfile.TemporaryDirectory(prefix='ch32-shared-irq-') as tmp:

--- a/tools/check_ch32_shared_irq.py
+++ b/tools/check_ch32_shared_irq.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Test CH32 shared IRQ archive retention, instance topology and PMA policy.
+
+Only the WCH-specific ISR attribute is removed for host execution. Production
+logic is compiled into an archive and linked against separate weak BSP handlers.
+These tests do not replace target compilation or physical USB/CAN verification.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def run(args, **kwargs):
+    p = subprocess.run(args, capture_output=True, text=True, **kwargs)
+    if p.returncode:
+        raise RuntimeError(' '.join(map(str, args))+'\n'+p.stdout+p.stderr)
+    return p.stdout
+
+
+MAIN = r'''
+#include "ch32_usbcan_shared.hpp"
+#include <cstdio>
+using namespace LibXR::CH32UsbCanShared;
+extern "C" void USB_HP_CAN1_TX_IRQHandler();
+extern "C" void USB_LP_CAN1_RX0_IRQHandler();
+extern "C" unsigned default_hits;
+static unsigned usb_hits, rx_hits, tx_hits, sequence;
+static void Usb() { ++usb_hits; sequence=sequence*10+1; }
+static void Rx() { ++rx_hits; sequence=sequence*10+2; }
+static void Tx() { ++tx_hits; sequence=sequence*10+3; }
+#define CHECK(x) do { if (!(x)) { std::fprintf(stderr,"%d: %s\n",__LINE__,#x); return 1; } } while(0)
+int main() {
+    constexpr bool USE_USB=TEST_APP!=2;
+    constexpr bool USE_CAN1=TEST_APP==2 || TEST_APP==3;
+    constexpr bool USE_CAN2=TEST_APP==4;
+    CHECK(K_HAS_CAN2==bool(TEST_DUAL));
+    CHECK(usb_can_share_enabled() && usb_can_irq_share_enabled());
+    CHECK(!can1_active() && !usb_pma_configured.load());
+    CHECK(usb_pma_limit_bytes()==512);
+    if (USE_USB) register_usb_irq(&Usb);
+    if (USE_CAN1) { register_can1_rx0(&Rx); register_can1_tx(&Tx); }
+    can1_inited.store(USE_CAN1); can2_inited.store(USE_CAN2);
+    CHECK(can1_active()==USE_CAN1);
+    CHECK(usb_pma_limit_bytes()==(USE_CAN2?256:USE_CAN1?384:512));
+    sequence=0; USB_LP_CAN1_RX0_IRQHandler();
+    CHECK(sequence==(USE_USB?(USE_CAN1?12:1):2));
+    sequence=0; USB_HP_CAN1_TX_IRQHandler();
+    CHECK(sequence==(USE_USB?(USE_CAN1?13:1):3));
+    CHECK(default_hits==0);
+    CHECK(usb_hits==(USE_USB?2:0));
+    CHECK(rx_hits==(USE_CAN1?1:0) && tx_hits==(USE_CAN1?1:0));
+    // Both CAN instances, or CAN2 alone, reserve the upper 256 PMA bytes.
+    can2_inited.store(true);
+    CHECK(usb_pma_limit_bytes()==(TEST_DUAL?256:USE_CAN1?384:512));
+    can2_inited.store(USE_CAN2);
+    usb_pma_configured.store(true);
+    register_usb_irq(nullptr);
+    CHECK(can1_active()==USE_CAN1 && usb_pma_configured.load());
+    USB_LP_CAN1_RX0_IRQHandler(); USB_HP_CAN1_TX_IRQHandler();
+    CHECK(usb_hits==(USE_USB?2:0));
+    CHECK(rx_hits==(USE_CAN1?2:0) && tx_hits==(USE_CAN1?2:0));
+    register_can1_rx0(nullptr); register_can1_tx(nullptr);
+    CHECK(!can1_active());
+    USB_LP_CAN1_RX0_IRQHandler(); USB_HP_CAN1_TX_IRQHandler();
+    CHECK(default_hits==0);
+    std::puts("PASS"); return 0;
+}
+'''
+STARTUP = r'''
+extern "C" { unsigned default_hits=0; }
+extern "C" __attribute__((weak,noinline)) void USB_HP_CAN1_TX_IRQHandler(){++default_hits;}
+extern "C" __attribute__((weak,noinline)) void USB_LP_CAN1_RX0_IRQHandler(){++default_hits;}
+'''
+EMPTY = r'''
+#include "ch32_usbcan_shared.hpp"
+int main(){
+ using namespace LibXR::CH32UsbCanShared;
+ auto callback=+[](){};
+ register_usb_irq(callback); register_can1_rx0(callback); register_can1_tx(callback);
+ can1_inited.store(true);can2_inited.store(true);
+ if(can1_active() || usb_can_share_enabled() || usb_can_irq_share_enabled())return 1;
+ if(usb_pma_limit_bytes()!=512)return 2;
+ register_usb_irq(nullptr);return 0;
+}
+'''
+
+
+def main():
+    ap=argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--repo',required=True,type=Path)
+    ap.add_argument('--cxx',default=os.environ.get('CXX','g++'))
+    ap.add_argument('--output',type=Path)
+    args=ap.parse_args()
+    results=[]
+    source=(args.repo/'driver/ch/ch32_usbcan_shared.cpp').read_text()
+    source=source.replace('__attribute__((interrupt("WCH-Interrupt-fast")))','')
+    with tempfile.TemporaryDirectory(prefix='ch32-shared-irq-') as tmp:
+        work=Path(tmp)
+        (work/'libxr_def.hpp').write_text('#pragma once\n#define XR_TEST_STR_(x) #x\n#define DEF2STR(x) XR_TEST_STR_(x)\n')
+        (work/'shared.cpp').write_text(source)
+        (work/'startup.cpp').write_text(STARTUP)
+        for family in ('CH32V20x_D6','CH32V20x_D8','CH32V20x_D8W','CH32V30x_D8','CH32V30x_D8C'):
+            dual=family=='CH32V30x_D8C'
+            # A common SDK can declare CAN2 even on a single-CAN target.
+            (work/'test_device.hpp').write_text('#define RCC_APB1Periph_USB 1\n#define CAN1 1\n#define CAN2 1\n#define '+family+' 1\n')
+            for lto in (False,True):
+                flags=[args.cxx,'-std=c++20','-ffunction-sections','-fdata-sections','-I'+str(work),
+                       '-I'+str(args.repo/'driver/ch'),'-DLIBXR_CH32_CONFIG_FILE=test_device.hpp',
+                       '-DTEST_DUAL='+str(int(dual))]
+                flags+=['-O2','-flto'] if lto else ['-O0']
+                run(flags+['-c',str(work/'shared.cpp'),'-o',str(work/'shared.o')])
+                archive=work/'libshared.a'
+                if archive.exists():archive.unlink()
+                run(['ar','rcs',str(archive),str(work/'shared.o')])
+                run(flags+['-c',str(work/'startup.cpp'),'-o',str(work/'startup.o')])
+                for app in ((1,2,3,4) if dual else (1,2,3)):
+                    exe=work/f'check-{family}-{int(lto)}-{app}'
+                    run(flags+['-DTEST_APP='+str(app),'-x','c++','-','-c','-o',str(work/'main.o')],input=MAIN)
+                    run(flags+[str(work/'startup.o'),str(work/'main.o'),str(archive),'-Wl,--gc-sections','-o',str(exe)])
+                    run([str(exe)])
+                    symbols=run(['nm',str(exe)])
+                    for name in ('USB_HP_CAN1_TX_IRQHandler','USB_LP_CAN1_RX0_IRQHandler'):
+                        row=next(x.split() for x in symbols.splitlines() if x.endswith(' '+name))
+                        if row[-2].lower()!='t':raise RuntimeError('ISR is not strong: '+str(row))
+                    result={'family':family,'dual_can':dual,'lto':lto,'application':('usb','can1','both','usb-can2-only')[app-1],'pass':True}
+                    results.append(result);print(json.dumps(result),flush=True)
+        for macros in ('','#define RCC_APB1Periph_USB 1\n','#define CAN1 1\n'):
+            (work/'test_device.hpp').write_text(macros)
+            flags=[args.cxx,'-std=c++20','-O2','-I'+str(work),'-I'+str(args.repo/'driver/ch'),'-DLIBXR_CH32_CONFIG_FILE=test_device.hpp']
+            run(flags+[str(work/'shared.cpp'),'-x','c++','-','-o',str(work/'empty')],input=EMPTY)
+            run([str(work/'empty')]);results.append({'no_sharing_macros':macros.splitlines(),'pass':True})
+    summary={'pass':True,'cases':len(results),'results':results}
+    if args.output:args.output.write_text(json.dumps(summary,indent=2)+'\n')
+    return 0
+
+
+if __name__=='__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope

Complete CH32 CAN / legacy FSDEV shared-resource handling after #305. UART4 DMA mapping is kept in #306. This change does not modify generic `USB::CDCUart`, OTG FS/HS, SPI, I2C, Flash, or RTOS implementations.

## Fixes

- Put callback registration definitions in the shared-ISR translation unit so ordinary static-archive links retain both strong IRQ handlers even when the BSP provides weak defaults.
- Derive CAN2 capability from the selected device family: V20x D6/D8/D8W and V30x D8 (V303) are single-CAN; the common V30x header nevertheless declares CAN2.
- Keep CAN1 callbacks exclusive to the CAN1 object. CAN2-only applications enable the CAN1 clock for shared filters without pretending that CAN1 callbacks are active.
- Apply the actual FSDEV PMA budget on both single- and dual-CAN targets: 512 bytes without CAN, 384 with CAN1, 256 when CAN2's upper filter banks are reserved.
- Enforce CAN construction before any FSDEV PMA allocation, including allocation before the first bus reset and retained allocations after Stop. `REQUIRE` prevents silent Release corruption.
- Publish callbacks before enabling CAN/USB interrupt sources. Mask USB interrupt sources before unregistering on Stop, while preserving CAN1's shared IRQ lines.

The PMA rule comes from WCH's **CH32F/V20x_V30x_V31x Reference Manual V2.5**, section 21.3.3, printed pp. 353鈥?54. It corrects the previous assumption that only single-CAN devices share this SRAM. It does not apply to RAM-backed OTG FS/HS endpoints.

## Regression protection

`tools/check_ch32_shared_irq.py` exercises five macro families, real static archives with weak startup handlers, LTO on/off, USB-only/CAN1-only/combined/CAN2-only registrations, and the PMA policy. A separate GitHub Actions job runs this matrix on every PR.

Integrated validation is complete. The V203/D6 FSDEV endpoint, shared-IRQ and CAN translation units compile with WCH GCC 15.2 against the pinned openwch/ch32v20x SDK (77eea7ca), and the corresponding V30x translation units compile with the WCH GCC 15.2 target toolchain. The shared-IRQ/archive failure was previously reproduced and validated on V203 hardware with the equivalent out-of-line registration fix. Host regression covers weak startup handlers, LTO on/off and PMA topology; the normal Debug/Release CI matrix covers both DEV_ASSERT modes. The separate generic USB::CDCUart long-stream issue remains out of scope.

## Sourcery 鎽樿

淇 CH32 鍏变韩 CAN/FSDEV 涓柇鐨勪繚鐣欓棶棰橈紝骞跺湪鏁翠釜鍒濆鍖栧拰鐢熷懡鍛ㄦ湡鎿嶄綔杩囩▼涓己鍒舵墽琛屾劅鐭ユ嫇鎵戠粨鏋勭殑 PMA 棰勭暀绛栫暐銆俓n
Bug 淇锛歕n- 淇 CH32 CAN 鍔熻兘妫€娴嬶紝浠ユ敮鎸佸叕鍏卞ご鏂囦欢涓毚闇蹭簡涓嶅彈鏀寔鐨?CAN2 绗﹀彿鐨勮澶囩郴鍒椼€俓n- 纭繚 CAN 鍜?USB 鍏变韩 IRQ 澶勭悊绋嬪簭鍙婂洖璋冪殑鐢熷懡鍛ㄦ湡鍦ㄩ潤鎬佸綊妗ｉ摼鎺ャ€佸垵濮嬪寲浠ュ強 USB 鍋滄/鍚姩鍛ㄦ湡涓緱浠ヤ繚鐣欍€俓n- 淇鏃?CAN銆丆AN1銆佸弻 CAN 浠ュ強浠?CAN2 閰嶇疆涓嬬殑 FSDEV PMA 棰勭暀锛屽寘鎷浣嶅墠瀹屾垚鐨勫垎閰嶃€俓n
澧炲己鍔熻兘锛歕n- 纭繚鍦ㄥ惎鐢ㄤ腑鏂簮涔嬪墠娉ㄥ唽 CAN 鍥炶皟锛屽苟纭繚 CAN1 鍥炶皟鐨勬墍鏈夋潈浠呭綊 CAN1銆俓n- 鍏佽浠?CAN2 鐨勮繍琛屾ā寮忛厤缃叡浜繃婊ゅ櫒璧勬簮锛岃€屾棤闇€娉ㄥ唽 CAN1 鍥炶皟銆俓n
CI锛歕n- 娣诲姞 GitHub Actions 鐭╅樀锛岀敤浜庨獙璇?CH32 鍏变韩 IRQ 褰掓。淇濈暀銆佸急澶勭悊绋嬪簭鏇挎崲銆丩TO 閰嶇疆銆佸洖璋冨垎鍙戙€佽澶囨嫇鎵戠粨鏋勪互鍙?PMA 绛栫暐銆俓n
鏂囨。锛歕n- 璁板綍 CH32 CAN 鍜屾棫鐗?FSDEV 璁惧鍔熻兘銆丳MA 鍒嗛厤瑕佹眰銆佸叡浜悜閲忕敓鍛藉懆鏈熶互鍙婇獙璇佽寖鍥淬€俓n
娴嬭瘯锛歕n- 娣诲姞涓绘満绔洖褰掓祴璇曪紝瑕嗙洊鍏变韩 IRQ 琛屼负銆丆AN 鎷撴墤缁撴瀯澶勭悊锛屼互鍙婅法 CH32 瀹忕郴鍒楃殑 512/384/256 瀛楄妭 PMA 闄愬埗銆俓n
<details>
<summary>Original summary in English</summary>

## Sourcery 鎬荤粨

閫氳繃淇濈暀鍏变韩 IRQ锛屽苟鍦ㄨ澶囧垵濮嬪寲鍜?USB 杩愯鏈熼棿寮哄埗鎵ц涓庢嫇鎵戠粨鏋勭浉鍏崇殑 PMA 淇濈暀瑙勫垯锛屼慨澶?CH32 鍏变韩 CAN/FSDEV 璧勬簮澶勭悊闂銆俓n
Bug 淇锛歕n- 淇 CH32 CAN 鍔熻兘妫€娴嬶紝浠ユ敮鎸佸叾鍏叡澶存枃浠舵毚闇蹭簡涓嶅彈鏀寔鐨?CAN2 绗﹀彿鐨勮澶囩郴鍒椼€俓n- 鍦ㄩ潤鎬佸綊妗ｅ拰寮卞鐞嗙▼搴忛摼鎺ュ満鏅笅锛屼繚鐣欏叡浜?CAN/USB IRQ 澶勭悊绋嬪簭鍜屽洖璋冨垎鍙戙€俓n- 鍦ㄥ垵濮嬪寲鍜?USB 鐢熷懡鍛ㄦ湡鐨勫悇涓樁娈碉紝瀵规棤 CAN銆丆AN1 鍜?CAN2 閰嶇疆寮哄埗鎵ц涓庢嫇鎵戠粨鏋勭浉鍏崇殑 FSDEV PMA 闄愬埗銆俓n- 閫氳繃鍦ㄥ惎鐢ㄤ腑鏂簮涔嬪墠鍙戝竷鍥炶皟锛屽苟鍦ㄦ敞閿€ USB 涓柇涔嬪墠灞忚斀杩欎簺涓柇锛岄伩鍏嶅叡浜?IRQ 绔炰簤銆俓n
澧炲己鍔熻兘锛歕n- 淇濇寔 CAN1 鍥炶皟褰?CAN1 鐙崰锛屽悓鏃舵敮鎸佷粎 CAN2 閰嶇疆鎵€闇€鐨勫叡浜繃婊ゅ櫒璧勬簮銆俓n
CI锛歕n- 娣诲姞 GitHub Actions 浠诲姟锛岃繍琛?CH32 鍏变韩 IRQ銆佸洖璋冦€丩TO銆佹嫇鎵戠粨鏋勫拰 PMA 鍥炲綊娴嬭瘯鐭╅樀銆俓n
鏂囨。锛歕n- 璁板綍 CH32 CAN 鍔熻兘銆丗SDEV PMA 淇濈暀瑙勫垯銆佸垵濮嬪寲椤哄簭銆佸叡浜悜閲忕敓鍛藉懆鏈熶互鍙婇獙璇佽寖鍥淬€俓n
娴嬭瘯锛歕n- 娣诲姞涓绘満绔洖褰掓祴璇曪紝瑕嗙洊寮卞鐞嗙▼搴忔浛鎹€侀潤鎬佸綊妗ｄ繚鐣欍€丩TO 妯″紡銆佸洖璋冨垎鍙戙€丆AN 鎷撴墤缁撴瀯鍜?PMA 绛栫暐銆俓n
<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix CH32 shared CAN/FSDEV resource handling by retaining shared IRQs and enforcing topology-aware PMA reservations across device initialization and USB operation.

Bug Fixes:
- Correct CH32 CAN capability detection for device families whose common headers expose unsupported CAN2 symbols.
- Preserve shared CAN/USB IRQ handlers and callback dispatch across static-archive and weak-handler linking scenarios.
- Enforce topology-aware FSDEV PMA limits for no-CAN, CAN1, and CAN2 configurations throughout initialization and the USB lifecycle.
- Prevent shared IRQ races by publishing callbacks before enabling interrupt sources and masking USB interrupts before unregistering them.

Enhancements:
- Keep CAN1 callback ownership exclusive to CAN1 while supporting CAN2-only configurations with the required shared filter resources.

CI:
- Add a GitHub Actions job running the CH32 shared IRQ, callback, LTO, topology, and PMA regression matrix.

Documentation:
- Document CH32 CAN capabilities, FSDEV PMA reservation rules, initialization ordering, shared-vector lifetimes, and validation scope.

Tests:
- Add host-side regression coverage for weak-handler replacement, static archive retention, LTO modes, callback dispatch, CAN topologies, and PMA policy.

</details>

</details>