### PR TITLE
fix(ch32): correct V203/V208 UART DMA and shared USB/CAN resources

### DIFF
--- a/driver/ch/ch32_can.cpp
+++ b/driver/ch/ch32_can.cpp
@@ -53,7 +53,7 @@ static inline void ch32_can_enable_nvic(ch32_can_id_t id, uint8_t fifo)
       break;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     case CH32_CAN2:
       NVIC_EnableIRQ(CAN2_TX_IRQn);
       break;
@@ -74,7 +74,7 @@ static inline void ch32_can_enable_nvic(ch32_can_id_t id, uint8_t fifo)
         break;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
       case CH32_CAN2:
         NVIC_EnableIRQ(CAN2_RX0_IRQn);
         break;
@@ -93,7 +93,7 @@ static inline void ch32_can_enable_nvic(ch32_can_id_t id, uint8_t fifo)
         break;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
       case CH32_CAN2:
         NVIC_EnableIRQ(CAN2_RX1_IRQn);
         break;
@@ -114,7 +114,7 @@ static inline void ch32_can_enable_nvic(ch32_can_id_t id, uint8_t fifo)
       break;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     case CH32_CAN2:
       NVIC_EnableIRQ(CAN2_SCE_IRQn);
       break;
@@ -130,16 +130,12 @@ CH32CAN::CH32CAN(ch32_can_id_t id, uint32_t queue_size)
 {
   if constexpr (LibXR::CH32UsbCanShared::usb_can_share_enabled())
   {
-#if defined(CAN1) && !defined(CAN2)
-    const bool USB_ALREADY_INITED =
-        LibXR::CH32UsbCanShared::usb_inited.load(std::memory_order_acquire);
-    // 在 USB/CAN 共享中断拓扑下，CAN1 必须先于 USB 初始化。
-    // On shared USB/CAN interrupt configurations, CAN1 must initialize before USB.
-    ASSERT(USB_ALREADY_INITED == false);
-#endif
+    // 端点地址在 Stop 后仍有效，不能在分配 PMA 后扩大 CAN 过滤器占用。
+    // Endpoint addresses survive Stop; reserve CAN filters before allocating PMA.
+    REQUIRE(!LibXR::CH32UsbCanShared::usb_pma_configured.load(std::memory_order_acquire));
   }
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
   if (id == CH32_CAN1)
   {
     filter_bank_ = 0;
@@ -163,12 +159,20 @@ CH32CAN::CH32CAN(ch32_can_id_t id, uint32_t queue_size)
   // 打开外设时钟。
   // Enable the peripheral clock.
   RCC_APB1PeriphClockCmd(CH32_CAN_RCC_PERIPH_MAP[id_], ENABLE);
+#if LIBXR_CH32_HAS_CAN2
+  if (id_ == CH32_CAN2)
+  {
+    // CAN2 的共享过滤器寄存器位于 CAN1，不能依赖应用先创建 CAN1 对象。
+    // CAN2 filter registers belong to CAN1, even in a CAN2-only application.
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN1, ENABLE);
+  }
+#endif
 
   // 在调用 SetConfig() 之前，保持 CAN 处于初始化模式。
   // Keep CAN in initialization mode until SetConfig() is called.
   (void)CAN_OperatingModeRequest(instance_, CAN_OperatingMode_Initialization);
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
   // 在双 CAN 变体上，配置默认的共享过滤器分界点。
   // On dual-CAN variants, configure the default shared filter split point.
   CAN_SlaveStartBank(CH32_CAN_DEFAULT_SLAVE_START_BANK);
@@ -199,12 +203,8 @@ ErrorCode CH32CAN::Init()
 
   CAN_FilterInit(&f);
 
-  EnableIRQs();
-
-  // 为当前 CAN 实例打开 NVIC。
-  // Enable NVIC for this CAN instance.
-  ch32_can_enable_nvic(id_, fifo_);
-
+  // 在放行中断源之前发布回调，防止已有 pending 中断进入空分发器。
+  // Publish callbacks before enabling an interrupt source with pending events.
   if constexpr (LibXR::CH32UsbCanShared::usb_can_irq_share_enabled())
   {
 #if defined(CAN1) && defined(RCC_APB1Periph_USB)
@@ -214,8 +214,17 @@ ErrorCode CH32CAN::Init()
       LibXR::CH32UsbCanShared::register_can1_tx(&can1_tx_thunk);
       LibXR::CH32UsbCanShared::can1_inited.store(true, std::memory_order_release);
     }
+#if LIBXR_CH32_HAS_CAN2
+    else if (id_ == CH32_CAN2)
+    {
+      LibXR::CH32UsbCanShared::can2_inited.store(true, std::memory_order_release);
+    }
+#endif
 #endif
   }
+
+  EnableIRQs();
+  ch32_can_enable_nvic(id_, fifo_);
 
   return ErrorCode::OK;
 }
@@ -804,7 +813,7 @@ extern "C" void CAN1_SCE_IRQHandler(void)
 }
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" void CAN2_TX_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/driver/ch/ch32_can_caps.hpp
+++ b/driver/ch/ch32_can_caps.hpp
@@ -3,16 +3,10 @@
 #include "libxr_def.hpp"
 #include DEF2STR(LIBXR_CH32_CONFIG_FILE)
 
-// These macros belong to the legacy ch32v20x.h/ch32v30x.h SDK families.
-// Newer devices such as CH32V205 use a separate header/resource model and are not
-// identified by CH32V20x_D6/D8/D8W.
-// 这些宏对应旧版 ch32v20x.h/ch32v30x.h 资源族；CH32V205 使用独立资源模型。
-// The common WCH V30x header declares CAN2 even for single-CAN V303 devices.
-// WCH V30x 公共头文件也为单 CAN 的 V303 声明了 CAN2，不能只判断符号是否存在。
-#if defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W) || \
-    defined(CH32V30x_D8)
-#define LIBXR_CH32_HAS_CAN2 0
-#elif defined(CAN2)
+// The V30x common header also defines CAN2 on single-CAN V303 (D8).
+// Only D8C (V305/V307/V317) has two CAN controllers in this SDK family.
+// V30x 公共头文件在单 CAN 的 V303（D8）上也定义 CAN2；仅 D8C 为双 CAN。
+#if defined(CH32V30x_D8C)
 #define LIBXR_CH32_HAS_CAN2 1
 #else
 #define LIBXR_CH32_HAS_CAN2 0

--- a/driver/ch/ch32_can_caps.hpp
+++ b/driver/ch/ch32_can_caps.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "libxr_def.hpp"
+#include DEF2STR(LIBXR_CH32_CONFIG_FILE)
+
+// These macros belong to the legacy ch32v20x.h/ch32v30x.h SDK families.
+// Newer devices such as CH32V205 use a separate header/resource model and are not
+// identified by CH32V20x_D6/D8/D8W.
+// 这些宏对应旧版 ch32v20x.h/ch32v30x.h 资源族；CH32V205 使用独立资源模型。
+// The common WCH V30x header declares CAN2 even for single-CAN V303 devices.
+// WCH V30x 公共头文件也为单 CAN 的 V303 声明了 CAN2，不能只判断符号是否存在。
+#if defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W) || \
+    defined(CH32V30x_D8)
+#define LIBXR_CH32_HAS_CAN2 0
+#elif defined(CAN2)
+#define LIBXR_CH32_HAS_CAN2 1
+#else
+#define LIBXR_CH32_HAS_CAN2 0
+#endif

--- a/driver/ch/ch32_can_def.cpp
+++ b/driver/ch/ch32_can_def.cpp
@@ -14,7 +14,7 @@ ch32_can_id_t CH32_CAN_GetID(CAN_TypeDef* addr)
     return CH32_CAN1;
   }
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
   else if (addr == CAN2)
   {
     return CH32_CAN2;
@@ -32,7 +32,7 @@ CAN_TypeDef* CH32_CAN_GetInstanceID(ch32_can_id_t id)
     case CH32_CAN1:
       return CAN1;
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     case CH32_CAN2:
       return CAN2;
 #endif

--- a/driver/ch/ch32_can_def.hpp
+++ b/driver/ch/ch32_can_def.hpp
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 
+#include "ch32_can_caps.hpp"
 #include "libxr.hpp"
-#include DEF2STR(LIBXR_CH32_CONFIG_FILE)
 
 /**
  * @brief CH32 CAN 实例编号 / CH32 CAN instance identifier
@@ -16,7 +16,7 @@ typedef enum
 #if defined(CAN1)
   CH32_CAN1,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
   CH32_CAN2,
 #endif
   CH32_CAN_NUMBER,
@@ -47,7 +47,7 @@ static constexpr uint32_t CH32_CAN_RCC_PERIPH_MAP[] = {
 #if defined(CAN1)
     RCC_APB1Periph_CAN1,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     RCC_APB1Periph_CAN2,
 #endif
 };
@@ -56,7 +56,7 @@ static constexpr IRQn_Type CH32_CAN_TX_IRQ_MAP[] = {
 #if defined(CAN1)
     USB_HP_CAN1_TX_IRQn,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     CAN2_TX_IRQn,
 #endif
 };
@@ -65,7 +65,7 @@ static constexpr IRQn_Type CH32_CAN_RX0_IRQ_MAP[] = {
 #if defined(CAN1)
     USB_LP_CAN1_RX0_IRQn,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     CAN2_RX0_IRQn,
 #endif
 };
@@ -74,7 +74,7 @@ static constexpr IRQn_Type CH32_CAN_RX1_IRQ_MAP[] = {
 #if defined(CAN1)
     CAN1_RX1_IRQn,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     CAN2_RX1_IRQn,
 #endif
 };
@@ -83,7 +83,7 @@ static constexpr IRQn_Type CH32_CAN_SCE_IRQ_MAP[] = {
 #if defined(CAN1)
     CAN1_SCE_IRQn,
 #endif
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
     CAN2_SCE_IRQn,
 #endif
 };

--- a/driver/ch/ch32_uart_def.hpp
+++ b/driver/ch/ch32_uart_def.hpp
@@ -197,7 +197,11 @@ static constexpr uint32_t CH32_UART_RCC_PERIPH_MAP_DMA[] = {
     RCC_AHBPeriph_DMA2,
 #endif
 #if defined(UART4)
+#if defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)
+    RCC_AHBPeriph_DMA1,
+#else
     RCC_AHBPeriph_DMA2,
+#endif
 #endif
 #if defined(UART5)
     RCC_AHBPeriph_DMA2,
@@ -248,10 +252,11 @@ static constexpr uint32_t CH32_UART_TX_DMA_IT_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if defined(DMA2_IT_TC5)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_IT_TC5)
     DMA2_IT_TC5,
 #else
-    DMA1_IT_TC1
+    DMA1_IT_TC1,
 #endif
 #endif
 #if defined(UART5)
@@ -303,10 +308,11 @@ static constexpr uint32_t CH32_UART_RX_DMA_IT_TC_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if defined(DMA2_IT_TC3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_IT_TC3)
     DMA2_IT_TC3,
 #else
-    DMA1_IT_TC8
+    DMA1_IT_TC8,
 #endif
 #endif
 #if defined(UART5)
@@ -358,10 +364,11 @@ static constexpr uint32_t CH32_UART_RX_DMA_IT_HT_MAP[] = {
     0,
 #endif
 #if defined(UART4)
-#if defined(DMA2_IT_HT3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_IT_HT3)
     DMA2_IT_HT3,
 #else
-    DMA1_IT_HT8
+    DMA1_IT_HT8,
 #endif
 #endif
 #if defined(UART5)
@@ -413,10 +420,11 @@ static DMA_Channel_TypeDef* const CH32_UART_TX_DMA_CHANNEL_MAP[] = {
     NULL,
 #endif
 #if defined(UART4)
-#if defined(DMA2_Channel5)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_Channel5)
     DMA2_Channel5,
 #else
-    DMA1_Channel1
+    DMA1_Channel1,
 #endif
 #endif
 #if defined(UART5)
@@ -468,10 +476,11 @@ static DMA_Channel_TypeDef* const CH32_UART_RX_DMA_CHANNEL_MAP[] = {
     NULL,
 #endif
 #if defined(UART4)
-#if defined(DMA2_Channel3)
+#if !(defined(CH32V20x_D6) || defined(CH32V20x_D8) || defined(CH32V20x_D8W)) && \
+    defined(DMA2_Channel3)
     DMA2_Channel3,
 #else
-    DMA1_Channel8
+    DMA1_Channel8,
 #endif
 #endif
 #if defined(UART5)

--- a/driver/ch/ch32_usb_devfs.cpp
+++ b/driver/ch/ch32_usb_devfs.cpp
@@ -538,14 +538,6 @@ void CH32USBDeviceFS::Start(bool)
   EXTEN->EXTEN_CTR &= ~EXTEN_USBD_LS;
 #endif
 
-  NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
-  NVIC_EnableIRQ(USB_HP_CAN1_TX_IRQn);
-  NVIC_EnableIRQ(USBWakeUp_IRQn);
-
-#if defined(EXTEN_USBD_PU_EN)
-  EXTEN->EXTEN_CTR |= EXTEN_USBD_PU_EN;
-#endif
-
   *usbdev_daddr() = USB_DADDR_EF;
 
   CH32EndpointDevFs::SetEpTxStatus(0, USB_EP_TX_NAK);
@@ -575,10 +567,22 @@ void CH32USBDeviceFS::Start(bool)
   self_ = this;
   LibXR::CH32UsbCanShared::usb_inited.store(true, std::memory_order_release);
   LibXR::CH32UsbCanShared::register_usb_irq(&usb_irq_thunk);
+
+  // 回调与端点就绪后再放行中断和连接主机。
+  // Publish the handler and arm endpoints before enabling IRQs or the pull-up.
+  NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
+  NVIC_EnableIRQ(USB_HP_CAN1_TX_IRQn);
+  NVIC_EnableIRQ(USBWakeUp_IRQn);
+#if defined(EXTEN_USBD_PU_EN)
+  EXTEN->EXTEN_CTR |= EXTEN_USBD_PU_EN;
+#endif
 }
 
 void CH32USBDeviceFS::Stop(bool)
 {
+  // 先屏蔽 USB 中断源，再解除回调；共享 CAN 中断线可能仍然开启。
+  // Mask USB interrupt sources before unregistering from live shared CAN IRQs.
+  *usbdev_cntr() = USB_CNTR_FRES;
   LibXR::CH32UsbCanShared::register_usb_irq(nullptr);
   LibXR::CH32UsbCanShared::usb_inited.store(false, std::memory_order_release);
   self_ = nullptr;
@@ -593,8 +597,6 @@ void CH32USBDeviceFS::Stop(bool)
     NVIC_DisableIRQ(USB_HP_CAN1_TX_IRQn);
   }
   NVIC_DisableIRQ(USBWakeUp_IRQn);
-
-  *usbdev_cntr() = USB_CNTR_FRES;
 }
 
 #endif  // defined(RCC_APB1Periph_USB)

--- a/driver/ch/ch32_usb_endpoint_devfs.cpp
+++ b/driver/ch/ch32_usb_endpoint_devfs.cpp
@@ -277,21 +277,33 @@ void CH32EndpointDevFs::ResetPMAAllocator()
 
   g_pma_next = PMA_ALLOC_BASE;
   g_pma_next = static_cast<uint16_t>((g_pma_next + 1U) & ~1U);
-  ASSERT(g_pma_next <= g_pma_limit);
+  REQUIRE(g_pma_next <= g_pma_limit);
 }
 
 static inline uint16_t alloc_pma(size_t bytes)
 {
-  const uint16_t ADDR = g_pma_next;
-  const uint16_t INC = static_cast<uint16_t>((bytes + 1U) & ~1U);
+  // Init may allocate endpoints before the first USB bus reset.
+  // 首次 USB reset 前也可能分配端点，必须立即使用当前 CAN 预留后的上限。
+  g_pma_limit = LibXR::CH32UsbCanShared::usb_pma_limit_bytes();
+  // PMA is at most 512 bytes. Reject before narrowing the aligned size to uint16_t,
+  // so an oversized endpoint buffer cannot wrap the allocation increment.
+  // PMA 最大只有 512 字节；先拒绝超大缓冲，避免对齐长度收窄到 uint16_t 时回绕。
+  REQUIRE(bytes <= g_pma_limit);
+  if (bytes > g_pma_limit)
+  {
+    return 0;
+  }
 
-  const uint32_t END = static_cast<uint32_t>(ADDR) + static_cast<uint32_t>(INC);
-  ASSERT(END <= g_pma_limit);
+  const uint16_t ADDR = g_pma_next;
+  const uint32_t INC = (static_cast<uint32_t>(bytes) + 1U) & ~1U;
+  const uint32_t END = static_cast<uint32_t>(ADDR) + INC;
+  REQUIRE(END <= g_pma_limit);
   if (END > g_pma_limit)
   {
     return 0;
   }
 
+  LibXR::CH32UsbCanShared::usb_pma_configured.store(true, std::memory_order_release);
   g_pma_next = static_cast<uint16_t>(END);
   return ADDR;
 }
@@ -345,7 +357,7 @@ void CH32EndpointDevFs::Configure(const Config& cfg)
   if (pma_addr_ == 0 || pma_addr_ < PMA_ALLOC_BASE)
   {
     const uint16_t ADDR = alloc_pma(BUF.size_);
-    ASSERT(ADDR >= PMA_ALLOC_BASE);
+    REQUIRE(ADDR >= PMA_ALLOC_BASE);
     if (ADDR < PMA_ALLOC_BASE)
     {
       return;

--- a/driver/ch/ch32_usbcan_shared.cpp
+++ b/driver/ch/ch32_usbcan_shared.cpp
@@ -1,5 +1,34 @@
 #include "ch32_usbcan_shared.hpp"
 
+namespace LibXR::CH32UsbCanShared
+{
+void register_usb_irq(IrqFn fn) { usb_irq_cb.store(fn, std::memory_order_release); }
+
+void register_can1_rx0(IrqFn fn)
+{
+  if constexpr (K_USB_CAN_IRQ_SHARE)
+  {
+    can1_rx0_cb.store(fn, std::memory_order_release);
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+
+void register_can1_tx(IrqFn fn)
+{
+  if constexpr (K_USB_CAN_IRQ_SHARE)
+  {
+    can1_tx_cb.store(fn, std::memory_order_release);
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+}  // namespace LibXR::CH32UsbCanShared
+
 #if defined(RCC_APB1Periph_USB) && defined(CAN1)
 
 // NOLINTNEXTLINE(readability-identifier-naming)

--- a/driver/ch/ch32_usbcan_shared.hpp
+++ b/driver/ch/ch32_usbcan_shared.hpp
@@ -2,8 +2,7 @@
 #include <atomic>
 #include <cstdint>
 
-#include "libxr_def.hpp"
-#include DEF2STR(LIBXR_CH32_CONFIG_FILE)
+#include "ch32_can_caps.hpp"
 
 namespace LibXR::CH32UsbCanShared
 {
@@ -14,9 +13,14 @@ using IrqFn = void (*)();
 
 inline std::atomic_bool usb_inited{false};
 inline std::atomic_bool can1_inited{false};
+inline std::atomic_bool can2_inited{false};
+// Endpoint objects retain their PMA addresses across Stop/Start.
+// 端点对象在 Stop/Start 后仍保留 PMA 地址；分配后不能再增加 CAN 占用。
+inline std::atomic_bool usb_pma_configured{false};
 
 static constexpr uint16_t USBD_PMA_BYTES_SOLO = 512;
 static constexpr uint16_t USBD_PMA_BYTES_WITHCAN = 384;
+static constexpr uint16_t USBD_PMA_BYTES_WITHCAN2 = 256;
 
 // USB/CAN 共享中断拓扑的编译期能力标志。
 // Build-time capability flags for USB/CAN shared interrupt topology.
@@ -32,7 +36,7 @@ inline constexpr bool K_HAS_CAN1 = true;
 inline constexpr bool K_HAS_CAN1 = false;
 #endif
 
-#if defined(CAN2)
+#if LIBXR_CH32_HAS_CAN2
 inline constexpr bool K_HAS_CAN2 = true;
 #else
 inline constexpr bool K_HAS_CAN2 = false;
@@ -42,9 +46,9 @@ inline constexpr bool K_SINGLE_CAN1 = K_HAS_CAN1 && !K_HAS_CAN2;
 // CAN1 uses the USB-named IRQ vectors even on dual-CAN devices.
 // CAN1 在双 CAN 器件上仍使用 USB 命名的共享中断向量。
 inline constexpr bool K_USB_CAN_IRQ_SHARE = K_HAS_USB_DEV_FS && K_HAS_CAN1;
-// PMA/resource sharing is limited to the original single-CAN topology.
-// PMA/资源共享仍只适用于原来的单 CAN 拓扑。
-inline constexpr bool K_USB_CAN_SHARE = K_HAS_USB_DEV_FS && K_SINGLE_CAN1;
+// FSDEV shares PMA with CAN on both single- and dual-CAN devices.
+// 单 CAN、双 CAN 器件上的 FSDEV 都与 CAN 共享 PMA。
+inline constexpr bool K_USB_CAN_SHARE = K_HAS_USB_DEV_FS && K_HAS_CAN1;
 
 inline constexpr bool usb_can_irq_share_enabled() { return K_USB_CAN_IRQ_SHARE; }
 inline constexpr bool usb_can_share_enabled() { return K_USB_CAN_SHARE; }
@@ -56,6 +60,15 @@ inline uint16_t usb_pma_limit_bytes()
     return USBD_PMA_BYTES_SOLO;
   }
 
+  // CAN2 uses the upper filter banks, including when no CAN1 object was created.
+  // CAN2 使用高编号过滤器组，即使应用没有创建 CAN1 对象也必须预留。
+  if constexpr (K_HAS_CAN2)
+  {
+    if (can2_inited.load(std::memory_order_acquire))
+    {
+      return USBD_PMA_BYTES_WITHCAN2;
+    }
+  }
   return can1_inited.load(std::memory_order_acquire) ? USBD_PMA_BYTES_WITHCAN
                                                      : USBD_PMA_BYTES_SOLO;
 }
@@ -64,34 +77,11 @@ inline std::atomic<IrqFn> usb_irq_cb{nullptr};
 inline std::atomic<IrqFn> can1_rx0_cb{nullptr};
 inline std::atomic<IrqFn> can1_tx_cb{nullptr};
 
-inline void register_usb_irq(IrqFn fn)
-{
-  usb_irq_cb.store(fn, std::memory_order_release);
-}
-
-inline void register_can1_rx0(IrqFn fn)
-{
-  if constexpr (K_USB_CAN_IRQ_SHARE)
-  {
-    can1_rx0_cb.store(fn, std::memory_order_release);
-  }
-  else
-  {
-    (void)fn;
-  }
-}
-
-inline void register_can1_tx(IrqFn fn)
-{
-  if constexpr (K_USB_CAN_IRQ_SHARE)
-  {
-    can1_tx_cb.store(fn, std::memory_order_release);
-  }
-  else
-  {
-    (void)fn;
-  }
-}
+// Out-of-line registration retains the shared ISR object when linking libxr.a.
+// 非内联注册使静态库链接必须带入共享 ISR 所在的目标文件。
+void register_usb_irq(IrqFn fn);
+void register_can1_rx0(IrqFn fn);
+void register_can1_tx(IrqFn fn);
 
 inline bool can1_active()
 {


### PR DESCRIPTION
Supersedes #306 and #307. Product changes only: nine files under `driver/ch/`. No new workflow, audit script, or driver README.

## Changes

- Select DMA1 CH1/CH8 for UART4 on legacy V203/V208; keep the V30x DMA2 mapping.
- Enable `LIBXR_CH32_HAS_CAN2` only for `CH32V30x_D8C` (V305/V307/V317). Do not infer physical CAN2 capability from the common header's `CAN2` symbol.
- Retain the shared USB/CAN ISR object through out-of-line callback registration.
- Keep CAN1 callbacks separate from CAN2-only initialization and reserve FSDEV PMA for active CAN resources. CAN2-only uses a conservative 256-byte USB budget.
- Check PMA allocation limits in Release and preserve shared CAN interrupts through USB Stop/Start.

## Validation at 57a45df3

Real WCH SDK compilation passed for all five legacy V20x/V30x macro families, including extra CAN2-symbol cases. Existing repository CI passed.

On the original V203C8 board, Debug and Release passed UART4 cold-start DMA, loopback/configuration/recovery, Config/I/O concurrency, GPIO/EXTI, PWM, SPI2, I2C2 with real sensors, and RTOS/timebase checks. The Debug USB/CAN run passed 1,058,144 bytes, 549 host cases, 9,352 CAN frames, and three USB Stop/Start cycles.

**Release USB/CAN long-stream acceptance is NOT complete.** Repeated runs include both passes and write timeouts, including a failure while the host reader was active. The earlier accepted candidate ELF also reproduced a timeout. A post-failure debugger capture shows HardFault/illegal instruction with the exception PC in descriptor data; root cause and fault timing are not yet established. This endpoint fixture bypasses generic CDCUart, so the failure cannot be dismissed as the prior CDCUart queue issue.

The PR remains draft pending this failure's resolution. Detailed results and control runs: https://github.com/Jiu-xiao/libxr/pull/308#issuecomment-5643117143

The original 64 KiB Flash image and option area were restored and compared byte-for-byte after testing. No merge was performed.
